### PR TITLE
Fix a naming conflict in titles

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -155,53 +155,36 @@ paths:
           application/json:
             schema:
               oneOf:
-                - title: Individual Customer
+                - title: New Individual Customer
                   allOf:
                     - $ref: '#/components/schemas/IndividualCustomerUpdate'
                     - type: object
                       required:
                         - platformCustomerId
-                        - customerType
                       properties:
                         platformCustomerId:
                           type: string
                           description: Platform-specific customer identifier
                           example: 9f84e0c2a72c4fa
-                        customerType:
-                          type: string
-                          enum:
-                            - INDIVIDUAL
-                          description: Customer type
                         kycUrl:
                           type: string
                           description: A KYC URL to be shared with your individual customer if KYC needs to be completed
                           example: https://example.com/kyc
-                - title: Business Customer
+                - title: New Business Customer
                   allOf:
                     - $ref: '#/components/schemas/BusinessCustomerUpdate'
                     - type: object
                       required:
                         - platformCustomerId
-                        - customerType
                       properties:
                         platformCustomerId:
                           type: string
                           description: Platform-specific customer identifier
                           example: 9f84e0c2a72c4fa
-                        customerType:
-                          type: string
-                          enum:
-                            - BUSINESS
-                          description: Customer type
                         kycUrl:
                           type: string
                           description: A KYC URL to be shared with your business customer if KYC needs to be completed
                           example: https://example.com/kyc
-              discriminator:
-                propertyName: customerType
-                mapping:
-                  INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdate'
-                  BUSINESS: '#/components/schemas/BusinessCustomerUpdate'
             examples:
               individualCustomerWithUmaAddress:
                 summary: Create individual customer with UMA address, including deposit bank account information.
@@ -493,9 +476,9 @@ paths:
           application/json:
             schema:
               oneOf:
-                - title: Individual cCstomer Update
+                - title: Update Individual Customer
                   $ref: '#/components/schemas/IndividualCustomerUpdate'
-                - title: Business Customer Update
+                - title: Update Business Customer
                   $ref: '#/components/schemas/BusinessCustomerUpdate'
               discriminator:
                 propertyName: customerType
@@ -4758,6 +4741,8 @@ components:
           SPARK_WALLET: '#/components/schemas/CustomerSparkWalletInfo'
     IndividualCustomerUpdate:
       type: object
+      required:
+        - customerType
       properties:
         customerType:
           type: string
@@ -4794,6 +4779,8 @@ components:
             receive incoming funds. Other platforms should add external accounts instead.
     BusinessCustomerUpdate:
       type: object
+      required:
+        - customerType
       properties:
         customerType:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -155,53 +155,36 @@ paths:
           application/json:
             schema:
               oneOf:
-                - title: Individual Customer
+                - title: New Individual Customer
                   allOf:
                     - $ref: '#/components/schemas/IndividualCustomerUpdate'
                     - type: object
                       required:
                         - platformCustomerId
-                        - customerType
                       properties:
                         platformCustomerId:
                           type: string
                           description: Platform-specific customer identifier
                           example: 9f84e0c2a72c4fa
-                        customerType:
-                          type: string
-                          enum:
-                            - INDIVIDUAL
-                          description: Customer type
                         kycUrl:
                           type: string
                           description: A KYC URL to be shared with your individual customer if KYC needs to be completed
                           example: https://example.com/kyc
-                - title: Business Customer
+                - title: New Business Customer
                   allOf:
                     - $ref: '#/components/schemas/BusinessCustomerUpdate'
                     - type: object
                       required:
                         - platformCustomerId
-                        - customerType
                       properties:
                         platformCustomerId:
                           type: string
                           description: Platform-specific customer identifier
                           example: 9f84e0c2a72c4fa
-                        customerType:
-                          type: string
-                          enum:
-                            - BUSINESS
-                          description: Customer type
                         kycUrl:
                           type: string
                           description: A KYC URL to be shared with your business customer if KYC needs to be completed
                           example: https://example.com/kyc
-              discriminator:
-                propertyName: customerType
-                mapping:
-                  INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdate'
-                  BUSINESS: '#/components/schemas/BusinessCustomerUpdate'
             examples:
               individualCustomerWithUmaAddress:
                 summary: Create individual customer with UMA address, including deposit bank account information.
