### PR TITLE
feat: adding openapi schema for fx api

### DIFF
--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -37,6 +37,7 @@ jobs:
           org: ${{ env.STAINLESS_ORG }}
           project: ${{ env.STAINLESS_PROJECT }}
           oas_path: ${{ env.OAS_PATH }}
+          guess_config: true
 
   merge:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true

--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -10,7 +10,7 @@ organization:
   # and headings.
   name: grid
   # Link to your API documentation.
-  docs: ''
+  docs: 'grid.lightspark.com'
   # Contact email for bug reports, questions, and support requests.
   contact: support@lightspark.com
 
@@ -229,6 +229,11 @@ resources:
       list: get /tokens
       retrieve: get /tokens/{tokenId}
       delete: delete /tokens/{tokenId}
+  exchange_rates:
+    methods:
+      list:
+        endpoint: get /exchange-rates
+        paginated: false
 
 settings:
   # All generated integration tests that hit the prism mock http server are marked
@@ -326,6 +331,86 @@ openapi:
       args:
         unionPath: AllErrors
         enumProperty: code
+    # ── customerType: IndividualCustomerFields / BusinessCustomerFields ──
+    - command: remove
+      reason: >-
+        Remove inline customerType enums from customer fields schemas to avoid
+        conflicting types when allOf merges them with base schemas (Customer,
+        CustomerCreateRequest, CustomerUpdateRequest) that define customerType
+        via the shared CustomerType $ref
+      args:
+        target:
+          - "$.components.schemas.IndividualCustomerFields.properties"
+          - "$.components.schemas.BusinessCustomerFields.properties"
+        keys: [ "customerType" ]
+
+    # ── accountType: common account info schemas ──
+    - command: remove
+      reason: >-
+        Remove inline accountType enums from common account info schemas to
+        avoid conflicting types when allOf merges them with
+        BaseExternalAccountInfo or BasePaymentAccountInfo, which define
+        accountType via shared $ref enums
+      args:
+        target:
+          - "$.components.schemas.UsAccountInfo.properties"
+          - "$.components.schemas.ClabeAccountInfo.properties"
+          - "$.components.schemas.PixAccountInfo.properties"
+          - "$.components.schemas.IbanAccountInfo.properties"
+          - "$.components.schemas.UpiAccountInfo.properties"
+          - "$.components.schemas.NgnAccountInfo.properties"
+          - "$.components.schemas.CadAccountInfo.properties"
+          - "$.components.schemas.GbpAccountInfo.properties"
+          - "$.components.schemas.PhpAccountInfo.properties"
+          - "$.components.schemas.SgdAccountInfo.properties"
+          - "$.components.schemas.SparkWalletInfo.properties"
+          - "$.components.schemas.LightningInfo.properties"
+          - "$.components.schemas.SolanaWalletInfo.properties"
+          - "$.components.schemas.TronWalletInfo.properties"
+          - "$.components.schemas.PolygonWalletInfo.properties"
+          - "$.components.schemas.BaseWalletInfo.properties"
+        keys: [ "accountType" ]
+
+    # ── sourceType: transaction and quote source schemas ──
+    - command: remove
+      reason: >-
+        Remove inline sourceType enums from transaction and quote source
+        allOf variants to avoid conflicting types with their base schemas
+        which define sourceType via shared $ref enums
+      args:
+        target:
+          - "$.components.schemas.AccountTransactionSource.allOf[1].properties"
+          - "$.components.schemas.UmaAddressTransactionSource.allOf[1].properties"
+          - "$.components.schemas.AccountQuoteSource.allOf[1].properties"
+          - "$.components.schemas.RealtimeFundingQuoteSource.allOf[1].properties"
+        keys: [ "sourceType" ]
+
+    # ── destinationType: transaction and quote destination schemas ──
+    - command: remove
+      reason: >-
+        Remove inline destinationType enums from transaction and quote
+        destination allOf variants to avoid conflicting types with their
+        base schemas which define destinationType via shared $ref enums
+      args:
+        target:
+          - "$.components.schemas.AccountTransactionDestination.allOf[1].properties"
+          - "$.components.schemas.UmaAddressTransactionDestination.allOf[1].properties"
+          - "$.components.schemas.AccountDestination.allOf[1].properties"
+          - "$.components.schemas.UmaAddressDestination.allOf[1].properties"
+          - "$.components.schemas.ExternalAccountDetailsDestination.allOf[1].properties"
+        keys: [ "destinationType" ]
+
+    # ── beneficiaryType: beneficiary schemas ──
+    - command: remove
+      reason: >-
+        Remove inline beneficiaryType enums from beneficiary allOf variants
+        to avoid conflicting types with BaseBeneficiary which defines
+        beneficiaryType via a shared $ref enum
+      args:
+        target:
+          - "$.components.schemas.IndividualBeneficiary.allOf[1].properties"
+          - "$.components.schemas.BusinessBeneficiary.allOf[1].properties"
+        keys: [ "beneficiaryType" ]
 
 errors:
   union:
@@ -339,3 +424,4 @@ diagnostics:
   ignored:
     Schema/ObjectHasNoProperties:
       - pagination.0.response.data.items
+    Schema/EnumHasOneMember: true

--- a/.stainless/workspace.json
+++ b/.stainless/workspace.json
@@ -5,6 +5,9 @@
   "targets": {
     "typescript": {
       "output_path": "../sdks/grid-typescript"
+    },
+    "kotlin": {
+      "output_path": "../sdks/grid-kotlin"
     }
   }
 }

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -38,6 +38,8 @@ tags:
     description: Endpoints to trigger test cases in sandbox
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
+  - name: Exchange Rates
+    description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
 paths:
   /config:
     get:
@@ -140,6 +142,124 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error501'
+  /exchange-rates:
+    get:
+      summary: Get exchange rates
+      description: |
+        Retrieve cached exchange rates for currency corridors. Returns FX rates that are cached
+        for approximately 5 minutes. Rates include fees specific to your platform for authenticated requests.
+
+        **Filtering Options:**
+        - Filter by source currency to get all available destination corridors
+        - Filter by specific destination currency or currencies
+        - Provide a sending amount to get calculated receiving amounts
+      operationId: getExchangeRates
+      tags:
+        - Exchange Rates
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: sourceCurrency
+          in: query
+          description: Filter by source currency code (e.g., USD)
+          required: false
+          schema:
+            type: string
+          example: USD
+        - name: destinationCurrency
+          in: query
+          description: Filter by destination currency code(s). Can be repeated for multiple currencies (e.g., &destinationCurrency=INR&destinationCurrency=GBP)
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example:
+            - INR
+        - name: sendingAmount
+          in: query
+          description: Sending amount in the smallest unit of the source currency (e.g., cents for USD).  If no amount is provided, the default is 10000 in the sending currency smallest unit.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 10000
+          example: 10000
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    description: List of exchange rates matching the filter criteria
+                    items:
+                      $ref: '#/components/schemas/ExchangeRate'
+              examples:
+                allRatesFromUSD:
+                  summary: All exchange rates from USD
+                  value:
+                    data:
+                      - sourceCurrency:
+                          code: USD
+                          decimals: 2
+                          name: US Dollar
+                          symbol: $
+                        sendingAmount: 10000
+                        destinationCurrency:
+                          code: INR
+                          decimals: 2
+                          name: Indian Rupee
+                          symbol: ₹
+                        destinationPaymentRail: UPI
+                        receivingAmount: 825000
+                        exchangeRate: 82.5
+                        fees:
+                          fixed: 100
+                        updatedAt: '2025-02-05T12:00:00Z'
+                      - sourceCurrency:
+                          code: USD
+                          decimals: 2
+                          name: US Dollar
+                          symbol: $
+                        sendingAmount: 10000
+                        destinationCurrency:
+                          code: EUR
+                          decimals: 2
+                          name: Euro
+                          symbol: €
+                        destinationPaymentRail: SEPA_INSTANT
+                        receivingAmount: 18500
+                        exchangeRate: 0.925
+                        fees:
+                          fixed: 10
+                        updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /customers:
     post:
       summary: Add a new customer
