### PR TITLE
[Grid] Move source into outgoing/incoming transaction

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5627,7 +5627,6 @@ components:
         - id
         - status
         - type
-        - source
         - destination
         - customerId
         - platformCustomerId
@@ -5640,37 +5639,6 @@ components:
           $ref: '#/components/schemas/TransactionStatus'
         type:
           $ref: '#/components/schemas/TransactionType'
-        source:
-          oneOf:
-            - title: Account Source
-              type: object
-              required:
-                - accountId
-                - currency
-              properties:
-                accountId:
-                  type: string
-                  description: Source account identifier
-                  example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                currency:
-                  type: string
-                  description: Currency code for the source account
-                  example: USD
-              description: Source account details
-            - title: UMA Address Source
-              type: object
-              required:
-                - umaAddress
-              properties:
-                umaAddress:
-                  type: string
-                  description: UMA address of the sender
-                  example: $sender@uma.domain.com
-                currency:
-                  type: string
-                  description: Currency code for the source
-                  example: USD
-              description: UMA address source details
         destination:
           oneOf:
             - title: Account Destination
@@ -5802,6 +5770,37 @@ components:
           required:
             - receivedAmount
           properties:
+            source:
+              oneOf:
+                - title: Account Source
+                  type: object
+                  required:
+                    - accountId
+                    - currency
+                  properties:
+                    accountId:
+                      type: string
+                      description: Source account identifier
+                      example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    currency:
+                      type: string
+                      description: Currency code for the source account
+                      example: USD
+                  description: Source account details
+                - title: UMA Address Source
+                  type: object
+                  required:
+                    - umaAddress
+                  properties:
+                    umaAddress:
+                      type: string
+                      description: UMA address of the sender
+                      example: $sender@uma.domain.com
+                    currency:
+                      type: string
+                      description: Currency code for the source
+                      example: USD
+                  description: UMA address source details
             receivedAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount received in the recipient's currency
@@ -5898,7 +5897,39 @@ components:
           required:
             - sentAmount
             - paymentInstructions
+            - source
           properties:
+            source:
+              oneOf:
+                - title: Account Source
+                  type: object
+                  required:
+                    - accountId
+                    - currency
+                  properties:
+                    accountId:
+                      type: string
+                      description: Source account identifier
+                      example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    currency:
+                      type: string
+                      description: Currency code for the source account
+                      example: USD
+                  description: Source account details
+                - title: UMA Address Source
+                  type: object
+                  required:
+                    - umaAddress
+                  properties:
+                    umaAddress:
+                      type: string
+                      description: UMA address of the sender
+                      example: $sender@uma.domain.com
+                    currency:
+                      type: string
+                      description: Currency code for the source
+                      example: USD
+                  description: UMA address source details
             sentAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount sent in the sender's currency

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5627,7 +5627,6 @@ components:
         - id
         - status
         - type
-        - source
         - destination
         - customerId
         - platformCustomerId
@@ -5640,37 +5639,6 @@ components:
           $ref: '#/components/schemas/TransactionStatus'
         type:
           $ref: '#/components/schemas/TransactionType'
-        source:
-          oneOf:
-            - title: Account Source
-              type: object
-              required:
-                - accountId
-                - currency
-              properties:
-                accountId:
-                  type: string
-                  description: Source account identifier
-                  example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                currency:
-                  type: string
-                  description: Currency code for the source account
-                  example: USD
-              description: Source account details
-            - title: UMA Address Source
-              type: object
-              required:
-                - umaAddress
-              properties:
-                umaAddress:
-                  type: string
-                  description: UMA address of the sender
-                  example: $sender@uma.domain.com
-                currency:
-                  type: string
-                  description: Currency code for the source
-                  example: USD
-              description: UMA address source details
         destination:
           oneOf:
             - title: Account Destination
@@ -5802,6 +5770,37 @@ components:
           required:
             - receivedAmount
           properties:
+            source:
+              oneOf:
+                - title: Account Source
+                  type: object
+                  required:
+                    - accountId
+                    - currency
+                  properties:
+                    accountId:
+                      type: string
+                      description: Source account identifier
+                      example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    currency:
+                      type: string
+                      description: Currency code for the source account
+                      example: USD
+                  description: Source account details
+                - title: UMA Address Source
+                  type: object
+                  required:
+                    - umaAddress
+                  properties:
+                    umaAddress:
+                      type: string
+                      description: UMA address of the sender
+                      example: $sender@uma.domain.com
+                    currency:
+                      type: string
+                      description: Currency code for the source
+                      example: USD
+                  description: UMA address source details
             receivedAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount received in the recipient's currency
