### PR TITLE
[Grid] Remove required currency from uma source

### DIFF
--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -22,6 +22,7 @@ properties:
         type: object
         required:
           - accountId
+          - currency
         properties:
           accountId:
             type: string
@@ -36,7 +37,6 @@ properties:
         type: object
         required:
           - umaAddress
-          - currency
         properties:
           umaAddress:
             type: string
@@ -53,6 +53,7 @@ properties:
         type: object
         required:
           - accountId
+          - currency
         properties:
           accountId:
             type: string


### PR DESCRIPTION
When we onboard accounts we have a good idea what currency they are backed in however thats not always the case with a uma transaction.

For example, in a receive uma to uma transaction we would not know what the originating currency is so we shouldn't make currency required for a uma source but we can make it required for an account source