### PR TITLE
feat: adding external account verification to UPI accounts

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -8,7 +8,7 @@ edition: 2025-10-10
 organization:
   # Name of your organization or company, used to determine the name of the client
   # and headings.
-  name: grid
+  name: Lightspark Grid
   # Link to your API documentation.
   docs: 'grid.lightspark.com'
   # Contact email for bug reports, questions, and support requests.
@@ -22,14 +22,14 @@ targets:
     #
     # [docs]: https://www.stainless.com/docs/reference/editions
     edition: typescript.2025-10-10
-    package_name: grid
-    production_repo: null
+    package_name: lightspark-grid
+    production_repo: lightsparkdev/grid-js-sdk
     publish:
       npm: false
   kotlin:
     edition: kotlin.2025-10-08
-    reverse_domain: com.grid.api
-    production_repo: null
+    reverse_domain: com.lightspark.grid
+    production_repo: lightsparkdev/grid-kotlin-sdk
     publish:
       maven: false
 
@@ -65,15 +65,15 @@ resources:
 
   customers:
     models:
-      customer_type: '#/components/schemas/CustomerType'
-      individual_customer: '#/components/schemas/IndividualCustomer'
+      # customer_type: '#/components/schemas/CustomerType'
+      # individual_customer: '#/components/schemas/IndividualCustomer'
       customer: '#/components/schemas/Customer'
-      address: '#/components/schemas/Address'
-      ultimate_beneficial_owner: '#/components/schemas/UltimateBeneficialOwner'
-      business_customer: '#/components/schemas/BusinessCustomer'
-      business_customer_fields: "#/components/schemas/BusinessCustomerFields"
-      business_info: "#/components/schemas/BusinessInfo"
-      individual_customer_fields: "#/components/schemas/IndividualCustomerFields"
+      # address: '#/components/schemas/Address'
+      # ultimate_beneficial_owner: '#/components/schemas/UltimateBeneficialOwner'
+      # business_customer: '#/components/schemas/BusinessCustomer'
+      # business_customer_fields: "#/components/schemas/BusinessCustomerFields"
+      # business_info: "#/components/schemas/BusinessInfo"
+      # individual_customer_fields: "#/components/schemas/IndividualCustomerFields"
       customer_one_of: "#/components/schemas/CustomerOneOf"
       customer_create: "#/components/schemas/CustomerCreateRequest"
       customer_update: "#/components/schemas/CustomerUpdateRequest"
@@ -94,24 +94,28 @@ resources:
     subresources:
       external_accounts:
         models:
-          us_account_info: '#/components/schemas/UsAccountInfo'
-          pix_account_info: '#/components/schemas/PixAccountInfo'
-          iban_account_info: '#/components/schemas/IbanAccountInfo'
-          upi_account_info: '#/components/schemas/UpiAccountInfo'
-          spark_wallet_info: '#/components/schemas/SparkWalletInfo'
-          solana_wallet_info: '#/components/schemas/SolanaWalletInfo'
-          tron_wallet_info: '#/components/schemas/TronWalletInfo'
-          polygon_wallet_info: '#/components/schemas/PolygonWalletInfo'
-          clabe_account_info: '#/components/schemas/ClabeAccountInfo'
-          base_wallet_info: '#/components/schemas/BaseWalletInfo'
-          individual_beneficiary: '#/components/schemas/IndividualBeneficiary'
-          business_beneficiary: '#/components/schemas/BusinessBeneficiary'
+          us_account_info: '#/components/schemas/UsAccountExternalAccountInfo'
+          clabe_account_info: '#/components/schemas/ClabeAccountExternalAccountInfo'
+          pix_account_info: '#/components/schemas/PixAccountExternalAccountInfo'
+          iban_account_info: '#/components/schemas/IbanAccountExternalAccountInfo'
+          upi_account_info: '#/components/schemas/UpiAccountExternalAccountInfo'
+          ngn_account_info: '#/components/schemas/NgnAccountExternalAccountInfo'
+          cad_account_info: '#/components/schemas/CadAccountExternalAccountInfo'
+          gbp_account_info: '#/components/schemas/GbpAccountExternalAccountInfo'
+          php_account_info: '#/components/schemas/PhpAccountExternalAccountInfo'
+          sgd_account_info: '#/components/schemas/SgdAccountExternalAccountInfo'
+          spark_wallet_info: '#/components/schemas/SparkWalletExternalAccountInfo'
+          solana_wallet_info: '#/components/schemas/SolanaWalletExternalAccountInfo'
+          tron_wallet_info: '#/components/schemas/TronWalletExternalAccountInfo'
+          polygon_wallet_info: '#/components/schemas/PolygonWalletExternalAccountInfo'
+          lightning_wallet_info: '#/components/schemas/LightningExternalAccountInfo'
+          base_wallet_info: '#/components/schemas/BaseWalletExternalAccountInfo'
+          # individual_beneficiary: '#/components/schemas/IndividualBeneficiary'
+          # business_beneficiary: '#/components/schemas/BusinessBeneficiary'
           external_account: '#/components/schemas/ExternalAccount'
           external_account_create: '#/components/schemas/ExternalAccountCreateRequest'
