### PR TITLE
fix: adding type:string to const discriminators

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4612,6 +4612,7 @@ components:
         - accountCategory
       properties:
         accountType:
+          type: string
           const: US_ACCOUNT
           example: US_ACCOUNT
         accountNumber:
@@ -4656,6 +4657,7 @@ components:
         - taxId
       properties:
         accountType:
+          type: string
           const: PIX
           example: PIX
         pixKey:
@@ -4688,6 +4690,7 @@ components:
         - swiftBic
       properties:
         accountType:
+          type: string
           const: IBAN
           example: IBAN
         iban:
@@ -4740,6 +4743,7 @@ components:
         - vpa
       properties:
         accountType:
+          type: string
           const: UPI
           example: UPI
         vpa:
@@ -4758,6 +4762,7 @@ components:
         - bankName
       properties:
         accountType:
+          type: string
           const: NGN_ACCOUNT
           example: NGN_ACCOUNT
         accountNumber:
@@ -4789,6 +4794,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: SPARK_WALLET
           example: SPARK_WALLET
         address:
@@ -4835,6 +4841,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: SOLANA_WALLET
           example: SOLANA_WALLET
         address:
@@ -4859,6 +4866,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: TRON_WALLET
           example: TRON_WALLET
         address:
@@ -4882,6 +4890,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: POLYGON_WALLET
           example: POLYGON_WALLET
         address:
@@ -4922,6 +4931,7 @@ components:
         - clabeNumber
       properties:
         accountType:
+          type: string
           const: CLABE
           example: CLABE
         clabeNumber:
@@ -4938,6 +4948,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: BASE_WALLET
           example: BASE_WALLET
         address:
@@ -5106,6 +5117,7 @@ components:
             - beneficiary
           properties:
             accountType:
+              type: string
               const: US_ACCOUNT
               example: US_ACCOUNT
             beneficiary:
@@ -5125,6 +5137,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: CLABE
               example: CLABE
             beneficiary:
@@ -5144,6 +5157,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: PIX
               example: PIX
             beneficiary:
@@ -5163,6 +5177,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: IBAN
               example: IBAN
             beneficiary:
@@ -5182,6 +5197,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: UPI
               example: UPI
             beneficiary:
@@ -5203,6 +5219,7 @@ components:
             - beneficiary
           properties:
             accountType:
+              type: string
               const: NGN_ACCOUNT
               example: NGN_ACCOUNT
             beneficiary:
@@ -5239,6 +5256,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
@@ -5249,6 +5267,7 @@ components:
         Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
       properties:
         accountType:
+          type: string
           const: LIGHTNING
           example: LIGHTNING
         invoice:
@@ -5271,6 +5290,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: SOLANA_WALLET
               example: SOLANA_WALLET
     TronWalletExternalAccountInfo:
@@ -5281,6 +5301,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: TRON_WALLET
               example: TRON_WALLET
     PolygonWalletExternalAccountInfo:
@@ -5291,6 +5312,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: POLYGON_WALLET
               example: POLYGON_WALLET
     BaseWalletExternalAccountInfo:
@@ -5301,6 +5323,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: BASE_WALLET
               example: BASE_WALLET
     ExternalAccountInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4612,6 +4612,7 @@ components:
         - accountCategory
       properties:
         accountType:
+          type: string
           const: US_ACCOUNT
           example: US_ACCOUNT
         accountNumber:
@@ -4656,6 +4657,7 @@ components:
         - taxId
       properties:
         accountType:
+          type: string
           const: PIX
           example: PIX
         pixKey:
@@ -4688,6 +4690,7 @@ components:
         - swiftBic
       properties:
         accountType:
+          type: string
           const: IBAN
           example: IBAN
         iban:
@@ -4740,6 +4743,7 @@ components:
         - vpa
       properties:
         accountType:
+          type: string
           const: UPI
           example: UPI
         vpa:
@@ -4758,6 +4762,7 @@ components:
         - bankName
       properties:
         accountType:
+          type: string
           const: NGN_ACCOUNT
           example: NGN_ACCOUNT
         accountNumber:
@@ -4789,6 +4794,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: SPARK_WALLET
           example: SPARK_WALLET
         address:
@@ -4835,6 +4841,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: SOLANA_WALLET
           example: SOLANA_WALLET
         address:
@@ -4859,6 +4866,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: TRON_WALLET
           example: TRON_WALLET
         address:
@@ -4882,6 +4890,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: POLYGON_WALLET
           example: POLYGON_WALLET
         address:
@@ -4922,6 +4931,7 @@ components:
         - clabeNumber
       properties:
         accountType:
+          type: string
           const: CLABE
           example: CLABE
         clabeNumber:
@@ -4938,6 +4948,7 @@ components:
         - address
       properties:
         accountType:
+          type: string
           const: BASE_WALLET
           example: BASE_WALLET
         address:
@@ -5106,6 +5117,7 @@ components:
             - beneficiary
           properties:
             accountType:
+              type: string
               const: US_ACCOUNT
               example: US_ACCOUNT
             beneficiary:
@@ -5125,6 +5137,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: CLABE
               example: CLABE
             beneficiary:
@@ -5144,6 +5157,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: PIX
               example: PIX
             beneficiary:
@@ -5163,6 +5177,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: IBAN
               example: IBAN
             beneficiary:
@@ -5182,6 +5197,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: UPI
               example: UPI
             beneficiary:
@@ -5203,6 +5219,7 @@ components:
             - beneficiary
           properties:
             accountType:
+              type: string
               const: NGN_ACCOUNT
               example: NGN_ACCOUNT
             beneficiary:
@@ -5239,6 +5256,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: SPARK_WALLET
               example: SPARK_WALLET
     LightningExternalAccountInfo:
@@ -5249,6 +5267,7 @@ components:
         Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
       properties:
         accountType:
+          type: string
           const: LIGHTNING
           example: LIGHTNING
         invoice:
@@ -5271,6 +5290,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: SOLANA_WALLET
               example: SOLANA_WALLET
     TronWalletExternalAccountInfo:
@@ -5281,6 +5301,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: TRON_WALLET
               example: TRON_WALLET
     PolygonWalletExternalAccountInfo:
@@ -5291,6 +5312,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: POLYGON_WALLET
               example: POLYGON_WALLET
     BaseWalletExternalAccountInfo:
@@ -5301,6 +5323,7 @@ components:
             - accountType
           properties:
             accountType:
+              type: string
               const: BASE_WALLET
               example: BASE_WALLET
     ExternalAccountInfo:

--- a/openapi/components/schemas/common/BaseWalletInfo.yaml
+++ b/openapi/components/schemas/common/BaseWalletInfo.yaml
@@ -4,6 +4,7 @@ required:
   - address
 properties:
   accountType:
+    type: string
     const: BASE_WALLET
     example: BASE_WALLET
   address:

--- a/openapi/components/schemas/common/ClabeAccountInfo.yaml
+++ b/openapi/components/schemas/common/ClabeAccountInfo.yaml
@@ -4,6 +4,7 @@ required:
   - clabeNumber
 properties:
   accountType:
+    type: string
     const: CLABE
     example: CLABE
   clabeNumber:

--- a/openapi/components/schemas/common/FboAccountInfo.yaml
+++ b/openapi/components/schemas/common/FboAccountInfo.yaml
@@ -4,6 +4,7 @@ required:
   - currencyCode
 properties:
   accountType:
+    type: string
     const: FBO
     example: FBO
   currencyCode:

--- a/openapi/components/schemas/common/IbanAccountInfo.yaml
+++ b/openapi/components/schemas/common/IbanAccountInfo.yaml
@@ -5,6 +5,7 @@ required:
   - swiftBic
 properties:
   accountType:
+    type: string
     const: IBAN
     example: IBAN
   iban:

--- a/openapi/components/schemas/common/NgnAccountInfo.yaml
+++ b/openapi/components/schemas/common/NgnAccountInfo.yaml
@@ -5,6 +5,7 @@ required:
   - bankName
 properties:
   accountType:
+    type: string
     const: NGN_ACCOUNT
     example: NGN_ACCOUNT
   accountNumber:

--- a/openapi/components/schemas/common/PixAccountInfo.yaml
+++ b/openapi/components/schemas/common/PixAccountInfo.yaml
@@ -6,6 +6,7 @@ required:
   - taxId
 properties:
   accountType:
+    type: string
     const: PIX
     example: PIX
   pixKey:

--- a/openapi/components/schemas/common/PolygonWalletInfo.yaml
+++ b/openapi/components/schemas/common/PolygonWalletInfo.yaml
@@ -4,6 +4,7 @@ required:
   - address
 properties:
   accountType:
+    type: string
     const: POLYGON_WALLET
     example: POLYGON_WALLET
   address:

--- a/openapi/components/schemas/common/SolanaWalletInfo.yaml
+++ b/openapi/components/schemas/common/SolanaWalletInfo.yaml
@@ -4,6 +4,7 @@ required:
   - address
 properties:
   accountType:
+    type: string
     const: SOLANA_WALLET
     example: SOLANA_WALLET
   address:

--- a/openapi/components/schemas/common/SparkWalletInfo.yaml
+++ b/openapi/components/schemas/common/SparkWalletInfo.yaml
@@ -4,6 +4,7 @@ required:
   - address
 properties:
   accountType:
+    type: string
     const: SPARK_WALLET
     example: SPARK_WALLET
   address:

--- a/openapi/components/schemas/common/TronWalletInfo.yaml
+++ b/openapi/components/schemas/common/TronWalletInfo.yaml
@@ -4,6 +4,7 @@ required:
   - address
 properties:
   accountType:
+    type: string
     const: TRON_WALLET
     example: TRON_WALLET
   address:

--- a/openapi/components/schemas/common/UpiAccountInfo.yaml
+++ b/openapi/components/schemas/common/UpiAccountInfo.yaml
@@ -4,6 +4,7 @@ required:
   - vpa
 properties:
   accountType:
+    type: string
     const: UPI
     example: UPI
   vpa:

--- a/openapi/components/schemas/common/UsAccountInfo.yaml
+++ b/openapi/components/schemas/common/UsAccountInfo.yaml
@@ -6,6 +6,7 @@ required:
   - accountCategory
 properties:
   accountType:
+    type: string
     const: US_ACCOUNT
     example: US_ACCOUNT
   accountNumber:

--- a/openapi/components/schemas/external_accounts/BaseWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/BaseWalletExternalAccountInfo.yaml
@@ -5,5 +5,6 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: BASE_WALLET
         example: BASE_WALLET

--- a/openapi/components/schemas/external_accounts/ClabeAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/ClabeAccountExternalAccountInfo.yaml
@@ -5,6 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: CLABE
         example: CLABE
       beneficiary:

--- a/openapi/components/schemas/external_accounts/IbanAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/IbanAccountExternalAccountInfo.yaml
@@ -5,6 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: IBAN
         example: IBAN
       beneficiary:

--- a/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
@@ -5,6 +5,7 @@ description: >
   Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
 properties:
   accountType:
+    type: string
     const: LIGHTNING
     example: LIGHTNING
   invoice:

--- a/openapi/components/schemas/external_accounts/NgnAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/NgnAccountExternalAccountInfo.yaml
@@ -7,6 +7,7 @@ allOf:
       - beneficiary
     properties:
       accountType:
+        type: string
         const: NGN_ACCOUNT
         example: NGN_ACCOUNT
       beneficiary:

--- a/openapi/components/schemas/external_accounts/PixAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/PixAccountExternalAccountInfo.yaml
@@ -5,6 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: PIX
         example: PIX
       beneficiary:

--- a/openapi/components/schemas/external_accounts/PolygonWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/PolygonWalletExternalAccountInfo.yaml
@@ -5,5 +5,6 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: POLYGON_WALLET
         example: POLYGON_WALLET

--- a/openapi/components/schemas/external_accounts/SolanaWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SolanaWalletExternalAccountInfo.yaml
@@ -5,5 +5,6 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: SOLANA_WALLET
         example: SOLANA_WALLET

--- a/openapi/components/schemas/external_accounts/SparkWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SparkWalletExternalAccountInfo.yaml
@@ -5,5 +5,6 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: SPARK_WALLET
         example: SPARK_WALLET

--- a/openapi/components/schemas/external_accounts/TronWalletExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/TronWalletExternalAccountInfo.yaml
@@ -5,5 +5,6 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: TRON_WALLET
         example: TRON_WALLET

--- a/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
@@ -5,6 +5,7 @@ allOf:
       - accountType
     properties:
       accountType:
+        type: string
         const: UPI
         example: UPI
       beneficiary:

--- a/openapi/components/schemas/external_accounts/UsAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UsAccountExternalAccountInfo.yaml
@@ -6,6 +6,7 @@ allOf:
       - beneficiary
     properties:
       accountType:
+        type: string
         const: US_ACCOUNT
         example: US_ACCOUNT
       beneficiary:


### PR DESCRIPTION
### TL;DR

Added explicit `type: string` property to all `accountType` fields in the OpenAPI schema.  This fixes an issue where openapi generator didn't create the field validator for the discriminator.

### What changed?

Added the `type: string` property to all `accountType` fields across various account information schemas in the OpenAPI specification. This change affects multiple account types including:

- US_ACCOUNT
- PIX
- IBAN
- UPI
- NGN_ACCOUNT
- SPARK_WALLET
- SOLANA_WALLET
- TRON_WALLET
- POLYGON_WALLET
- CLABE
- BASE_WALLET
- LIGHTNING
- FBO

The change ensures that all `accountType` fields are properly typed as strings in the schema.