@@ -5898,7 +5897,39 @@ components:
           required:
             - sentAmount
             - paymentInstructions
+            - source
           properties:
+            source:
+              oneOf:
+                - title: Account Source
+                  type: object
+                  required:
+                    - accountId
+                    - currency
+                  properties:
+                    accountId:
+                      type: string
+                      description: Source account identifier
+                      example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    currency:
+                      type: string
+                      description: Currency code for the source account
+                      example: USD
+                  description: Source account details
+                - title: UMA Address Source
+                  type: object
+                  required:
+                    - umaAddress
+                  properties:
+                    umaAddress:
+                      type: string
+                      description: UMA address of the sender
+                      example: $sender@uma.domain.com
+                    currency:
+                      type: string
+                      description: Currency code for the source
+                      example: USD
+                  description: UMA address source details
             sentAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount sent in the sender's currency

--- a/openapi/components/schemas/transactions/IncomingTransaction.yaml
+++ b/openapi/components/schemas/transactions/IncomingTransaction.yaml
@@ -4,6 +4,37 @@ allOf:
     required:
       - receivedAmount
     properties:
+      source:
+        oneOf:
+          - title: Account Source
+            type: object
+            required:
+              - accountId
+              - currency
+            properties:
+              accountId:
+                type: string
+                description: Source account identifier
+                example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+              currency:
+                type: string
+                description: Currency code for the source account
+                example: USD
+            description: Source account details
+          - title: UMA Address Source
+            type: object
+            required:
+              - umaAddress
+            properties:
+              umaAddress:
+                type: string
+                description: UMA address of the sender
+                example: $sender@uma.domain.com
+              currency:
+                type: string
+                description: Currency code for the source
+                example: USD
+            description: UMA address source details
       receivedAmount:
         $ref: ../common/CurrencyAmount.yaml
         description: Amount received in the recipient's currency

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -4,7 +4,39 @@ allOf:
     required:
       - sentAmount
       - paymentInstructions
+      - source
     properties:
+      source:
+        oneOf:
+          - title: Account Source
+            type: object
+            required:
+              - accountId
+              - currency
+            properties:
+              accountId:
+                type: string
+                description: Source account identifier
+                example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+              currency:
+                type: string
+                description: Currency code for the source account
+                example: USD
+            description: Source account details
+          - title: UMA Address Source
+            type: object
+            required:
+              - umaAddress
+            properties:
+              umaAddress:
+                type: string
+                description: UMA address of the sender
+                example: $sender@uma.domain.com
+              currency:
+                type: string
+                description: Currency code for the source
+                example: USD
+            description: UMA address source details
       sentAmount:
         $ref: ../common/CurrencyAmount.yaml
         description: Amount sent in the sender's currency

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -3,7 +3,6 @@ required:
   - id
   - status
   - type
-  - source
   - destination
   - customerId
   - platformCustomerId
@@ -16,37 +15,6 @@ properties:
     $ref: ./TransactionStatus.yaml
   type:
     $ref: ./TransactionType.yaml
-  source:
-    oneOf:
-      - title: Account Source
-        type: object
-        required:
-          - accountId
-          - currency
-        properties:
-          accountId:
-            type: string
-            description: Source account identifier
-            example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-          currency:
-            type: string
-            description: Currency code for the source account
-            example: USD
-        description: Source account details
-      - title: UMA Address Source
-        type: object
-        required:
-          - umaAddress
-        properties:
-          umaAddress:
-            type: string
-            description: UMA address of the sender
-            example: $sender@uma.domain.com
-          currency:
-            type: string
-            description: Currency code for the source
-            example: USD
-        description: UMA address source details
   destination:
     oneOf:
       - title: Account Destination


### PR DESCRIPTION
This moves source out of the base transaction object and into the incoming/outgoing transaction. We still enforce it for outgoing transaction but not for a incoming transaction. The reason why we need to do this is because an incoming transaction like a funding event will not have a source 