### PR TITLE
feat: updating fx rates with a map

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -264,6 +264,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /exchange-rates-new:
+    get:
+      summary: Get exchange rates (currency map)
+      description: |
+        Retrieve cached exchange rates grouped by destination currency code.
+        This endpoint is intended to validate map-style response modeling where destination
+        currency codes are dynamic keys (for example, `destinationCurrencies["MXN"]`).
+      operationId: getExchangeRatesNew
+      tags:
+        - Exchange Rates
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: sourceCurrency
+          in: query
+          description: Filter by source currency code (e.g., USD)
+          required: false
+          schema:
+            type: string
+          example: USD
+        - name: sendingAmount
+          in: query
+          description: Sending amount in the smallest unit of the source currency.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 10000
+          example: 10000
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ExchangeRatesNew'
+              examples:
+                destinationCurrencyMap:
+                  summary: Exchange rates grouped by destination currency code
+                  value:
+                    data:
+                      sourceCurrency:
+                        code: USD
+                        decimals: 2
+                        name: US Dollar
+                        symbol: $
+                      sendingAmount: 10000
+                      destinationCurrencies:
+                        MXN:
+                          code: MXN
+                          decimals: 2
+                          name: Mexican Peso
+                          symbol: $
+                        EUR:
+                          code: EUR
+                          decimals: 2
+                          name: Euro
+                          symbol: EUR
+                      updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /customers:
     post:
       summary: Add a new customer
@@ -4322,6 +4405,46 @@ components:
           type: string
           format: date-time
           description: Timestamp when this exchange rate was last refreshed
+          example: '2025-02-05T12:00:00Z'
+    ExchangeRatesNew:
+      type: object
+      description: Exchange rates grouped by destination currency code.
+      required:
+        - sourceCurrency
+        - sendingAmount
+        - destinationCurrencies
+        - updatedAt
+      properties:
+        sourceCurrency:
+          $ref: '#/components/schemas/Currency'
+        sendingAmount:
+          type: integer
+          format: int64
+          description: Sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 10000
+        destinationCurrencies:
+          type: object
+          description: Map keyed by destination ISO 4217 currency code.
+          propertyNames:
+            pattern: ^[A-Z]{3}$
+          additionalProperties:
+            $ref: '#/components/schemas/Currency'
+          example:
+            MXN:
+              code: MXN
+              decimals: 2
+              name: Mexican Peso
+              symbol: $
+            EUR:
+              code: EUR
+              decimals: 2
+              name: Euro
+              symbol: EUR
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when this exchange rate map was last refreshed.
           example: '2025-02-05T12:00:00Z'
     CustomerType:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -264,6 +264,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /exchange-rates-new:
+    get:
+      summary: Get exchange rates (currency map)
+      description: |
+        Retrieve cached exchange rates grouped by destination currency code.
+        This endpoint is intended to validate map-style response modeling where destination
+        currency codes are dynamic keys (for example, `destinationCurrencies["MXN"]`).
+      operationId: getExchangeRatesNew
+      tags:
+        - Exchange Rates
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: sourceCurrency
+          in: query
+          description: Filter by source currency code (e.g., USD)
+          required: false
+          schema:
+            type: string
+          example: USD
+        - name: sendingAmount
+          in: query
+          description: Sending amount in the smallest unit of the source currency.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            default: 10000
+          example: 10000
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ExchangeRatesNew'
+              examples:
+                destinationCurrencyMap:
+                  summary: Exchange rates grouped by destination currency code
+                  value:
+                    data:
+                      sourceCurrency:
+                        code: USD
+                        decimals: 2
+                        name: US Dollar
+                        symbol: $
+                      sendingAmount: 10000
+                      destinationCurrencies:
+                        MXN:
+                          code: MXN
+                          decimals: 2
+                          name: Mexican Peso
+                          symbol: $
+                        EUR:
+                          code: EUR
+                          decimals: 2
+                          name: Euro
+                          symbol: EUR
+                      updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /customers:
     post:
       summary: Add a new customer
@@ -4322,6 +4405,46 @@ components:
           type: string
           format: date-time
           description: Timestamp when this exchange rate was last refreshed
+          example: '2025-02-05T12:00:00Z'
+    ExchangeRatesNew:
+      type: object
+      description: Exchange rates grouped by destination currency code.
+      required:
+        - sourceCurrency
+        - sendingAmount
+        - destinationCurrencies
+        - updatedAt
+      properties:
+        sourceCurrency:
+          $ref: '#/components/schemas/Currency'
+        sendingAmount:
+          type: integer
+          format: int64
+          description: Sending amount in the smallest unit of the source currency.
+          minimum: 0
+          example: 10000
+        destinationCurrencies:
+          type: object
+          description: Map keyed by destination ISO 4217 currency code.
+          propertyNames:
+            pattern: ^[A-Z]{3}$
+          additionalProperties:
+            $ref: '#/components/schemas/Currency'
+          example:
+            MXN:
+              code: MXN
+              decimals: 2
+              name: Mexican Peso
+              symbol: $
+            EUR:
+              code: EUR
+              decimals: 2
+              name: Euro
+              symbol: EUR
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when this exchange rate map was last refreshed.
           example: '2025-02-05T12:00:00Z'
     CustomerType:
       type: string

