### PR TITLE
feat: convert single-value enums to const for base types

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5242,44 +5242,27 @@ components:
               const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
-      allOf:
-        - type: object
-          required:
-            - accountType
-          properties:
-            accountType:
-              type: string
-              enum:
-                - LIGHTNING
-              example: LIGHTNING
-        - oneOf:
-            - title: Lightning Invoice
-              type: object
-              required:
-                - invoice
-              properties:
-                invoice:
-                  type: string
-                  description: 1-time use lightning bolt11 invoice payout destination
-                  example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            - title: Lightning - Bolt12 Offer
-              type: object
-              required:
-                - bolt12
-              properties:
-                bolt12:
-                  type: string
-                  description: A bolt12 offer which can be reused as a payment destination
-                  example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            - title: Lightning Address
-              type: object
-              required:
-                - lightningAddress
-              properties:
-                lightningAddress:
-                  type: string
-                  description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-                  example: john.doe@lightningwallet.com
+      type: object
+      required:
+        - accountType
+      description: |
+        Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+      properties:
+        accountType:
+          const: LIGHTNING
+          example: LIGHTNING
+        invoice:
+          type: string
+          description: 1-time use lightning bolt11 invoice payout destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        bolt12:
+          type: string
+          description: A bolt12 offer which can be reused as a payment destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        lightningAddress:
+          type: string
+          description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+          example: john.doe@lightningwallet.com
     SolanaWalletExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/SolanaWalletInfo'

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4044,8 +4044,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 401
+          const: 401
           type: integer
           description: HTTP status code
         code:
@@ -4072,8 +4071,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 500
+          const: 500
           type: integer
           description: HTTP status code
         code:
@@ -4100,8 +4098,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 400
+          const: 400
           type: integer
           description: HTTP status code
         code:
@@ -4178,8 +4175,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 501
+          const: 501
           type: integer
           description: HTTP status code
         code:
@@ -4436,8 +4432,7 @@ components:
       properties:
         customerType:
           type: string
-          enum:
-            - BUSINESS
+          const: BUSINESS
           description: Customer type
         umaAddress:
           type: string
@@ -4472,8 +4467,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 409
+          const: 409
           type: integer
           description: HTTP status code
         code:
@@ -4500,8 +4494,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 404
+          const: 404
           type: integer
           description: HTTP status code
         code:
@@ -4619,9 +4612,7 @@ components:
         - accountCategory
       properties:
         accountType:
-          type: string
-          enum:
-            - US_ACCOUNT
+          const: US_ACCOUNT
           example: US_ACCOUNT
         accountNumber:
           type: string
@@ -4665,9 +4656,7 @@ components:
         - taxId
       properties:
         accountType:
-          type: string
-          enum:
-            - PIX
+          const: PIX
           example: PIX
         pixKey:
           type: string
@@ -4699,9 +4688,7 @@ components:
         - swiftBic
       properties:
         accountType:
-          type: string
-          enum:
-            - IBAN
+          const: IBAN
           example: IBAN
         iban:
           type: string
@@ -4753,9 +4740,7 @@ components:
         - vpa
       properties:
         accountType:
-          type: string
-          enum:
-            - UPI
+          const: UPI
           example: UPI
         vpa:
           type: string
@@ -4773,9 +4758,7 @@ components:
         - bankName
       properties:
         accountType:
-          type: string
-          enum:
-            - NGN_ACCOUNT
+          const: NGN_ACCOUNT
           example: NGN_ACCOUNT
         accountNumber:
           type: string
@@ -4806,9 +4789,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - SPARK_WALLET
+          const: SPARK_WALLET
           example: SPARK_WALLET
         address:
           type: string
@@ -4854,9 +4835,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - SOLANA_WALLET
+          const: SOLANA_WALLET
           example: SOLANA_WALLET
         address:
           type: string
@@ -4880,9 +4859,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - TRON_WALLET
+          const: TRON_WALLET
           example: TRON_WALLET
         address:
           type: string
