### PR TITLE
feat: rename Error to GridError and add additionalProperties to error schemas

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3945,6 +3945,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error500:
       type: object
       required:
@@ -3973,6 +3974,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error400:
       type: object
       required:
@@ -4051,6 +4053,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error501:
       type: object
       required:
@@ -4079,6 +4082,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     CustomerType:
       type: string
       enum:
@@ -4398,6 +4402,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error404:
       type: object
       required:
@@ -4438,6 +4443,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error:
       type: object
       properties:
@@ -6045,6 +6051,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error424:
       type: object
       required:
@@ -6077,6 +6084,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     AccountQuoteSource:
       allOf:
         - $ref: '#/components/schemas/BaseQuoteSource'
@@ -6412,6 +6420,32 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    GridError:
+      type: object
+      title: GridError
+      properties:
+        code:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+          additionalProperties: true
+    BulkCustomerImportErrorEntry:
+      allOf:
+        - $ref: '#/components/schemas/GridError'
+        - type: object
+          description: Error information for a failed bulk import entry
+          required:
+            - correlationId
+          properties:
+            correlationId:
+              type: string
+              description: Platform customer ID or row number for the failed entry
+              example: biz456
     BulkCustomerImportJob:
       type: object
       required:
@@ -6460,17 +6494,7 @@ components:
           type: array
           description: Detailed error information for failed entries
           items:
-            type: object
-            required:
-              - correlationId
-              - error
-            properties:
-              correlationId:
-                type: string
-                description: Platform customer ID or row number for the failed entry
-                example: biz456
-              error:
-                $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/BulkCustomerImportErrorEntry'
         completedAt:
           type: string
           format: date-time
@@ -6566,6 +6590,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     UmaProvider:
       type: object
       properties:
@@ -6785,7 +6810,7 @@ components:
           description: Information about the recipient, provided by the platform if requested in the webhook via `requestedReceiverCustomerInfoFields` and the payment is approved.
     IncomingPaymentWebhookForbiddenResponse:
       allOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/GridError'
         - type: object
           properties:
             reason:
@@ -6794,7 +6819,7 @@ components:
               example: RESTRICTED_JURISDICTION
     IncomingPaymentWebhookUnprocessableResponse:
       allOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/GridError'
         - type: object
           properties:
             requiredFields:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3945,6 +3945,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error500:
       type: object
       required:
@@ -3973,6 +3974,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error400:
       type: object
       required:
@@ -4051,6 +4053,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error501:
       type: object
       required:
@@ -4079,6 +4082,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     CustomerType:
       type: string
       enum:
@@ -4398,6 +4402,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error404:
       type: object
       required:
@@ -4438,6 +4443,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error:
       type: object
       properties:
@@ -6045,6 +6051,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     Error424:
       type: object
       required:
@@ -6077,6 +6084,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     AccountQuoteSource:
       allOf:
         - $ref: '#/components/schemas/BaseQuoteSource'
@@ -6412,6 +6420,32 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    GridError:
+      type: object
+      title: GridError
+      properties:
+        code:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+          additionalProperties: true
+    BulkCustomerImportErrorEntry:
+      allOf:
+        - $ref: '#/components/schemas/GridError'
+        - type: object
+          description: Error information for a failed bulk import entry
+          required:
+            - correlationId
+          properties:
+            correlationId:
+              type: string
+              description: Platform customer ID or row number for the failed entry
+              example: biz456
     BulkCustomerImportJob:
       type: object
       required:
@@ -6460,17 +6494,7 @@ components:
           type: array
           description: Detailed error information for failed entries
           items:
-            type: object
-            required:
-              - correlationId
-              - error
-            properties:
-              correlationId:
-                type: string
-                description: Platform customer ID or row number for the failed entry
-                example: biz456
-              error:
-                $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/BulkCustomerImportErrorEntry'
         completedAt:
           type: string
           format: date-time
@@ -6566,6 +6590,7 @@ components:
         details:
           type: object
           description: Additional error details
+          additionalProperties: true
     UmaProvider:
       type: object
       properties:
@@ -6785,7 +6810,7 @@ components:
           description: Information about the recipient, provided by the platform if requested in the webhook via `requestedReceiverCustomerInfoFields` and the payment is approved.
     IncomingPaymentWebhookForbiddenResponse:
       allOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/GridError'
         - type: object
           properties:
             reason:
@@ -6794,7 +6819,7 @@ components:
               example: RESTRICTED_JURISDICTION
     IncomingPaymentWebhookUnprocessableResponse:
       allOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/GridError'
         - type: object
           properties:
             requiredFields:

--- a/openapi/components/schemas/common/GridError.yaml
+++ b/openapi/components/schemas/common/GridError.yaml
@@ -1,0 +1,13 @@
+type: object
+title: GridError
+properties:
+  code:
+    type: string
+    description: Error code
+  message:
+    type: string
+    description: Error message
+  details:
+    type: object
+    description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/customers/BulkCustomerImportErrorEntry.yaml
+++ b/openapi/components/schemas/customers/BulkCustomerImportErrorEntry.yaml
@@ -1,0 +1,11 @@
+allOf:
+  - $ref: ../common/GridError.yaml
+  - type: object
+    description: Error information for a failed bulk import entry
+    required:
+      - correlationId
+    properties:
+      correlationId:
+        type: string
+        description: Platform customer ID or row number for the failed entry
+        example: biz456

--- a/openapi/components/schemas/customers/BulkCustomerImportJob.yaml
+++ b/openapi/components/schemas/customers/BulkCustomerImportJob.yaml
@@ -45,17 +45,7 @@ properties:
     type: array
     description: Detailed error information for failed entries
     items:
-      type: object
-      required:
-        - correlationId
-        - error
-      properties:
-        correlationId:
-          type: string
-          description: Platform customer ID or row number for the failed entry
-          example: biz456
-        error:
-          $ref: ../common/Error.yaml
+      $ref: BulkCustomerImportErrorEntry.yaml
   completedAt:
     type: string
     format: date-time

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -75,3 +75,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -25,3 +25,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error403.yaml
+++ b/openapi/components/schemas/errors/Error403.yaml
@@ -29,3 +29,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error404.yaml
+++ b/openapi/components/schemas/errors/Error404.yaml
@@ -37,3 +37,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -25,3 +25,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error410.yaml
+++ b/openapi/components/schemas/errors/Error410.yaml
@@ -7,22 +7,16 @@ properties:
   status:
     type: integer
     enum: 
-      - 424
+      - 410
     description: HTTP status code
   code:
     type: string
     description: |
       | Error Code | Description |
       |------------|-------------|
-      | PAYREQ_REQUEST_FAILED | Payment request failed |
-      | COUNTERPARTY_PUBKEY_FETCH_ERROR | Error fetching counterparty public key |
-      | NO_COMPATIBLE_UMA_VERSION | No compatible UMA version |
-      | LNURLP_REQUEST_FAILED | LNURLP request failed |
+      | CUSTOMER_DELETED | Customer has been permanently deleted |
     enum:
-      - PAYREQ_REQUEST_FAILED
-      - COUNTERPARTY_PUBKEY_FETCH_ERROR
-      - NO_COMPATIBLE_UMA_VERSION
-      - LNURLP_REQUEST_FAILED
+      - CUSTOMER_DELETED
   message:
     type: string
     description: Error message

--- a/openapi/components/schemas/errors/Error412.yaml
+++ b/openapi/components/schemas/errors/Error412.yaml
@@ -22,3 +22,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error500.yaml
+++ b/openapi/components/schemas/errors/Error500.yaml
@@ -25,3 +25,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/errors/Error501.yaml
+++ b/openapi/components/schemas/errors/Error501.yaml
@@ -25,3 +25,4 @@ properties:
   details:
     type: object
     description: Additional error details
+    additionalProperties: true

--- a/openapi/components/schemas/webhooks/IncomingPaymentWebhookForbiddenResponse.yaml
+++ b/openapi/components/schemas/webhooks/IncomingPaymentWebhookForbiddenResponse.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: ../common/Error.yaml
+  - $ref: ../common/GridError.yaml
   - type: object
     properties:
       reason:

--- a/openapi/components/schemas/webhooks/IncomingPaymentWebhookUnprocessableResponse.yaml
+++ b/openapi/components/schemas/webhooks/IncomingPaymentWebhookUnprocessableResponse.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: ../common/Error.yaml
+  - $ref: ../common/GridError.yaml
   - type: object
     properties:
       requiredFields:


### PR DESCRIPTION
### TL;DR

Added a new `GridError` schema and improved error handling in the OpenAPI specification.

### What changed?

- Created a new `GridError` schema to standardize error responses
- Added `additionalProperties: true` to all error schema `details` objects to allow for flexible error details
- Refactored `BulkCustomerImportErrorEntry` to extend from `GridError` instead of using a nested error structure
- Updated webhook response schemas to reference `GridError` instead of `Error`