@@ -4110,6 +4230,81 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    Currency:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
+        name:
+          type: string
+          description: Full name of the currency
+          example: United States Dollar
+        symbol:
+          type: string
+          description: Symbol of the currency
+          example: $
+        decimals:
+          type: integer
+          description: Number of decimal places for the currency
+          minimum: 0
+          example: 2
+    ExchangeRateFees:
+      type: object
+      description: Fees associated with an exchange rate
+      properties:
+        fixed:
+          type: integer
+          format: int64
+          description: Fixed fee in the smallest unit of the sending currency (e.g., cents for USD)
+          minimum: 0
+          example: 100
+    ExchangeRate:
+      type: object
+      description: Exchange rate information for a currency corridor
+      required:
+        - sourceCurrency
+        - destinationCurrency
+        - destinationPaymentRail
+        - sendingAmount
+        - receivingAmount
+        - exchangeRate
+        - fees
+        - updatedAt
+      properties:
+        sourceCurrency:
+          $ref: '#/components/schemas/Currency'
+        sendingAmount:
+          type: integer
+          format: int64
+          description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
+          minimum: 0
+          example: 10000
+        destinationCurrency:
+          $ref: '#/components/schemas/Currency'
+        destinationPaymentRail:
+          type: string
+          description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+          example: UPI
+        receivingAmount:
+          type: integer
+          format: int64
+          description: The receiving amount in the smallest unit of the destination currency
+          minimum: 0
+          example: 1650000
+        exchangeRate:
+          type: number
+          description: Number of sending currency units per receiving currency unit.
+          exclusiveMinimum: 0
+          example: 82.5
+        fees:
+          $ref: '#/components/schemas/ExchangeRateFees'
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when this exchange rate was last refreshed
+          example: '2025-02-05T12:00:00Z'
     CustomerType:
       type: string
       enum:
@@ -4534,26 +4729,6 @@ components:
         mapping:
           INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdateRequest'
           BUSINESS: '#/components/schemas/BusinessCustomerUpdateRequest'
-    Currency:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-          example: USD
-        name:
-          type: string
-          description: Full name of the currency
-          example: United States Dollar
-        symbol:
-          type: string
-          description: Symbol of the currency
-          example: $
-        decimals:
-          type: integer
-          description: Number of decimal places for the currency
-          minimum: 0
-          example: 2
     CurrencyAmount:
       type: object
       required:
@@ -4808,6 +4983,10 @@ components:
           required:
             - invoice
           properties:
+            accountType:
+              type: string
+              enum:
+                - LIGHTNING
             invoice:
               type: string
               description: Invoice for the payment
@@ -5373,31 +5552,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletInfo'
+    LightningInfo:
+      type: object
+      description: |
+        Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+      required:
+        - accountType
+      properties:
+        accountType:
+          type: string
+          enum:
+            - LIGHTNING
+        invoice:
+          type: string
+          description: 1-time use lightning bolt11 invoice payout destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        bolt12:
+          type: string
+          description: A bolt12 offer which can be reused as a payment destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        lightningAddress:
+          type: string
+          description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+          example: john.doe@lightningwallet.com
     LightningExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
-        - type: object
-          description: |
-            Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
-          required:
-            - accountType
-          properties:
-            accountType:
-              type: string
-              enum:
-                - LIGHTNING
-            invoice:
-              type: string
-              description: 1-time use lightning bolt11 invoice payout destination
-              example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            bolt12:
-              type: string
-              description: A bolt12 offer which can be reused as a payment destination
-              example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            lightningAddress:
-              type: string
-              description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-              example: john.doe@lightningwallet.com
+        - $ref: '#/components/schemas/LightningInfo'
     SolanaWalletExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,8 @@ tags:
     description: Endpoints to trigger test cases in sandbox
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
+  - name: Exchange Rates
+    description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
 paths:
   /config:
     get:
