### PR TITLE
feat: adding min and max to fx api

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -214,6 +214,8 @@ paths:
                           name: US Dollar
                           symbol: $
                         sendingAmount: 10000
+                        minSendingAmount: 100
+                        maxSendingAmount: 10000000
                         destinationCurrency:
                           code: INR
                           decimals: 2
@@ -231,6 +233,8 @@ paths:
                           name: US Dollar
                           symbol: $
                         sendingAmount: 10000
+                        minSendingAmount: 100
+                        maxSendingAmount: 10000000
                         destinationCurrency:
                           code: EUR
                           decimals: 2
@@ -4267,6 +4271,8 @@ components:
         - sourceCurrency
         - destinationCurrency
         - destinationPaymentRail
+        - minSendingAmount
+        - maxSendingAmount
         - sendingAmount
         - receivingAmount
         - exchangeRate
@@ -4281,6 +4287,18 @@ components:
           description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
           minimum: 0
           example: 10000
+        minSendingAmount:
+          type: integer
+          format: int64
+          description: The minimum supported sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 100
+        maxSendingAmount:
+          type: integer
+          format: int64
+          description: The maximum supported sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 10000000
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -214,6 +214,8 @@ paths:
                           name: US Dollar
                           symbol: $
                         sendingAmount: 10000
+                        minSendingAmount: 100
+                        maxSendingAmount: 10000000
                         destinationCurrency:
                           code: INR
                           decimals: 2
@@ -231,6 +233,8 @@ paths:
                           name: US Dollar
                           symbol: $
                         sendingAmount: 10000
+                        minSendingAmount: 100
+                        maxSendingAmount: 10000000
                         destinationCurrency:
                           code: EUR
                           decimals: 2
@@ -4267,6 +4271,8 @@ components:
         - sourceCurrency
         - destinationCurrency
         - destinationPaymentRail
+        - minSendingAmount
+        - maxSendingAmount
         - sendingAmount
         - receivingAmount
         - exchangeRate
@@ -4281,6 +4287,18 @@ components:
           description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
           minimum: 0
           example: 10000
+        minSendingAmount:
+          type: integer
+          format: int64
+          description: The minimum supported sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 100
+        maxSendingAmount:
+          type: integer
+          format: int64
+          description: The maximum supported sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 10000000
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -4,6 +4,8 @@ required:
   - sourceCurrency
   - destinationCurrency
   - destinationPaymentRail
+  - minSendingAmount
+  - maxSendingAmount
   - sendingAmount
   - receivingAmount
   - exchangeRate
@@ -18,6 +20,18 @@ properties:
     description: The sending amount in the smallest unit of the source currency (e.g., cents for USD). Echoed back from the request if provided.
     minimum: 0
     example: 10000
+  minSendingAmount:
+    type: integer
+    format: int64
+    description: The minimum supported sending amount in the smallest unit of the source currency.
+    minimum: 0
+    example: 100
+  maxSendingAmount:
+    type: integer
+    format: int64
+    description: The maximum supported sending amount in the smallest unit of the source currency.
+    minimum: 0
+    example: 10000000
   destinationCurrency:
     $ref: ../common/Currency.yaml
   destinationPaymentRail:

--- a/openapi/paths/exchange-rates/exchange_rates.yaml
+++ b/openapi/paths/exchange-rates/exchange_rates.yaml
@@ -72,6 +72,8 @@ get:
                       name: US Dollar
                       symbol: "$"
                     sendingAmount: 10000
+                    minSendingAmount: 100
+                    maxSendingAmount: 10000000
                     destinationCurrency:
                       code: INR
                       decimals: 2
@@ -89,6 +91,8 @@ get:
                       name: US Dollar
                       symbol: "$"
                     sendingAmount: 10000
+                    minSendingAmount: 100
+                    maxSendingAmount: 10000000
                     destinationCurrency:
                       code: EUR
                       decimals: 2


### PR DESCRIPTION
### TL;DR

Added min/max sending amount fields to the Exchange Rate API response.

### What changed?

- Added `minSendingAmount` and `maxSendingAmount` fields to the `ExchangeRate` schema
- Made these fields required in the schema definition
- Updated example responses in the API documentation to include these new fields
- Added appropriate descriptions, type definitions, and example values for the new fields

### How to test?

1. Make a request to the Exchange Rates API endpoint
2. Verify that the response includes the `minSendingAmount` and `maxSendingAmount` fields
3. Confirm that the values represent the minimum and maximum allowed sending amounts in the smallest unit of the source currency

### Why make this change?

This change provides clients with important information about the valid range of sending amounts for each currency pair. By exposing these limits in the API response, clients can implement proper validation in their applications before submitting transactions, reducing the likelihood of failed transactions due to amount constraints.