-          lightning_external_account_info: "#/components/schemas/LightningExternalAccountInfo"
-          ngn_account_external_account_info: "#/components/schemas/NgnAccountExternalAccountInfo"
-          base_external_account_info: "#/components/schemas/BaseExternalAccountInfo"
-          base_beneficiary: "#/components/schemas/BaseBeneficiary"
+          # base_external_account_info: "#/components/schemas/BaseExternalAccountInfo"
+          # base_beneficiary: "#/components/schemas/BaseBeneficiary"
           beneficiary_one_of: "#/components/schemas/BeneficiaryOneOf"
           external_account_info_one_of: "#/components/schemas/ExternalAccountInfoOneOf"
         methods:
@@ -288,11 +292,11 @@ readme:
   example_requests:
     default:
       type: request
-      endpoint: get /config
+      endpoint: post /quotes
       params: {}
     headline:
       type: request
-      endpoint: get /config
+      endpoint: post /quotes
       params: {}
     pagination:
       type: request
@@ -331,87 +335,188 @@ openapi:
       args:
         unionPath: AllErrors
         enumProperty: code
-    # ── customerType: IndividualCustomerFields / BusinessCustomerFields ──
+
+    # # ── customerType: IndividualCustomerFields / BusinessCustomerFields ──
+    # - command: remove
+    #   reason: >-
+    #     Remove inline customerType enums from customer fields schemas to avoid
+    #     conflicting types when allOf merges them with base schemas (Customer,
+    #     CustomerCreateRequest, CustomerUpdateRequest) that define customerType
+    #     via the shared CustomerType $ref
+    #   args:
+    #     target:
+    #       - "$.components.schemas.IndividualCustomerFields.properties"
+    #       - "$.components.schemas.BusinessCustomerFields.properties"
+    #     keys: [ "customerType" ]
+
+    # # ── accountType: common account info schemas ──
+    # - command: remove
+    #   reason: >-
+    #     Remove inline accountType enums from common account info schemas to
+    #     avoid conflicting types when allOf merges them with
+    #     BaseExternalAccountInfo or BasePaymentAccountInfo, which define
+    #     accountType via shared $ref enums
+    #   args:
+    #     target:
+    #       - "$.components.schemas.UsAccountInfo.properties"
+    #       - "$.components.schemas.ClabeAccountInfo.properties"
+    #       - "$.components.schemas.PixAccountInfo.properties"
+    #       - "$.components.schemas.IbanAccountInfo.properties"
+    #       - "$.components.schemas.UpiAccountInfo.properties"
+    #       - "$.components.schemas.NgnAccountInfo.properties"
+    #       - "$.components.schemas.CadAccountInfo.properties"
+    #       - "$.components.schemas.GbpAccountInfo.properties"
+    #       - "$.components.schemas.PhpAccountInfo.properties"
+    #       - "$.components.schemas.SgdAccountInfo.properties"
+    #       - "$.components.schemas.SparkWalletInfo.properties"
+    #       - "$.components.schemas.LightningInfo.properties"
+    #       - "$.components.schemas.SolanaWalletInfo.properties"
+    #       - "$.components.schemas.TronWalletInfo.properties"
+    #       - "$.components.schemas.PolygonWalletInfo.properties"
+    #       - "$.components.schemas.BaseWalletInfo.properties"
+    #     keys: [ "accountType" ]
+
+    # # ── sourceType: transaction and quote source schemas ──
+    # - command: remove
+    #   reason: >-
+    #     Remove inline sourceType enums from transaction and quote source
+    #     allOf variants to avoid conflicting types with their base schemas
+    #     which define sourceType via shared $ref enums
+    #   args:
+    #     target:
+    #       - "$.components.schemas.AccountTransactionSource.allOf[1].properties"
+    #       - "$.components.schemas.UmaAddressTransactionSource.allOf[1].properties"
+    #       - "$.components.schemas.AccountQuoteSource.allOf[1].properties"
+    #       - "$.components.schemas.RealtimeFundingQuoteSource.allOf[1].properties"
+    #     keys: [ "sourceType" ]
+
+    # # ── destinationType: transaction and quote destination schemas ──
+    # - command: remove
+    #   reason: >-
+    #     Remove inline destinationType enums from transaction and quote
+    #     destination allOf variants to avoid conflicting types with their
+    #     base schemas which define destinationType via shared $ref enums
+    #   args:
+    #     target:
+    #       - "$.components.schemas.AccountTransactionDestination.allOf[1].properties"
+    #       - "$.components.schemas.UmaAddressTransactionDestination.allOf[1].properties"
+    #       - "$.components.schemas.AccountDestination.allOf[1].properties"
+    #       - "$.components.schemas.UmaAddressDestination.allOf[1].properties"
+    #       - "$.components.schemas.ExternalAccountDetailsDestination.allOf[1].properties"
+    #     keys: [ "destinationType" ]
+
+    # # ── beneficiaryType: beneficiary schemas ──
+    # - command: remove
+    #   reason: >-
+    #     Remove inline beneficiaryType enums from beneficiary allOf variants
+    #     to avoid conflicting types with BaseBeneficiary which defines
+    #     beneficiaryType via a shared $ref enum
+    #   args:
+    #     target:
+    #       - "$.components.schemas.IndividualBeneficiary.allOf[1].properties"
+    #       - "$.components.schemas.BusinessBeneficiary.allOf[1].properties"
+    #     keys: [ "beneficiaryType" ]
+    # ── customerType: remove from base schemas ──
     - command: remove
       reason: >-