@@ -4905,9 +4882,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - POLYGON_WALLET
+          const: POLYGON_WALLET
           example: POLYGON_WALLET
         address:
           type: string
@@ -4947,9 +4922,7 @@ components:
         - clabeNumber
       properties:
         accountType:
-          type: string
-          enum:
-            - CLABE
+          const: CLABE
           example: CLABE
         clabeNumber:
           type: string
@@ -4965,9 +4938,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - BASE_WALLET
+          const: BASE_WALLET
           example: BASE_WALLET
         address:
           type: string
@@ -5085,8 +5056,7 @@ components:
       properties:
         beneficiaryType:
           type: string
-          enum:
-            - INDIVIDUAL
+          const: INDIVIDUAL
           example: INDIVIDUAL
         fullName:
           type: string
@@ -5111,8 +5081,7 @@ components:
       properties:
         beneficiaryType:
           type: string
-          enum:
-            - BUSINESS
+          const: BUSINESS
           example: BUSINESS
         legalName:
           type: string
@@ -5137,9 +5106,7 @@ components:
             - beneficiary
           properties:
             accountType:
-              type: string
-              enum:
-                - US_ACCOUNT
+              const: US_ACCOUNT
               example: US_ACCOUNT
             beneficiary:
               oneOf:
@@ -5158,9 +5125,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - CLABE
+              const: CLABE
               example: CLABE
             beneficiary:
               oneOf:
@@ -5179,9 +5144,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - PIX
+              const: PIX
               example: PIX
             beneficiary:
               oneOf:
@@ -5200,9 +5163,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - IBAN
+              const: IBAN
               example: IBAN
             beneficiary:
               oneOf:
@@ -5221,9 +5182,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - UPI
+              const: UPI
               example: UPI
             beneficiary:
               oneOf:
@@ -5244,9 +5203,7 @@ components:
             - beneficiary
           properties:
             accountType:
-              type: string
-              enum:
-                - NGN_ACCOUNT
+              const: NGN_ACCOUNT
               example: NGN_ACCOUNT
             beneficiary:
               oneOf:
@@ -5282,9 +5239,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - SPARK_WALLET
+              const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
       allOf:
@@ -5333,9 +5288,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - SOLANA_WALLET
+              const: SOLANA_WALLET
               example: SOLANA_WALLET
     TronWalletExternalAccountInfo:
       allOf:
@@ -5345,9 +5298,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - TRON_WALLET
+              const: TRON_WALLET
               example: TRON_WALLET
     PolygonWalletExternalAccountInfo:
       allOf:
@@ -5357,9 +5308,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - POLYGON_WALLET
+              const: POLYGON_WALLET
               example: POLYGON_WALLET
     BaseWalletExternalAccountInfo:
       allOf:
@@ -5369,9 +5318,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - BASE_WALLET
+              const: BASE_WALLET
               example: BASE_WALLET
     ExternalAccountInfo:
       oneOf:
@@ -5951,8 +5898,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 412
+          const: 412
           type: integer
           description: HTTP status code
         code:
@@ -5961,8 +5907,7 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | UNSUPPORTED_UMA_VERSION | Counterparty doesn't support the Grid UMA version |
-          enum:
-            - UNSUPPORTED_UMA_VERSION
+          const: UNSUPPORTED_UMA_VERSION
         message:
           type: string
           description: Error message
@@ -5977,8 +5922,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 424
+          const: 424
           type: integer
           description: HTTP status code
         code:
@@ -6403,8 +6347,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 403
+          const: 403
           type: integer
           description: HTTP status code
         code:
@@ -6619,8 +6562,7 @@ components:
               $ref: '#/components/schemas/UmaInvitation'
             type:
               type: string
-              enum:
-                - INVITATION_CLAIMED
+              const: INVITATION_CLAIMED
               description: Type of webhook event
               example: INVITATION_CLAIMED
     KycStatusWebhook:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5242,44 +5242,27 @@ components:
               const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