@@ -140,6 +142,124 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error501'
+  /exchange-rates:
+    get:
+      summary: Get exchange rates
+      description: |
+        Retrieve cached exchange rates for currency corridors. Returns FX rates that are cached
+        for approximately 5 minutes. Rates include fees specific to your platform for authenticated requests.
+
+        **Filtering Options:**
+        - Filter by source currency to get all available destination corridors
+        - Filter by specific destination currency or currencies
+        - Provide a sending amount to get calculated receiving amounts
+      operationId: getExchangeRates
+      tags:
+        - Exchange Rates
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: sourceCurrency
+          in: query
+          description: Filter by source currency code (e.g., USD)
+          required: false
+          schema:
+            type: string
+          example: USD
+        - name: destinationCurrency
+          in: query
+          description: Filter by destination currency code(s). Can be repeated for multiple currencies (e.g., &destinationCurrency=INR&destinationCurrency=GBP)
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          example:
+            - INR
+        - name: sendingAmount
+          in: query
+          description: Sending amount in the smallest unit of the source currency (e.g., cents for USD).  If no amount is provided, the default is 10000 in the sending currency smallest unit.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 10000
+          example: 10000
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    description: List of exchange rates matching the filter criteria
+                    items:
+                      $ref: '#/components/schemas/ExchangeRate'
+              examples:
+                allRatesFromUSD:
+                  summary: All exchange rates from USD
+                  value:
+                    data:
+                      - sourceCurrency:
+                          code: USD
+                          decimals: 2
+                          name: US Dollar
+                          symbol: $
+                        sendingAmount: 10000
+                        destinationCurrency:
+                          code: INR
+                          decimals: 2
+                          name: Indian Rupee
+                          symbol: ₹
+                        destinationPaymentRail: UPI
+                        receivingAmount: 825000
+                        exchangeRate: 82.5
+                        fees:
+                          fixed: 100
+                        updatedAt: '2025-02-05T12:00:00Z'
+                      - sourceCurrency:
+                          code: USD
+                          decimals: 2
+                          name: US Dollar
+                          symbol: $
+                        sendingAmount: 10000
+                        destinationCurrency:
+                          code: EUR
+                          decimals: 2
+                          name: Euro
+                          symbol: €
+                        destinationPaymentRail: SEPA_INSTANT
+                        receivingAmount: 18500
+                        exchangeRate: 0.925
+                        fees:
+                          fixed: 10
+                        updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /customers:
     post:
       summary: Add a new customer
@@ -4110,6 +4230,81 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    Currency:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
+        name:
+          type: string
+          description: Full name of the currency
+          example: United States Dollar
+        symbol:
+          type: string
+          description: Symbol of the currency
+          example: $
+        decimals:
+          type: integer
+          description: Number of decimal places for the currency
+          minimum: 0
+          example: 2
+    ExchangeRateFees:
+      type: object
+      description: Fees associated with an exchange rate
+      properties:
+        fixed:
+          type: integer
+          format: int64
+          description: Fixed fee in the smallest unit of the sending currency (e.g., cents for USD)
+          minimum: 0
+          example: 100
+    ExchangeRate:
+      type: object
+      description: Exchange rate information for a currency corridor
+      required:
+        - sourceCurrency
+        - destinationCurrency
+        - destinationPaymentRail
+        - sendingAmount
+        - receivingAmount
+        - exchangeRate
+        - fees
+        - updatedAt
+      properties:
+        sourceCurrency:
+          $ref: '#/components/schemas/Currency'
+        sendingAmount:
+          type: integer
+          format: int64
+          description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
+          minimum: 0
+          example: 10000
+        destinationCurrency:
+          $ref: '#/components/schemas/Currency'
+        destinationPaymentRail:
+          type: string
+          description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+          example: UPI
+        receivingAmount:
+          type: integer
+          format: int64
+          description: The receiving amount in the smallest unit of the destination currency
+          minimum: 0
+          example: 1650000
+        exchangeRate:
+          type: number
+          description: Number of sending currency units per receiving currency unit.
+          exclusiveMinimum: 0
+          example: 82.5
+        fees:
+          $ref: '#/components/schemas/ExchangeRateFees'
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when this exchange rate was last refreshed
+          example: '2025-02-05T12:00:00Z'
     CustomerType:
       type: string
       enum:
@@ -4534,26 +4729,6 @@ components:
         mapping:
           INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdateRequest'
           BUSINESS: '#/components/schemas/BusinessCustomerUpdateRequest'
-    Currency:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-          example: USD
-        name:
-          type: string
-          description: Full name of the currency
-          example: United States Dollar
-        symbol:
-          type: string
-          description: Symbol of the currency
-          example: $
-        decimals:
-          type: integer
-          description: Number of decimal places for the currency
-          minimum: 0
-          example: 2
     CurrencyAmount:
       type: object
       required:
@@ -4808,6 +4983,10 @@ components:
           required:
             - invoice
           properties:
+            accountType:
+              type: string
+              enum:
+                - LIGHTNING
             invoice:
               type: string
               description: Invoice for the payment
@@ -5373,31 +5552,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletInfo'
+    LightningInfo:
+      type: object
+      description: |
+        Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+      required:
+        - accountType
+      properties:
+        accountType:
+          type: string
+          enum:
+            - LIGHTNING
+        invoice:
+          type: string
+          description: 1-time use lightning bolt11 invoice payout destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        bolt12:
+          type: string
+          description: A bolt12 offer which can be reused as a payment destination
+          example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+        lightningAddress:
+          type: string
+          description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+          example: john.doe@lightningwallet.com
     LightningExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
