### PR TITLE
Align CustomerInfoFieldName with UMAaaS fields.

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3970,7 +3970,7 @@ components:
         - NATIONALITY
         - PHONE_NUMBER
         - EMAIL
-        - ADDRESS
+        - POSTAL_ADDRESS
         - TAX_ID
         - REGISTRATION_NUMBER
         - USER_TYPE
@@ -3980,6 +3980,7 @@ components:
         - FI_ADDRESS
         - PURPOSE_OF_PAYMENT
         - ULTIMATE_INSTITUTION_COUNTRY
+        - IDENTIFIER
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3970,7 +3970,7 @@ components:
         - NATIONALITY
         - PHONE_NUMBER
         - EMAIL
-        - ADDRESS
+        - POSTAL_ADDRESS
         - TAX_ID
         - REGISTRATION_NUMBER
         - USER_TYPE
@@ -3980,6 +3980,7 @@ components:
         - FI_ADDRESS
         - PURPOSE_OF_PAYMENT
         - ULTIMATE_INSTITUTION_COUNTRY
+        - IDENTIFIER
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
+++ b/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
@@ -5,7 +5,7 @@ enum:
   - NATIONALITY
   - PHONE_NUMBER
   - EMAIL
-  - ADDRESS
+  - POSTAL_ADDRESS
   - TAX_ID
   - REGISTRATION_NUMBER
   - USER_TYPE
@@ -15,6 +15,7 @@ enum:
   - FI_ADDRESS
   - PURPOSE_OF_PAYMENT
   - ULTIMATE_INSTITUTION_COUNTRY
+  - IDENTIFIER
 description: >-
   Name of a type of field containing info about a platform's customer or
   counterparty customer.


### PR DESCRIPTION
This is causing a deserialization error in the /config endpoint when testing with an existing UMAaaS platform.