-        Remove inline customerType enums from customer fields schemas to avoid
-        conflicting types when allOf merges them with base schemas (Customer,
-        CustomerCreateRequest, CustomerUpdateRequest) that define customerType
-        via the shared CustomerType $ref
+        Remove customerType $ref from base schemas so the inline single-value
+        enums in IndividualCustomerFields/BusinessCustomerFields become the
+        sole definition, avoiding allOf type conflicts
       args:
         target:
-          - "$.components.schemas.IndividualCustomerFields.properties"
-          - "$.components.schemas.BusinessCustomerFields.properties"
+          - "$.components.schemas.Customer.properties"
+          - "$.components.schemas.CustomerCreateRequest.properties"
+          - "$.components.schemas.CustomerUpdateRequest.properties"
         keys: [ "customerType" ]
 
-    # ── accountType: common account info schemas ──
+    # ── accountType: remove from base schemas ──
     - command: remove
       reason: >-
-        Remove inline accountType enums from common account info schemas to
-        avoid conflicting types when allOf merges them with
-        BaseExternalAccountInfo or BasePaymentAccountInfo, which define
-        accountType via shared $ref enums
+        Remove accountType $ref from base schemas so the inline single-value
+        enums in each account info variant become the sole definition,
+        enabling structural matching to distinguish them
       args:
         target:
-          - "$.components.schemas.UsAccountInfo.properties"
-          - "$.components.schemas.ClabeAccountInfo.properties"
-          - "$.components.schemas.PixAccountInfo.properties"
-          - "$.components.schemas.IbanAccountInfo.properties"
-          - "$.components.schemas.UpiAccountInfo.properties"
-          - "$.components.schemas.NgnAccountInfo.properties"
-          - "$.components.schemas.CadAccountInfo.properties"
-          - "$.components.schemas.GbpAccountInfo.properties"
-          - "$.components.schemas.PhpAccountInfo.properties"
-          - "$.components.schemas.SgdAccountInfo.properties"
-          - "$.components.schemas.SparkWalletInfo.properties"
-          - "$.components.schemas.LightningInfo.properties"
-          - "$.components.schemas.SolanaWalletInfo.properties"
-          - "$.components.schemas.TronWalletInfo.properties"
-          - "$.components.schemas.PolygonWalletInfo.properties"
-          - "$.components.schemas.BaseWalletInfo.properties"
+          - "$.components.schemas.BaseExternalAccountInfo.properties"
+          - "$.components.schemas.BasePaymentAccountInfo.properties"
         keys: [ "accountType" ]
 
