### PR TITLE
feat: adding idempotency to transfers

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -1240,6 +1240,15 @@ paths:
         - Same-Currency Transfers
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          description: |
+            A unique identifier for the request. If the same key is sent multiple times, the server will return the same response as the first request.
+          schema:
+            type: string
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:
@@ -1325,6 +1334,15 @@ paths:
         - Same-Currency Transfers
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          description: |
+            A unique identifier for the request. If the same key is sent multiple times, the server will return the same response as the first request.
+          schema:
+            type: string
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1240,6 +1240,15 @@ paths:
         - Same-Currency Transfers
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          description: |
+            A unique identifier for the request. If the same key is sent multiple times, the server will return the same response as the first request.
+          schema:
+            type: string
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:
@@ -1325,6 +1334,15 @@ paths:
         - Same-Currency Transfers
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          description: |
+            A unique identifier for the request. If the same key is sent multiple times, the server will return the same response as the first request.
+          schema:
+            type: string
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:

--- a/openapi/paths/transfers/transfer_in.yaml
+++ b/openapi/paths/transfers/transfer_in.yaml
@@ -9,6 +9,16 @@ post:
     - Same-Currency Transfers
   security:
     - BasicAuth: []
+  parameters:
+    - name: Idempotency-Key
+      in: header
+      required: false
+      description: >
+        A unique identifier for the request. If the same key is sent multiple times,
+        the server will return the same response as the first request.
+      schema:
+        type: string
+        example: 550e8400-e29b-41d4-a716-446655440000
   requestBody:
     required: true
     content:

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -7,6 +7,16 @@ post:
     - Same-Currency Transfers
   security:
     - BasicAuth: []
+  parameters:
+    - name: Idempotency-Key
+      in: header
+      required: false
+      description: >
+        A unique identifier for the request. If the same key is sent multiple times,
+        the server will return the same response as the first request.
+      schema:
+        type: string
+        example: 550e8400-e29b-41d4-a716-446655440000
   requestBody:
     required: true
     content:


### PR DESCRIPTION
### TL;DR

Added Idempotency-Key header support to transfer endpoints.

### What changed?

- Added an optional `Idempotency-Key` header parameter to the transfer-in and transfer-out API endpoints
- The header allows clients to safely retry requests without risking duplicate transfers
- Included documentation explaining that if the same key is sent multiple times, the server will return the same response as the first request
- Added an example UUID format for the header value: `550e8400-e29b-41d4-a716-446655440000`
