### PR TITLE
fix: use font-display swap to prevent text FOUC during navigation

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -8,7 +8,7 @@
   src: url("/fonts/suisse-intl/SuisseIntl-Regular.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
   ascent-override: 85%;
   descent-override: 15%;
   line-gap-override: 0%;
@@ -20,7 +20,7 @@
   src: url("/fonts/suisse-intl/SuisseIntl-Book.woff2") format("woff2");
   font-weight: 450;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
   ascent-override: 85%;
   descent-override: 15%;
   line-gap-override: 0%;
@@ -32,7 +32,7 @@
   src: url("/fonts/suisse-intl/SuisseIntl-Medium.woff2") format("woff2");
   font-weight: 500;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
   ascent-override: 85%;
   descent-override: 15%;
   line-gap-override: 0%;
@@ -44,7 +44,7 @@
   src: url("/fonts/suisse-intl/SuisseIntl-Medium.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
   ascent-override: 85%;
   descent-override: 15%;
   line-gap-override: 0%;
@@ -60,7 +60,7 @@
   src: url("/fonts/suisse-intl-mono/SuisseIntlMono-Regular-WebXL.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
 }
 
 /* Mono Bold - Bold code */
@@ -69,7 +69,7 @@
   src: url("/fonts/suisse-intl-mono/SuisseIntlMono-Bold-WebXL.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
 }
 /* ===========================================
    Lightspark Design Tokens


### PR DESCRIPTION
## Summary

- Changes `font-display: block` to `font-display: swap` in all 6 `@font-face` declarations in `style.css`
- Prevents text from going blank during SPA navigation on production

## Problem

After PR #170, text briefly goes **blank** during SPA page navigation on grid.lightspark.com. Icons, sidebar, navbar, and dark mode toggle stay styled — only text flashes invisible.

**Root cause**: Mintlify re-injects the `<style data-custom-css>` tag during SPA navigation, which re-triggers the `font-display: block` period — telling the browser to hide text while fonts re-load. This causes a brief invisible-text flash on every page change.

## Fix

Change `font-display: block` → `font-display: swap` in all 6 `@font-face` declarations. With `swap`, the browser shows a fallback font immediately and swaps to Suisse Intl once loaded — text is never invisible. When fonts are cached (the common case), the swap is imperceptible.

This matches the pattern used by other Mintlify-powered sites (e.g., code.claude.com/docs uses `font-display: swap` with 42 `@font-face` declarations and has no text flicker).

## Test plan

- [ ] Run `mint dev` locally, navigate between pages — confirm text never goes blank
- [ ] Verify fonts render as Suisse Intl (not stuck on system fallback)
- [ ] Check Mintlify staging preview
- [ ] Deploy to production, verify on grid.lightspark.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)