### PR TITLE
Remove filter by or account parameter

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2018,12 +2018,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: accountIdentifier
-          in: query
-          description: Filter by account identifier (either sender or receiver)
-          required: false
-          schema:
-            type: string
         - name: senderAccountIdentifier
           in: query
           description: Filter by sender account identifier

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2018,12 +2018,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: accountIdentifier
-          in: query
-          description: Filter by account identifier (either sender or receiver)
-          required: false
-          schema:
-            type: string
         - name: senderAccountIdentifier
           in: query
           description: Filter by sender account identifier

--- a/openapi/paths/transactions/transactions.yaml
+++ b/openapi/paths/transactions/transactions.yaml
@@ -22,12 +22,6 @@ get:
       required: false
       schema:
         type: string
-    - name: accountIdentifier
-      in: query
-      description: Filter by account identifier (either sender or receiver)
-      required: false
-      schema:
-        type: string
     - name: senderAccountIdentifier
       in: query
       description: Filter by sender account identifier


### PR DESCRIPTION
This removes the accountIdentifier from the list transactions endpoint because we have a limitation of doing ORs from the ent framework. We can still query each field individually via the sender or receiver account identifier