-      allOf:
-        - type: object
-          required:
-            - accountType
-          properties:
-            accountType:
-              type: string
-              enum:
-                - LIGHTNING
-              example: LIGHTNING
-        - oneOf:
-            - title: Lightning Invoice
-              type: object
-              required:
-                - invoice
-              properties:
-                invoice:
-                  type: string
-                  description: 1-time use lightning bolt11 invoice payout destination
-                  example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            - title: Lightning - Bolt12 Offer
-              type: object
-              required:
-                - bolt12
-              properties:
-                bolt12:
-                  type: string
-                  description: A bolt12 offer which can be reused as a payment destination
-                  example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            - title: Lightning Address
-              type: object
-              required:
-                - lightningAddress
-              properties:
-                lightningAddress:
-                  type: string
-                  description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-                  example: john.doe@lightningwallet.com
+      type: object
+      required:
+        - accountType
+      description: |
+        Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+      properties:
+        accountType:
+          const: LIGHTNING
+          example: LIGHTNING
+        invoice:
+          type: string
+          description: 1-time use lightning bolt11 invoice payout destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        bolt12:
+          type: string
+          description: A bolt12 offer which can be reused as a payment destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        lightningAddress:
+          type: string
+          description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+          example: john.doe@lightningwallet.com
     SolanaWalletExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/SolanaWalletInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4044,8 +4044,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 401
+          const: 401
           type: integer
           description: HTTP status code
         code:
@@ -4072,8 +4071,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 500
+          const: 500
           type: integer
           description: HTTP status code
         code:
@@ -4100,8 +4098,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 400
+          const: 400
           type: integer
           description: HTTP status code
         code:
@@ -4178,8 +4175,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 501
+          const: 501
           type: integer
           description: HTTP status code
         code:
@@ -4436,8 +4432,7 @@ components:
       properties:
         customerType:
           type: string
-          enum:
-            - BUSINESS
+          const: BUSINESS
           description: Customer type
         umaAddress:
           type: string
@@ -4472,8 +4467,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 409
+          const: 409
           type: integer
           description: HTTP status code
         code:
@@ -4500,8 +4494,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 404
+          const: 404
           type: integer
           description: HTTP status code
         code:
@@ -4619,9 +4612,7 @@ components:
         - accountCategory
       properties:
         accountType:
-          type: string
-          enum:
-            - US_ACCOUNT
+          const: US_ACCOUNT
           example: US_ACCOUNT
         accountNumber:
           type: string
@@ -4665,9 +4656,7 @@ components:
         - taxId
       properties:
         accountType:
-          type: string
-          enum:
-            - PIX
+          const: PIX
           example: PIX
         pixKey:
           type: string
@@ -4699,9 +4688,7 @@ components:
         - swiftBic
       properties:
         accountType:
-          type: string
-          enum:
-            - IBAN
+          const: IBAN
           example: IBAN
         iban:
           type: string
@@ -4753,9 +4740,7 @@ components:
         - vpa
       properties:
         accountType:
-          type: string
-          enum:
-            - UPI
+          const: UPI
           example: UPI
         vpa:
           type: string
@@ -4773,9 +4758,7 @@ components:
         - bankName
       properties:
         accountType:
-          type: string
-          enum:
-            - NGN_ACCOUNT
+          const: NGN_ACCOUNT
           example: NGN_ACCOUNT
         accountNumber:
           type: string
@@ -4806,9 +4789,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - SPARK_WALLET
+          const: SPARK_WALLET
           example: SPARK_WALLET
         address:
           type: string
@@ -4854,9 +4835,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - SOLANA_WALLET
+          const: SOLANA_WALLET
           example: SOLANA_WALLET
         address:
           type: string
@@ -4880,9 +4859,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - TRON_WALLET
+          const: TRON_WALLET
           example: TRON_WALLET
         address:
           type: string
