### PR TITLE
feat: rename accounts to data in list external accounts response

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -999,9 +999,9 @@ paths:
               schema:
                 type: object
                 required:
-                  - accounts
+                  - data
                 properties:
-                  accounts:
+                  data:
                     type: array
                     description: List of external accounts matching the filter criteria
                     items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -999,9 +999,9 @@ paths:
               schema:
                 type: object
                 required:
-                  - accounts
+                  - data
                 properties:
-                  accounts:
+                  data:
                     type: array
                     description: List of external accounts matching the filter criteria
                     items:

--- a/openapi/paths/platform/platform_external_accounts.yaml
+++ b/openapi/paths/platform/platform_external_accounts.yaml
@@ -24,9 +24,9 @@ get:
           schema:
             type: object
             required:
-              - accounts
+              - data
             properties:
-              accounts:
+              data:
                 type: array
                 description: List of external accounts matching the filter criteria
                 items:


### PR DESCRIPTION
### TL;DR

Updated the response schema for external accounts endpoint to use `data` instead of `accounts` as the property name.

### What changed?

Changed the required property name in the external accounts API response from `accounts` to `data`. This affects the schema definition in the OpenAPI specification across multiple files:
- `mintlify/openapi.yaml`
- `openapi.yaml`
- `openapi/paths/platform/platform_external_accounts.yaml`

### How to test?

1. Make a request to the external accounts endpoint
2. Verify that the response contains a `data` array instead of an `accounts` array
3. Ensure all client code that consumes this API is updated to reference the new property name

### Why make this change?

This change standardizes the API response format to be consistent with other endpoints in the system that use `data` as the top-level property for array responses. This improves API consistency and makes client integration more predictable.