### PR TITLE
feat: adding google tag to docs

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -308,5 +308,10 @@
       { "rel": "stylesheet", "href": "/styles/fonts.css" },
       { "rel": "stylesheet", "href": "/styles/styles.css" }
     ]
+  },
+  "integrations": {
+    "gtm": {
+        "tagId": "GTM-5R5NP3DS"
+    }
   }
 }

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -311,7 +311,7 @@
   },
   "integrations": {
     "gtm": {
-        "tagId": "GTM-5R5NP3DS"
+      "tagId": "GTM-5R5NP3DS"
     }
   }
 }


### PR DESCRIPTION
### TL;DR

Added Google Tag Manager integration to the Mintlify documentation site.

### What changed?

Added a new `integrations` section to the `docs.json` configuration file with Google Tag Manager (GTM) configuration, specifying the tag ID `GTM-5R5NP3DS`.

### How to test?

1. Build and deploy the documentation site
2. Open browser developer tools and check the Network tab
3. Verify that GTM scripts are loading with the specified tag ID
4. Confirm in the Google Tag Manager dashboard that events are being tracked