@@ -4905,9 +4882,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - POLYGON_WALLET
+          const: POLYGON_WALLET
           example: POLYGON_WALLET
         address:
           type: string
@@ -4947,9 +4922,7 @@ components:
         - clabeNumber
       properties:
         accountType:
-          type: string
-          enum:
-            - CLABE
+          const: CLABE
           example: CLABE
         clabeNumber:
           type: string
@@ -4965,9 +4938,7 @@ components:
         - address
       properties:
         accountType:
-          type: string
-          enum:
-            - BASE_WALLET
+          const: BASE_WALLET
           example: BASE_WALLET
         address:
           type: string
@@ -5085,8 +5056,7 @@ components:
       properties:
         beneficiaryType:
           type: string
-          enum:
-            - INDIVIDUAL
+          const: INDIVIDUAL
           example: INDIVIDUAL
         fullName:
           type: string
@@ -5111,8 +5081,7 @@ components:
       properties:
         beneficiaryType:
           type: string
-          enum:
-            - BUSINESS
+          const: BUSINESS
           example: BUSINESS
         legalName:
           type: string
@@ -5137,9 +5106,7 @@ components:
             - beneficiary
           properties:
             accountType:
-              type: string
-              enum:
-                - US_ACCOUNT
+              const: US_ACCOUNT
               example: US_ACCOUNT
             beneficiary:
               oneOf:
@@ -5158,9 +5125,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - CLABE
+              const: CLABE
               example: CLABE
             beneficiary:
               oneOf:
@@ -5179,9 +5144,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - PIX
+              const: PIX
               example: PIX
             beneficiary:
               oneOf:
@@ -5200,9 +5163,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - IBAN
+              const: IBAN
               example: IBAN
             beneficiary:
               oneOf:
@@ -5221,9 +5182,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - UPI
+              const: UPI
               example: UPI
             beneficiary:
               oneOf:
@@ -5244,9 +5203,7 @@ components:
             - beneficiary
           properties:
             accountType:
-              type: string
-              enum:
-                - NGN_ACCOUNT
+              const: NGN_ACCOUNT
               example: NGN_ACCOUNT
             beneficiary:
               oneOf:
@@ -5282,9 +5239,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - SPARK_WALLET
+              const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
       allOf:
@@ -5333,9 +5288,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - SOLANA_WALLET
+              const: SOLANA_WALLET
               example: SOLANA_WALLET
     TronWalletExternalAccountInfo:
       allOf:
@@ -5345,9 +5298,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - TRON_WALLET
+              const: TRON_WALLET
               example: TRON_WALLET
     PolygonWalletExternalAccountInfo:
       allOf:
@@ -5357,9 +5308,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - POLYGON_WALLET
+              const: POLYGON_WALLET
               example: POLYGON_WALLET
     BaseWalletExternalAccountInfo:
       allOf:
@@ -5369,9 +5318,7 @@ components:
             - accountType
           properties:
             accountType:
-              type: string
-              enum:
-                - BASE_WALLET
+              const: BASE_WALLET
               example: BASE_WALLET
     ExternalAccountInfo:
       oneOf:
@@ -5951,8 +5898,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 412
+          const: 412
           type: integer
           description: HTTP status code
         code:
@@ -5961,8 +5907,7 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | UNSUPPORTED_UMA_VERSION | Counterparty doesn't support the Grid UMA version |
-          enum:
-            - UNSUPPORTED_UMA_VERSION
+          const: UNSUPPORTED_UMA_VERSION
         message:
           type: string
           description: Error message
@@ -5977,8 +5922,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 424
+          const: 424
           type: integer
           description: HTTP status code
         code:
@@ -6403,8 +6347,7 @@ components:
         - code
       properties:
         status:
-          enum:
-            - 403
+          const: 403
           type: integer
           description: HTTP status code
         code:
@@ -6619,8 +6562,7 @@ components:
               $ref: '#/components/schemas/UmaInvitation'
             type:
               type: string
