### PR TITLE
Make currencyAmount nullable in sandbox/send endpoint if quote is provided

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2766,7 +2766,6 @@ paths:
               required:
                 - quoteId
                 - currencyCode
-                - currencyAmount
               properties:
                 quoteId:
                   type: string
@@ -2779,7 +2778,7 @@ paths:
                 currencyAmount:
                   type: integer
                   format: int64
-                  description: The amount to send in the smallest unit of the currency (eg. cents)
+                  description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
                   exclusiveMinimum: 0
                   example: 1000
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2766,7 +2766,6 @@ paths:
               required:
                 - quoteId
                 - currencyCode
-                - currencyAmount
               properties:
                 quoteId:
                   type: string
@@ -2779,7 +2778,7 @@ paths:
                 currencyAmount:
                   type: integer
                   format: int64
-                  description: The amount to send in the smallest unit of the currency (eg. cents)
+                  description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
                   exclusiveMinimum: 0
                   example: 1000
       responses:

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -19,7 +19,6 @@ post:
           required:
             - quoteId
             - currencyCode
-            - currencyAmount
           properties:
             quoteId:
               type: string
@@ -34,7 +33,7 @@ post:
               format: int64
               description: >-
                 The amount to send in the smallest unit of the currency (eg.
-                cents)
+                cents). If not provided, the amount will be derived from the quote.
               exclusiveMinimum: 0
               example: 1000
   responses:


### PR DESCRIPTION
We can derive the amount from the quote ent so no need to ask the user for the amount. relic from umaaas