-    # ── sourceType: transaction and quote source schemas ──
+    # ── sourceType: remove from base schemas ──
     - command: remove
       reason: >-
-        Remove inline sourceType enums from transaction and quote source
-        allOf variants to avoid conflicting types with their base schemas
-        which define sourceType via shared $ref enums
+        Remove sourceType $ref from base schemas so the inline single-value
+        enums in each source variant become the sole definition
       args:
         target:
-          - "$.components.schemas.AccountTransactionSource.allOf[1].properties"
-          - "$.components.schemas.UmaAddressTransactionSource.allOf[1].properties"
-          - "$.components.schemas.AccountQuoteSource.allOf[1].properties"
-          - "$.components.schemas.RealtimeFundingQuoteSource.allOf[1].properties"
+          - "$.components.schemas.BaseTransactionSource.properties"
+          - "$.components.schemas.BaseQuoteSource.properties"
         keys: [ "sourceType" ]
 
-    # ── destinationType: transaction and quote destination schemas ──
+    # ── destinationType: remove from base schemas ──
     - command: remove
       reason: >-
-        Remove inline destinationType enums from transaction and quote
-        destination allOf variants to avoid conflicting types with their
-        base schemas which define destinationType via shared $ref enums
+        Remove destinationType $ref from base schemas so the inline
+        single-value enums in each destination variant become the sole definition
       args:
         target:
-          - "$.components.schemas.AccountTransactionDestination.allOf[1].properties"
-          - "$.components.schemas.UmaAddressTransactionDestination.allOf[1].properties"
-          - "$.components.schemas.AccountDestination.allOf[1].properties"
-          - "$.components.schemas.UmaAddressDestination.allOf[1].properties"
-          - "$.components.schemas.ExternalAccountDetailsDestination.allOf[1].properties"
+          - "$.components.schemas.BaseTransactionDestination.properties"
+          - "$.components.schemas.BaseDestination.properties"
         keys: [ "destinationType" ]
 
-    # ── beneficiaryType: beneficiary schemas ──
+    # ── Remove $ref to BasePaymentAccountInfo from payment account variants ──
     - command: remove
       reason: >-
-        Remove inline beneficiaryType enums from beneficiary allOf variants
-        to avoid conflicting types with BaseBeneficiary which defines
-        beneficiaryType via a shared $ref enum
+        Remove allOf $ref to BasePaymentAccountInfo from payment account variants
+        because the base schema becomes an empty object (no properties) after
+        stripping the accountType discriminator, which causes TS2312 errors
       args:
         target:
-          - "$.components.schemas.IndividualBeneficiary.allOf[1].properties"
-          - "$.components.schemas.BusinessBeneficiary.allOf[1].properties"
-        keys: [ "beneficiaryType" ]
+          - "$.components.schemas.PaymentClabeAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentUsAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentPixAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentIbanAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentUpiAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentNgnAccountInfo.allOf[0]"
+          - "$.components.schemas.PaymentSparkWalletInfo.allOf[0]"
+          - "$.components.schemas.PaymentLightningInvoiceInfo.allOf[0]"
+          - "$.components.schemas.PaymentSolanaWalletInfo.allOf[0]"
+          - "$.components.schemas.PaymentTronWalletInfo.allOf[0]"
+          - "$.components.schemas.PaymentPolygonWalletInfo.allOf[0]"
+          - "$.components.schemas.PaymentBaseWalletInfo.allOf[0]"
+        keys: [ "$ref" ]
 
+    # ── Remove $ref to BaseQuoteSource from quote source variants ──
+    - command: remove
+      reason: >-
+        Remove allOf $ref to BaseQuoteSource from quote source variants
+        because the base schema becomes an empty object after stripping sourceType
+      args:
+        target:
+          - "$.components.schemas.AccountQuoteSource.allOf[0]"
+          - "$.components.schemas.RealtimeFundingQuoteSource.allOf[0]"
+        keys: [ "$ref" ]
+
+    # ── Remove $ref to BaseDestination from destination variants ──
+    - command: remove
+      reason: >-
+        Remove allOf $ref to BaseDestination from destination variants
+        because the base schema becomes an empty object after stripping destinationType
+      args:
+        target:
+          - "$.components.schemas.AccountDestination.allOf[0]"
+          - "$.components.schemas.UmaAddressDestination.allOf[0]"
+          - "$.components.schemas.ExternalAccountDetailsDestination.allOf[0]"
+        keys: [ "$ref" ]
+
+    # ── beneficiaryType: remove from base schema ──
+    - command: remove
+      reason: >-
+        Remove beneficiaryType $ref from base schema so the inline
+        single-value enums in each beneficiary variant become the sole definition
+      args:
+        target:
+          - "$.components.schemas.BaseBeneficiary.properties"
+        keys: [ "beneficiaryType" ]
 errors:
   union:
     source: AllErrors