-              enum:
-                - INVITATION_CLAIMED
+              const: INVITATION_CLAIMED
               description: Type of webhook event
               example: INVITATION_CLAIMED
     KycStatusWebhook:

--- a/openapi/components/schemas/common/BaseWalletInfo.yaml
+++ b/openapi/components/schemas/common/BaseWalletInfo.yaml
@@ -4,8 +4,7 @@ required:
   - address
 properties:
   accountType:
-    type: string
-    enum: [BASE_WALLET]
+    const: BASE_WALLET
     example: BASE_WALLET
   address:
     type: string

--- a/openapi/components/schemas/common/ClabeAccountInfo.yaml
+++ b/openapi/components/schemas/common/ClabeAccountInfo.yaml
@@ -4,8 +4,7 @@ required:
   - clabeNumber
 properties:
   accountType:
-    type: string
-    enum: [CLABE]
+    const: CLABE
     example: CLABE
   clabeNumber:
     type: string

--- a/openapi/components/schemas/common/FboAccountInfo.yaml
+++ b/openapi/components/schemas/common/FboAccountInfo.yaml
@@ -4,8 +4,7 @@ required:
   - currencyCode
 properties:
   accountType:
-    type: string
-    enum: [FBO]
+    const: FBO
     example: FBO
   currencyCode:
     type: string

--- a/openapi/components/schemas/common/IbanAccountInfo.yaml
+++ b/openapi/components/schemas/common/IbanAccountInfo.yaml
@@ -5,8 +5,7 @@ required:
   - swiftBic
 properties:
   accountType:
-    type: string
-    enum: [IBAN]
+    const: IBAN
     example: IBAN
   iban:
     type: string

--- a/openapi/components/schemas/common/NgnAccountInfo.yaml
+++ b/openapi/components/schemas/common/NgnAccountInfo.yaml
@@ -5,8 +5,7 @@ required:
   - bankName
 properties:
   accountType:
-    type: string
-    enum: [NGN_ACCOUNT]
+    const: NGN_ACCOUNT
     example: NGN_ACCOUNT
   accountNumber:
     type: string

--- a/openapi/components/schemas/common/PixAccountInfo.yaml
+++ b/openapi/components/schemas/common/PixAccountInfo.yaml
@@ -6,8 +6,7 @@ required:
   - taxId
 properties:
   accountType:
-    type: string
-    enum: [PIX]
+    const: PIX
     example: PIX
   pixKey:
     type: string

--- a/openapi/components/schemas/common/PolygonWalletInfo.yaml
+++ b/openapi/components/schemas/common/PolygonWalletInfo.yaml
@@ -4,8 +4,7 @@ required:
   - address
 properties:
   accountType:
-    type: string
-    enum: [POLYGON_WALLET]
+    const: POLYGON_WALLET
     example: POLYGON_WALLET
   address:
     type: string

--- a/openapi/components/schemas/common/SolanaWalletInfo.yaml
+++ b/openapi/components/schemas/common/SolanaWalletInfo.yaml
@@ -4,8 +4,7 @@ required:
   - address
 properties:
   accountType:
-    type: string
-    enum: [SOLANA_WALLET]
+    const: SOLANA_WALLET
     example: SOLANA_WALLET
   address:
     type: string

--- a/openapi/components/schemas/common/SparkWalletInfo.yaml
+++ b/openapi/components/schemas/common/SparkWalletInfo.yaml
@@ -4,8 +4,7 @@ required:
   - address
 properties:
   accountType:
-    type: string
-    enum: [SPARK_WALLET]
+    const: SPARK_WALLET
     example: SPARK_WALLET
   address:
     type: string

--- a/openapi/components/schemas/common/TronWalletInfo.yaml
+++ b/openapi/components/schemas/common/TronWalletInfo.yaml
@@ -4,8 +4,7 @@ required:
   - address
 properties:
   accountType:
-    type: string
-    enum: [TRON_WALLET]
+    const: TRON_WALLET
     example: TRON_WALLET
   address:
     type: string