--- a/openapi/components/schemas/exchange_rates/ExchangeRatesNew.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRatesNew.yaml
@@ -1,0 +1,39 @@
+type: object
+description: Exchange rates grouped by destination currency code.
+required:
+  - sourceCurrency
+  - sendingAmount
+  - destinationCurrencies
+  - updatedAt
+properties:
+  sourceCurrency:
+    $ref: ../common/Currency.yaml
+  sendingAmount:
+    type: integer
+    format: int64
+    description: Sending amount in the smallest unit of the source currency.
+    minimum: 0
+    example: 10000
+  destinationCurrencies:
+    type: object
+    description: Map keyed by destination ISO 4217 currency code.
+    propertyNames:
+      pattern: '^[A-Z]{3}$'
+    additionalProperties:
+      $ref: ../common/Currency.yaml
+    example:
+      MXN:
+        code: MXN
+        decimals: 2
+        name: Mexican Peso
+        symbol: "$"
+      EUR:
+        code: EUR
+        decimals: 2
+        name: Euro
+        symbol: "EUR"
+  updatedAt:
+    type: string
+    format: date-time
+    description: Timestamp when this exchange rate map was last refreshed.
+    example: "2025-02-05T12:00:00Z"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -90,6 +90,8 @@ paths:
     $ref: paths/platform/config.yaml
   /exchange-rates:
     $ref: paths/exchange-rates/exchange_rates.yaml
+  /exchange-rates-new:
+    $ref: paths/exchange-rates/exchange_rates_new.yaml
   /customers:
     $ref: paths/customers/customers.yaml
   /customers/{customerId}:

--- a/openapi/paths/exchange-rates/exchange_rates_new.yaml
+++ b/openapi/paths/exchange-rates/exchange_rates_new.yaml
@@ -1,0 +1,82 @@
+get:
+  summary: Get exchange rates (currency map)
+  description: |
+    Retrieve cached exchange rates grouped by destination currency code.
+    This endpoint is intended to validate map-style response modeling where destination
+    currency codes are dynamic keys (for example, `destinationCurrencies["MXN"]`).
+  operationId: getExchangeRatesNew
+  tags:
+    - Exchange Rates
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: sourceCurrency
+      in: query
+      description: Filter by source currency code (e.g., USD)
+      required: false
+      schema:
+        type: string
+      example: USD
+    - name: sendingAmount
+      in: query
+      description: Sending amount in the smallest unit of the source currency.
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 0
+        default: 10000
+      example: 10000
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../../components/schemas/exchange_rates/ExchangeRatesNew.yaml
+          examples:
+            destinationCurrencyMap:
+              summary: Exchange rates grouped by destination currency code
+              value:
+                data:
+                  sourceCurrency:
+                    code: USD
+                    decimals: 2
+                    name: US Dollar
+                    symbol: "$"
+                  sendingAmount: 10000
+                  destinationCurrencies:
+                    MXN:
+                      code: MXN
+                      decimals: 2
+                      name: Mexican Peso
+                      symbol: "$"
+                    EUR:
+                      code: EUR
+                      decimals: 2
+                      name: Euro
+                      symbol: "EUR"
+                  updatedAt: "2025-02-05T12:00:00Z"
+    "400":
+      description: Bad request - Invalid parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    "500":
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
### TL;DR

Added a new `/exchange-rates-new` endpoint that returns exchange rates grouped by destination currency code.

### What changed?

- Created a new GET endpoint `/exchange-rates-new` that returns exchange rates in a map format
- Added a new schema `ExchangeRatesNew` that models exchange rates with destination currencies as dynamic keys
- The endpoint accepts optional query parameters for `sourceCurrency` and `sendingAmount`
- Implemented proper response examples showing the map structure with currency codes as keys

### How to test?

1. Make a GET request to `/exchange-rates-new` endpoint
2. Optionally include query parameters:
   - `sourceCurrency` (e.g., USD)
   - `sendingAmount` (e.g., 10000)
3. Verify the response contains a map of destination currencies with ISO currency codes as keys
4. Check that the structure matches the example with properties like `MXN` and `EUR` as dynamic keys

### Why make this change?

This endpoint was specifically created to validate map-style response modeling where destination currency codes are used as dynamic keys (e.g., `destinationCurrencies["MXN"]`). This pattern provides a more intuitive and efficient way to access exchange rate data by currency code compared to searching through an array.