@@ -425,3 +530,4 @@ diagnostics:
     Schema/ObjectHasNoProperties:
       - pagination.0.response.data.items
     Schema/EnumHasOneMember: true
+    Schema/RequiredPropertyNotDefined: true

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -39,7 +39,7 @@ tags:
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
   - name: Exchange Rates
-    description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
+    description: Endpoints for retrieving exchange rates.
 paths:
   /config:
     get:
@@ -5376,6 +5376,14 @@ components:
           required:
             - beneficiary
           properties:
+            beneficiaryNameVerificationStatus:
+              description: The result of verifying the beneficiary name provided at resource creation against the name on the account. `MATCHED` indicates an exact match, `PARTIALLY_MATCHED` indicates a fuzzy match, and `NO_MATCH` indicates the name failed the fuzzy match.
+              type: string
+              enum:
+                - MATCHED
+                - PARTIALLY_MATCHED
+                - NO_MATCH
+              example: MATCHED
             beneficiary:
               $ref: '#/components/schemas/BeneficiaryOneOf'
     NgnAccountExternalAccountInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,7 +39,7 @@ tags:
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
   - name: Exchange Rates
-    description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
+    description: Endpoints for retrieving exchange rates.
 paths:
   /config:
     get:
@@ -5376,6 +5376,14 @@ components:
           required:
             - beneficiary
           properties:
+            beneficiaryNameVerificationStatus:
+              description: The result of verifying the beneficiary name provided at resource creation against the name on the account. `MATCHED` indicates an exact match, `PARTIALLY_MATCHED` indicates a fuzzy match, and `NO_MATCH` indicates the name failed the fuzzy match.
+              type: string
+              enum:
+                - MATCHED
+                - PARTIALLY_MATCHED
+                - NO_MATCH
+              example: MATCHED
             beneficiary:
               $ref: '#/components/schemas/BeneficiaryOneOf'
     NgnAccountExternalAccountInfo:

--- a/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UpiAccountExternalAccountInfo.yaml
@@ -5,5 +5,16 @@ allOf:
     required:
       - beneficiary
     properties:
+      beneficiaryNameVerificationStatus:
+        description: >-
+          The result of verifying the beneficiary name provided at resource creation against the
+          name on the account. `MATCHED` indicates an exact match, `PARTIALLY_MATCHED` indicates
+          a fuzzy match, and `NO_MATCH` indicates the name failed the fuzzy match.
+        type: string
+        enum:
+          - MATCHED
+          - PARTIALLY_MATCHED
+          - NO_MATCH
+        example: MATCHED
       beneficiary:
         $ref: ./BeneficiaryOneOf.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -36,9 +36,7 @@ tags:
   - name: API Tokens
     description: Endpoints to programmatically manage API tokens
   - name: Exchange Rates
-    description: >-
-      Endpoints for retrieving cached foreign exchange rates. Rates are cached
-      for approximately 5 minutes and include platform-specific fees.
+    description: Endpoints for retrieving exchange rates.
 servers:
   - url: https://api.lightspark.com/grid/2025-10-13
     description: Production server


### PR DESCRIPTION
### TL;DR

Updated Stainless configuration for Lightspark Grid SDK, fixing type conflicts and adding beneficiary name verification status.

### What changed?

- Renamed organization from "grid" to "Lightspark Grid"
- Updated package names and production repositories for TypeScript and Kotlin SDKs
- Simplified schema handling by removing redundant model references
- Fixed type conflicts by removing discriminator properties from base schemas
- Added `beneficiaryNameVerificationStatus` field to UPI account external account info
- Updated Exchange Rates description to be more concise
- Adjusted example requests to use `/quotes` endpoint instead of `/config`