--- a/openapi/components/schemas/common/UpiAccountInfo.yaml
+++ b/openapi/components/schemas/common/UpiAccountInfo.yaml
@@ -4,8 +4,7 @@ required:
   - vpa
 properties:
   accountType:
-    type: string
-    enum: [UPI]
+    const: UPI
     example: UPI
   vpa:
     type: string

--- a/openapi/components/schemas/common/UsAccountInfo.yaml
+++ b/openapi/components/schemas/common/UsAccountInfo.yaml
@@ -6,8 +6,7 @@ required:
   - accountCategory
 properties:
   accountType:
-    type: string
-    enum: [US_ACCOUNT]
+    const: US_ACCOUNT
     example: US_ACCOUNT
   accountNumber:
     type: string

--- a/openapi/components/schemas/customers/BusinessCustomerUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessCustomerUpdate.yaml
@@ -4,7 +4,7 @@ required:
 properties:
   customerType:
     type: string
-    enum: [BUSINESS]
+    const: BUSINESS
     description: Customer type
   umaAddress:
     type: string

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 400
+    const: 400
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 401
+    const: 401
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error403.yaml
+++ b/openapi/components/schemas/errors/Error403.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 403
+    const: 403
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error404.yaml
+++ b/openapi/components/schemas/errors/Error404.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 404
+    const: 404
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 409
+    const: 409
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error412.yaml
+++ b/openapi/components/schemas/errors/Error412.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 412
+    const: 412
     type: integer
     description: HTTP status code
   code:
@@ -15,8 +14,7 @@ properties:
       | Error Code | Description |
       |------------|-------------|
       | UNSUPPORTED_UMA_VERSION | Counterparty doesn't support the Grid UMA version |
-    enum:
-      - UNSUPPORTED_UMA_VERSION
+    const: UNSUPPORTED_UMA_VERSION
   message:
     type: string
     description: Error message

--- a/openapi/components/schemas/errors/Error424.yaml
+++ b/openapi/components/schemas/errors/Error424.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 424
+    const: 424
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error500.yaml
+++ b/openapi/components/schemas/errors/Error500.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 500
+    const: 500
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/errors/Error501.yaml
+++ b/openapi/components/schemas/errors/Error501.yaml
@@ -5,8 +5,7 @@ required:
   - code
 properties:
   status:
-    enum:
-      - 501
+    const: 501
     type: integer
     description: HTTP status code
   code:

--- a/openapi/components/schemas/external_accounts/BaseWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/BaseWalletExternalAccountInfo.yaml
@@ -5,6 +5,5 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [BASE_WALLET]
+        const: BASE_WALLET
         example: BASE_WALLET

--- a/openapi/components/schemas/external_accounts/BusinessBeneficiary.yaml
+++ b/openapi/components/schemas/external_accounts/BusinessBeneficiary.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   beneficiaryType:
     type: string
-    enum: [BUSINESS]
+    const: BUSINESS
     example: BUSINESS
   legalName:
     type: string

--- a/openapi/components/schemas/external_accounts/ClabeAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/ClabeAccountExternalAccountInfo.yaml
@@ -5,8 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [CLABE]
+        const: CLABE
         example: CLABE
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/external_accounts/IbanAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/IbanAccountExternalAccountInfo.yaml
@@ -5,8 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [IBAN]
+        const: IBAN
         example: IBAN
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/external_accounts/IndividualBeneficiary.yaml
+++ b/openapi/components/schemas/external_accounts/IndividualBeneficiary.yaml
@@ -7,7 +7,7 @@ required:
 properties:
   beneficiaryType:
     type: string
-    enum: [INDIVIDUAL]
+    const: INDIVIDUAL
     example: INDIVIDUAL
   fullName:
     type: string

