### PR TITLE
fix: eliminate font swap flash during SPA navigation

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -17,10 +17,14 @@
   "fonts": {
     "heading": {
       "family": "Suisse Intl",
+      "source": "/fonts/suisse-intl/SuisseIntl-Medium.woff2",
+      "format": "woff2",
       "weight": 500
     },
     "body": {
       "family": "Suisse Intl",
+      "source": "/fonts/suisse-intl/SuisseIntl-Regular.woff2",
+      "format": "woff2",
       "weight": 400
     }
   },
@@ -292,7 +296,7 @@
   },
   "footer": {},
   "head": {
-    "raw": "<style>#header:empty,#page-title:empty{display:none!important}</style><script>if(location.pathname==='/'||location.pathname==='/index'||location.pathname===''){document.write('<style>header#header,#page-title,#page-context-menu-button,#page-context-menu,.eyebrow,#pagination,[class*=\"space-y-2\"]>*{display:none!important;visibility:hidden!important;height:0!important;overflow:hidden!important;margin:0!important;padding:0!important}</style>');document.documentElement.classList.add('is-homepage');}</script><style>html.is-homepage #pagination,body.is-homepage #pagination,html.is-homepage #footer,body.is-homepage #footer,html.is-homepage header#header,body.is-homepage header#header,html.is-homepage #page-title,body.is-homepage #page-title,html.is-homepage #page-context-menu-button,body.is-homepage #page-context-menu-button,html.is-homepage #page-context-menu,body.is-homepage #page-context-menu,html.is-homepage .eyebrow,body.is-homepage .eyebrow{display:none!important;visibility:hidden!important;height:0!important;overflow:hidden!important}</style>",
+    "raw": "<style>@font-face{font-family:\"Suisse Intl\";src:url(\"/fonts/suisse-intl/SuisseIntl-Regular.woff2\") format(\"woff2\");font-weight:400;font-style:normal;font-display:swap;ascent-override:85%;descent-override:15%;line-gap-override:0%}@font-face{font-family:\"Suisse Intl\";src:url(\"/fonts/suisse-intl/SuisseIntl-Book.woff2\") format(\"woff2\");font-weight:450;font-style:normal;font-display:swap;ascent-override:85%;descent-override:15%;line-gap-override:0%}@font-face{font-family:\"Suisse Intl\";src:url(\"/fonts/suisse-intl/SuisseIntl-Medium.woff2\") format(\"woff2\");font-weight:500;font-style:normal;font-display:swap;ascent-override:85%;descent-override:15%;line-gap-override:0%}@font-face{font-family:\"Suisse Intl\";src:url(\"/fonts/suisse-intl/SuisseIntl-Medium.woff2\") format(\"woff2\");font-weight:700;font-style:normal;font-display:swap;ascent-override:85%;descent-override:15%;line-gap-override:0%}@font-face{font-family:\"Suisse Intl Mono\";src:url(\"/fonts/suisse-intl-mono/SuisseIntlMono-Regular-WebXL.woff2\") format(\"woff2\");font-weight:400;font-style:normal;font-display:swap}@font-face{font-family:\"Suisse Intl Mono\";src:url(\"/fonts/suisse-intl-mono/SuisseIntlMono-Bold-WebXL.woff2\") format(\"woff2\");font-weight:700;font-style:normal;font-display:swap}*{font-feature-settings:\"salt\" on}</style><style>#header:empty,#page-title:empty{display:none!important}</style><script>if(location.pathname==='/'||location.pathname==='/index'||location.pathname===''){document.write('<style>header#header,#page-title,#page-context-menu-button,#page-context-menu,.eyebrow,#pagination,[class*=\"space-y-2\"]>*{display:none!important;visibility:hidden!important;height:0!important;overflow:hidden!important;margin:0!important;padding:0!important}</style>');document.documentElement.classList.add('is-homepage');}</script><style>html.is-homepage #pagination,body.is-homepage #pagination,html.is-homepage #footer,body.is-homepage #footer,html.is-homepage header#header,body.is-homepage header#header,html.is-homepage #page-title,body.is-homepage #page-title,html.is-homepage #page-context-menu-button,body.is-homepage #page-context-menu-button,html.is-homepage #page-context-menu,body.is-homepage #page-context-menu,html.is-homepage .eyebrow,body.is-homepage .eyebrow{display:none!important;visibility:hidden!important;height:0!important;overflow:hidden!important}</style>",
     "links": [
       {
         "rel": "preload",


### PR DESCRIPTION
## Summary

- **Adds `source` and `format` to fonts config** in `docs.json` — tells Mintlify to load Suisse Intl via `next/font/local` instead of attempting failed Google Fonts requests (HTTP 400), which was causing a double-loading race condition
- **Adds persistent `@font-face` declarations to `head.raw`** — covers all font weights (400, 450, 500, 700, Mono) so font declarations survive SPA navigation when `<style data-custom-css>` is removed/re-added
- **Adds `font-feature-settings: "salt" on` to `head.raw`** — prevents flash of double-story "a" reverting to single-story during navigation

### Why both approaches

| Layer | Covers | Purpose |
|-------|--------|---------|
| Mintlify `source`/`format` | Heading (500), Body (400) | Stops failed Google Fonts requests; enables `next/font` preloading |
| `head.raw` @font-face + salt | All weights + stylistic alternates | Stable anchor that persists during SPA navigation |
| style.css @font-face (unchanged) | All weights | Fallback/backup |

## Test plan

- [ ] Run `mint dev` and confirm fonts load on initial page load
- [ ] Check DevTools Network tab — no failed Google Fonts requests
- [ ] Navigate between pages — verify no font swap flash (system font → Suisse Intl)
- [ ] Navigate between pages — verify no stylistic alternate flash (double-story "a" → single-story)
- [ ] Inspect `<head>` in DevTools — confirm @font-face `<style>` persists during navigation
- [ ] Verify Mintlify staging preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)