@@ -493,9 +476,9 @@ paths:
           application/json:
             schema:
               oneOf:
-                - title: Individual cCstomer Update
+                - title: Update Individual Customer
                   $ref: '#/components/schemas/IndividualCustomerUpdate'
-                - title: Business Customer Update
+                - title: Update Business Customer
                   $ref: '#/components/schemas/BusinessCustomerUpdate'
               discriminator:
                 propertyName: customerType
@@ -4758,6 +4741,8 @@ components:
           SPARK_WALLET: '#/components/schemas/CustomerSparkWalletInfo'
     IndividualCustomerUpdate:
       type: object
+      required:
+        - customerType
       properties:
         customerType:
           type: string
@@ -4794,6 +4779,8 @@ components:
             receive incoming funds. Other platforms should add external accounts instead.
     BusinessCustomerUpdate:
       type: object
+      required:
+        - customerType
       properties:
         customerType:
           type: string

--- a/openapi/components/schemas/customers/BusinessCustomerUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessCustomerUpdate.yaml
@@ -1,4 +1,6 @@
 type: object
+required:
+  - customerType
 properties:
   customerType:
     type: string

--- a/openapi/components/schemas/customers/IndividualCustomerUpdate.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerUpdate.yaml
@@ -1,4 +1,6 @@
 type: object
+required:
+  - customerType
 properties:
   customerType:
     type: string

--- a/openapi/paths/customers/customers.yaml
+++ b/openapi/paths/customers/customers.yaml
@@ -14,51 +14,36 @@ post:
       application/json:
         schema:
           oneOf:
-            - title: Individual Customer
+            - title: New Individual Customer
               allOf:
                 - $ref: ../../components/schemas/customers/IndividualCustomerUpdate.yaml
                 - type: object
                   required:
                     - platformCustomerId
-                    - customerType
                   properties:
                     platformCustomerId:
                       type: string
                       description: Platform-specific customer identifier
                       example: 9f84e0c2a72c4fa
-                    customerType:
-                      type: string
-                      enum: [INDIVIDUAL]
-                      description: Customer type
                     kycUrl:
                       type: string
                       description: A KYC URL to be shared with your individual customer if KYC needs to be completed
                       example: "https://example.com/kyc"
-            - title: Business Customer
+            - title: New Business Customer
               allOf:
                 - $ref: ../../components/schemas/customers/BusinessCustomerUpdate.yaml
                 - type: object
                   required:
                     - platformCustomerId
-                    - customerType
                   properties:
                     platformCustomerId:
                       type: string
                       description: Platform-specific customer identifier
                       example: 9f84e0c2a72c4fa
-                    customerType:
-                      type: string
-                      enum: [BUSINESS]
-                      description: Customer type
                     kycUrl:
                       type: string
                       description: A KYC URL to be shared with your business customer if KYC needs to be completed
                       example: "https://example.com/kyc"
-          discriminator:
-            propertyName: customerType
-            mapping:
-              INDIVIDUAL: ../../components/schemas/customers/IndividualCustomerUpdate.yaml
-              BUSINESS: ../../components/schemas/customers/BusinessCustomerUpdate.yaml
         examples:
           individualCustomerWithUmaAddress:
             summary: Create individual customer with UMA address, including deposit bank account information.

--- a/openapi/paths/customers/customers_{customerId}.yaml
+++ b/openapi/paths/customers/customers_{customerId}.yaml
@@ -61,9 +61,9 @@ patch:
       application/json:
         schema:
           oneOf:
-            - title: Individual cCstomer Update
+            - title: Update Individual Customer
               $ref: ../../components/schemas/customers/IndividualCustomerUpdate.yaml
-            - title: Business Customer Update
+            - title: Update Business Customer
               $ref: ../../components/schemas/customers/BusinessCustomerUpdate.yaml
           discriminator:
             propertyName: customerType


### PR DESCRIPTION
The fact that the update options were called "Individual Customer" and "Business Customer" was causing the python SDK generator to get confused and lose the proper type hierarchy expected in the generated customer types.