-        - type: object
-          description: |
-            Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
-          required:
-            - accountType
-          properties:
-            accountType:
-              type: string
-              enum:
-                - LIGHTNING
-            invoice:
-              type: string
-              description: 1-time use lightning bolt11 invoice payout destination
-              example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            bolt12:
-              type: string
-              description: A bolt12 offer which can be reused as a payment destination
-              example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-            lightningAddress:
-              type: string
-              description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-              example: john.doe@lightningwallet.com
+        - $ref: '#/components/schemas/LightningInfo'
     SolanaWalletExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'

--- a/openapi/components/schemas/common/LightningInfo.yaml
+++ b/openapi/components/schemas/common/LightningInfo.yaml
@@ -1,0 +1,22 @@
+type: object
+description: >
+  Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
+required:
+  - accountType
+properties:
+  accountType:
+    type: string
+    enum:
+      - LIGHTNING
+  invoice:
+    type: string
+    description: 1-time use lightning bolt11 invoice payout destination
+    example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+  bolt12:
+    type: string
+    description: A bolt12 offer which can be reused as a payment destination
+    example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
+  lightningAddress:
+    type: string
+    description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
+    example: john.doe@lightningwallet.com

--- a/openapi/components/schemas/common/PaymentLightningInvoiceInfo.yaml
+++ b/openapi/components/schemas/common/PaymentLightningInvoiceInfo.yaml
@@ -4,6 +4,10 @@ allOf:
     required:
       - invoice
     properties:
+      accountType:
+        type: string
+        enum:
+          - LIGHTNING
       invoice:
         type: string
         description: Invoice for the payment

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -1,0 +1,44 @@
+type: object
+description: Exchange rate information for a currency corridor
+required:
+  - sourceCurrency
+  - destinationCurrency
+  - destinationPaymentRail
+  - sendingAmount
+  - receivingAmount
+  - exchangeRate
+  - fees
+  - updatedAt
+properties:
+  sourceCurrency:
+    $ref: ../common/Currency.yaml
+  sendingAmount:
+    type: integer
+    format: int64
+    description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
+    minimum: 0
+    example: 10000
+  destinationCurrency:
+    $ref: ../common/Currency.yaml
+  destinationPaymentRail:
+    type: string
+    description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+    example: UPI
+  receivingAmount:
+    type: integer
+    format: int64
+    description: The receiving amount in the smallest unit of the destination currency
+    minimum: 0
+    example: 1650000
+  exchangeRate:
+    type: number
+    description: Number of sending currency units per receiving currency unit.
+    exclusiveMinimum: 0
+    example: 82.50
+  fees:
+    $ref: ./ExchangeRateFees.yaml
+  updatedAt:
+    type: string
+    format: date-time
+    description: Timestamp when this exchange rate was last refreshed
+    example: "2025-02-05T12:00:00Z"

--- a/openapi/components/schemas/exchange_rates/ExchangeRateFees.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRateFees.yaml
@@ -1,0 +1,9 @@
+type: object
+description: Fees associated with an exchange rate
+properties:
+  fixed:
+    type: integer
+    format: int64
+    description: Fixed fee in the smallest unit of the sending currency (e.g., cents for USD)
+    minimum: 0
+    example: 100

--- a/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/LightningExternalAccountInfo.yaml
@@ -1,24 +1,3 @@
 allOf:
   - $ref: ./BaseExternalAccountInfo.yaml
-  - type: object
-    description: >
-      Lightning payment destination. Exactly one of `invoice`, `bolt12`, or `lightningAddress` must be provided.
-    required:
-      - accountType
-    properties:
-      accountType:
-        type: string
-        enum:
-          - LIGHTNING
-      invoice:
-        type: string
-        description: 1-time use lightning bolt11 invoice payout destination
-        example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-      bolt12:
-        type: string
-        description: A bolt12 offer which can be reused as a payment destination
-        example: lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs
-      lightningAddress:
-        type: string
-        description: A lightning address which can be used as a payment destination. Note that for UMA addresses, no external account is needed. You can use the UMA address directly as a destination.
-        example: john.doe@lightningwallet.com
+  - $ref: ../common/LightningInfo.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -35,6 +35,10 @@ tags:
     description: Endpoints to trigger test cases in sandbox
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
+  - name: Exchange Rates
+    description: >-
+      Endpoints for retrieving cached foreign exchange rates. Rates are cached
+      for approximately 5 minutes and include platform-specific fees.
 servers:
   - url: https://api.lightspark.com/grid/2025-10-13
     description: Production server
