### PR TITLE
Fix a small docs inaccuracy.

### DIFF
--- a/mintlify/rewards/developer-guides/configuring-customers.mdx
+++ b/mintlify/rewards/developer-guides/configuring-customers.mdx
@@ -11,7 +11,7 @@ This guide covers everything you need to know about creating and managing custom
 
 ## Overview
 
-Customers are the recipients of your Bitcoin rewards. They can be individuals or businesses. Each customer in the Grid system has:
+Customers are the *payers* of your Bitcoin rewards. They can be individuals or businesses. Each customer in the Grid system has:
 
 - **System-generated ID**: Unique identifier assigned by Grid (e.g., `Customer:019542f5-b3e7-1d02-0000-000000000001`)
 - **Customer Type**: Either `INDIVIDUAL` or `BUSINESS`


### PR DESCRIPTION
Turns out I'd left this file unsaved in a previous PR that cleaned up this rewards guide to indicate who each entity actually is.