### PR TITLE
Require legal name on business creation

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -176,6 +176,7 @@ paths:
                     - type: object
                       required:
                         - platformCustomerId
+                        - businessInfo
                       properties:
                         platformCustomerId:
                           type: string
@@ -185,6 +186,23 @@ paths:
                           type: string
                           description: A KYC URL to be shared with your business customer if KYC needs to be completed
                           example: https://example.com/kyc
+                        businessInfo:
+                          type: object
+                          required:
+                            - legalName
+                          properties:
+                            legalName:
+                              type: string
+                              description: Legal name of the business
+                              example: Acme Corporation, Inc.
+                            registrationNumber:
+                              type: string
+                              description: Business registration number
+                              example: BRN-123456789
+                            taxId:
+                              type: string
+                              description: Tax identification number
+                              example: EIN-987654321
             examples:
               individualCustomerWithUmaAddress:
                 summary: Create individual customer with UMA address, including deposit bank account information.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -176,6 +176,7 @@ paths:
                     - type: object
                       required:
                         - platformCustomerId
+                        - businessInfo
                       properties:
                         platformCustomerId:
                           type: string
@@ -185,6 +186,23 @@ paths:
                           type: string
                           description: A KYC URL to be shared with your business customer if KYC needs to be completed
                           example: https://example.com/kyc
+                        businessInfo:
+                          type: object
+                          required:
+                            - legalName
+                          properties:
+                            legalName:
+                              type: string
+                              description: Legal name of the business
+                              example: Acme Corporation, Inc.
+                            registrationNumber:
+                              type: string
+                              description: Business registration number
+                              example: BRN-123456789
+                            taxId:
+                              type: string
+                              description: Tax identification number
+                              example: EIN-987654321
             examples:
               individualCustomerWithUmaAddress:
                 summary: Create individual customer with UMA address, including deposit bank account information.

--- a/openapi/paths/customers/customers.yaml
+++ b/openapi/paths/customers/customers.yaml
@@ -35,6 +35,7 @@ post:
                 - type: object
                   required:
                     - platformCustomerId
+                    - businessInfo
                   properties:
                     platformCustomerId:
                       type: string
@@ -44,6 +45,23 @@ post:
                       type: string
                       description: A KYC URL to be shared with your business customer if KYC needs to be completed
                       example: "https://example.com/kyc"
+                    businessInfo:
+                      type: object
+                      required:
+                        - legalName
+                      properties:
+                        legalName:
+                          type: string
+                          description: Legal name of the business
+                          example: Acme Corporation, Inc.
+                        registrationNumber:
+                          type: string
+                          description: Business registration number
+                          example: BRN-123456789
+                        taxId:
+                          type: string
+                          description: Tax identification number
+                          example: EIN-987654321
         examples:
           individualCustomerWithUmaAddress:
             summary: Create individual customer with UMA address, including deposit bank account information.


### PR DESCRIPTION
We guarantee business legal name in the return objects but we don't enforce it when creating a business customer