--- a/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
@@ -1,37 +1,21 @@
-allOf:
-  - type: object
-    required:
-      - accountType
-    properties:
-      accountType:
-        type: string
-        enum: [LIGHTNING]
-        example: LIGHTNING
-  - oneOf:
-      - title: Lightning Invoice
-        type: object
-        required:
-          - invoice
-        properties:
-          invoice:
-            type: string
-            description: 1-time use lightning bolt11 invoice payout destination
-            example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-      - title: Lightning - Bolt12 Offer
-        type: object
-        required:
-          - bolt12
-        properties:
-          bolt12:
-            type: string
-            description: A bolt12 offer which can be reused as a payment destination
-            example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-      - title: Lightning Address
-        type: object
-        required:
-          - lightningAddress
-        properties:
-          lightningAddress:
-            type: string
-            description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-            example: john.doe@lightningwallet.com
+type: object
+required:
+  - accountType
+description: >
+  Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+properties:
+  accountType:
+    const: LIGHTNING
+    example: LIGHTNING
+  invoice:
+    type: string
+    description: 1-time use lightning bolt11 invoice payout destination
+    example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+  bolt12:
+    type: string
+    description: A bolt12 offer which can be reused as a payment destination
+    example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+  lightningAddress:
+    type: string
+    description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+    example: john.doe@lightningwallet.com

--- a/openapi/components/schemas/external_accounts/NgnAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/NgnAccountExternalAccountInfo.yaml
@@ -7,8 +7,7 @@ allOf:
       - beneficiary
     properties:
       accountType:
-        type: string
-        enum: [NGN_ACCOUNT]
+        const: NGN_ACCOUNT
         example: NGN_ACCOUNT
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/external_accounts/PixAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/PixAccountExternalAccountInfo.yaml
@@ -5,8 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [PIX]
+        const: PIX
         example: PIX
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/external_accounts/PolygonWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/PolygonWalletExternalAccountInfo.yaml
@@ -5,6 +5,5 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [POLYGON_WALLET]
+        const: POLYGON_WALLET
         example: POLYGON_WALLET

--- a/openapi/components/schemas/external_accounts/SolanaWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SolanaWalletExternalAccountInfo.yaml
@@ -5,6 +5,5 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [SOLANA_WALLET]
+        const: SOLANA_WALLET
         example: SOLANA_WALLET

--- a/openapi/components/schemas/external_accounts/SparkWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SparkWalletExternalAccountInfo.yaml
@@ -5,6 +5,5 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [SPARK_WALLET]
+        const: SPARK_WALLET
         example: SPARK_WALLET

--- a/openapi/components/schemas/external_accounts/TronWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/TronWalletExternalAccountInfo.yaml
@@ -5,6 +5,5 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [TRON_WALLET]
+        const: TRON_WALLET
         example: TRON_WALLET

--- a/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
@@ -5,8 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
-        type: string
-        enum: [UPI]
+        const: UPI
         example: UPI
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/external_accounts/UsAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UsAccountExternalAccountInfo.yaml
@@ -6,8 +6,7 @@ allOf:
       - beneficiary
     properties:
       accountType:
-        type: string
-        enum: [US_ACCOUNT]
+        const: US_ACCOUNT
         example: US_ACCOUNT
       beneficiary:
         oneOf:

--- a/openapi/components/schemas/webhooks/InvitationClaimedWebhook.yaml
+++ b/openapi/components/schemas/webhooks/InvitationClaimedWebhook.yaml
@@ -8,7 +8,6 @@ allOf:
         $ref: ../invitations/UmaInvitation.yaml
       type:
         type: string
-        enum:
-          - INVITATION_CLAIMED
+        const: INVITATION_CLAIMED
         description: Type of webhook event
         example: INVITATION_CLAIMED


### PR DESCRIPTION
# Convert single-value enums to const for base types

This PR replaces single-value enums with `const` properties throughout the OpenAPI schema. This change improves schema clarity and validation behavior.

Additionally, the PR flattens the `LightningExternalAccountInfo` schema structure, converting it from a complex nested structure with `allOf` and `oneOf` combinations to a simpler flat object with optional properties.