@@ -84,6 +88,8 @@ components:
 paths:
   /config:
     $ref: paths/platform/config.yaml
+  /exchange-rates:
+    $ref: paths/exchange-rates/exchange_rates.yaml
   /customers:
     $ref: paths/customers/customers.yaml
   /customers/{customerId}:

--- a/openapi/paths/exchange-rates/exchange_rates.yaml
+++ b/openapi/paths/exchange-rates/exchange_rates.yaml
@@ -1,0 +1,120 @@
+get:
+  summary: Get exchange rates
+  description: |
+    Retrieve cached exchange rates for currency corridors. Returns FX rates that are cached
+    for approximately 5 minutes. Rates include fees specific to your platform for authenticated requests.
+
+    **Filtering Options:**
+    - Filter by source currency to get all available destination corridors
+    - Filter by specific destination currency or currencies
+    - Provide a sending amount to get calculated receiving amounts
+
+  operationId: getExchangeRates
+  tags:
+    - Exchange Rates
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: sourceCurrency
+      in: query
+      description: Filter by source currency code (e.g., USD)
+      required: false
+      schema:
+        type: string
+      example: USD
+    - name: destinationCurrency
+      in: query
+      description: >-
+        Filter by destination currency code(s). Can be repeated for multiple currencies
+        (e.g., &destinationCurrency=INR&destinationCurrency=GBP)
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+      example:
+        - INR
+    - name: sendingAmount
+      in: query
+      description: Sending amount in the smallest unit of the source currency (e.g., cents for USD).  If no amount is provided, the default is 10000 in the sending currency smallest unit.
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 0
+        default: 10000
+      example: 10000
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                description: List of exchange rates matching the filter criteria
+                items:
+                  $ref: ../../components/schemas/exchange_rates/ExchangeRate.yaml
+          examples:
+            allRatesFromUSD:
+              summary: All exchange rates from USD
+              value:
+                data:
+                  - sourceCurrency:
+                      code: USD
+                      decimals: 2
+                      name: US Dollar
+                      symbol: "$"
+                    sendingAmount: 10000
+                    destinationCurrency:
+                      code: INR
+                      decimals: 2
+                      name: Indian Rupee
+                      symbol: "₹"
+                    destinationPaymentRail: UPI
+                    receivingAmount: 825000
+                    exchangeRate: 82.50
+                    fees:
+                      fixed: 100
+                    updatedAt: "2025-02-05T12:00:00Z"
+                  - sourceCurrency:
+                      code: USD
+                      decimals: 2
+                      name: US Dollar
+                      symbol: "$"
+                    sendingAmount: 10000
+                    destinationCurrency:
+                      code: EUR
+                      decimals: 2
+                      name: Euro
+                      symbol: "€"
+                    destinationPaymentRail: SEPA_INSTANT
+                    receivingAmount: 18500
+                    exchangeRate: 0.925
+                    fees:
+                      fixed: 10
+                    updatedAt: "2025-02-05T12:00:00Z"
+    "400":
+      description: Bad request - Invalid parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    "500":
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
### TL;DR

Added new Exchange Rates API endpoint to retrieve cached foreign exchange rates with platform-specific fees.

### What changed?

- Added a new `/exchange-rates` endpoint that provides cached FX rates
- Created new tag "Exchange Rates" in the OpenAPI specification
- Added new schemas for exchange rate data:
  - `ExchangeRate` - Contains source/destination currency details, payment rails, amounts, rates, and fees
  - `ExchangeRateFees` - Defines fee structure for exchange rates
- Moved the `Currency` schema definition to avoid duplication
- Added query parameters for filtering:
  - `sourceCurrency` (required)
  - `destinationCurrency` (optional, can specify multiple)
  - `sendingAmount` (optional)

GET request to `/exchange-rates` with the required `sourceCurrency` parameter:

```
GET /exchange-rates?sourceCurrency=USD
```

Optional parameters:
- Filter by specific destination currencies: `&destinationCurrency=INR&destinationCurrency=GBP`
- Specify sending amount: `&sendingAmount=20000`