### PR TITLE
Make the skill self-contained without needing the CLI.

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -181,13 +181,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
-    "accountType": "CLABE",
-    "clabeNumber": "<18-digit-number>",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name",
-      "birthDate": "1990-01-15",
-      "nationality": "MX"
+    "accountInfo": {
+      "accountType": "CLABE",
+      "clabeNumber": "<18-digit-number>",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "MX"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -198,11 +200,13 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
-    "accountType": "CLABE",
-    "clabeNumber": "<18-digit-number>",
-    "beneficiaryType": "BUSINESS",
-    "beneficiary": {
-      "legalName": "Company Name"
+    "accountInfo": {
+      "accountType": "CLABE",
+      "clabeNumber": "<18-digit-number>",
+      "beneficiary": {
+        "beneficiaryType": "BUSINESS",
+        "legalName": "Company Name"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -213,13 +217,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "INR",
-    "accountType": "UPI",
-    "upiId": "name@bank",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Name",
-      "birthDate": "1990-01-15",
-      "nationality": "IN"
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "name@bank",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Name",
+        "birthDate": "1990-01-15",
+        "nationality": "IN"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -230,15 +236,17 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "NGN",
-    "accountType": "NGN_ACCOUNT",
-    "accountNumber": "<10-digit>",
-    "bankName": "GTBank",
-    "purposeOfPayment": "GOODS_OR_SERVICES",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Name",
-      "birthDate": "1990-01-15",
-      "nationality": "NG"
+    "accountInfo": {
+      "accountType": "NGN_ACCOUNT",
+      "accountNumber": "<10-digit>",
+      "bankName": "GTBank",
+      "purposeOfPayment": "GOODS_OR_SERVICES",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Name",
+        "birthDate": "1990-01-15",
+        "nationality": "NG"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .

--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -7,7 +7,7 @@ description: >
   "pay [UMA address]", "send to CLABE", "send to PIX", "send to IBAN", "send to UPI",
   "fund sandbox account", "test a payment", "on-ramp", "off-ramp", "convert crypto to fiat",
   "convert fiat to crypto", "look up UMA", "real-time quote", "JIT funding", or any payment
-  operations using the Grid API CLI.
+  operations using the Grid API.
 allowed-tools:
   - Bash
   - Read
@@ -19,7 +19,7 @@ allowed-tools:
 
 You are a Grid API assistant that helps users manage global payments. You can:
 
-1. **Execute API Operations** - Use the CLI tool at `cli/dist/index.js` to interact with the Grid API
+1. **Execute API Operations** - Use `curl` to interact with the Grid API directly
 2. **Answer Documentation Questions** - Read the OpenAPI spec and Mintlify docs in this repo
 3. **Guide Payment Workflows** - Help users send payments to bank accounts, UMA addresses, and crypto wallets
 
@@ -27,13 +27,14 @@ You are a Grid API assistant that helps users manage global payments. You can:
 
 For detailed information, read these reference files in the `references/` directory:
 
-- **`references/account-types.md`** - Country-specific external account requirements (CLABE, PIX, IBAN, UPI, etc.) with field requirements and CLI examples. Read this when creating external accounts for international payments.
+- **`references/account-types.md`** - Country-specific external account requirements (CLABE, PIX, IBAN, UPI, etc.) with field requirements and curl examples. Read this when creating external accounts for international payments.
 - **`references/endpoints.md`** - Complete API endpoint reference with methods, paths, and response codes. Read this when answering questions about specific API capabilities.
 - **`references/workflows.md`** - Step-by-step payment workflow guides for common scenarios (UMA payments, international transfers, on-ramp, off-ramp). Read this when guiding users through multi-step payment flows.
 
 ## Key Concepts
 
 ### Entities
+
 - **Platform**: The top-level entity (the API user's business)
 - **Customer**: End users of the platform who send/receive payments
 - **Internal Account**: Grid-managed account for holding funds (can be platform-owned or customer-owned)
@@ -41,164 +42,362 @@ For detailed information, read these reference files in the `references/` direct
 - **UMA Address**: Universal Money Address (e.g., `$user@domain.com`) for receiving payments
 
 ### Account Types
+
 - **Platform internal accounts**: For pooled funds, rewards distribution, treasury
 - **Customer internal accounts**: Per-currency holding accounts created automatically for each customer
 - **External accounts**: Traditional bank accounts (CLABE, IBAN, UPI, etc.) or crypto wallets
 
 ### Account Status Lifecycle
+
 `PENDING` → `ACTIVE` → `UNDER_REVIEW` → `INACTIVE`
 
 ### Currency & Amounts
+
 - All amounts are in the **smallest currency unit** (cents for USD, satoshis for BTC)
 - Use the `currency.decimals` field to convert for display (USD=2, BTC=8, etc.)
 - Example: `10000` with `decimals: 2` = $100.00
 
 ## Configuration
 
-**Prerequisites**: Build the CLI before first use:
-```bash
-cd cli && npm install && npm run build && cd ..
-```
+The Grid API uses HTTP Basic Auth. Before making any API calls, ensure credentials and base URL are set as environment variables:
 
-### Quick Setup (Recommended)
-
-Run the interactive configuration command:
-```bash
-node cli/dist/index.js configure
-```
-
-This will:
-1. Prompt for your API Token ID and Client Secret
-2. Validate the credentials against the API
-3. Save them to `~/.grid-credentials`
-
-### Alternative: Environment Variables
-
-You can also configure via environment variables:
 - `GRID_API_TOKEN_ID` - API token ID
 - `GRID_API_CLIENT_SECRET` - API client secret
-- `GRID_BASE_URL` - Base URL (defaults to `https://api.lightspark.com/grid/2025-10-13`)
+- `GRID_BASE_URL` - API base URL
 
-### Non-Interactive Setup
-
-```bash
-node cli/dist/index.js configure --token-id <id> --client-secret <secret>
-```
-
-## CLI Commands
-
-Run all CLI commands from the repo root using: `node cli/dist/index.js <command>`
-
-### Command Aliases
-
-For faster typing, these aliases are available:
-- `customers` → `cust`
-- `transactions` → `tx`
-- `accounts` → `acct`
-
-Example: `node cli/dist/index.js cust list` is equivalent to `node cli/dist/index.js customers list`
-
-### Output Options
-
-By default, all commands output colorized JSON. You can change this:
+If not set, load them from `~/.grid-credentials`:
 
 ```bash
-# Table format (human-readable)
-node cli/dist/index.js customers list --format table
-
-# Disable colors (for piping/scripting)
-node cli/dist/index.js customers list --no-color
+export GRID_API_TOKEN_ID=$(jq -r .apiTokenId ~/.grid-credentials)
+export GRID_API_CLIENT_SECRET=$(jq -r .apiClientSecret ~/.grid-credentials)
+export GRID_BASE_URL=$(jq -r '.baseUrl // "https://api.lightspark.com/grid/2025-10-13"' ~/.grid-credentials)
 ```
+
+**Always load credentials from `~/.grid-credentials` before making API calls if the environment variables are not already set.**
+
+### Base URL
+
+- **Production**: `https://api.lightspark.com/grid/2025-10-13`
+- **Sandbox**: May use a different base URL — check `~/.grid-credentials` for the `baseUrl` field
+
+## Making API Calls
+
+All API calls use HTTP Basic Auth via `curl -u`:
+
+```bash
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/<endpoint>"
+```
+
+For POST/PATCH requests, add the JSON body:
+
+```bash
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '<json-body>' \
+  "$GRID_BASE_URL/<endpoint>"
+```
+
+Pipe through `jq` for readable output: `| jq .`
+
+## API Operations
 
 ### Platform Configuration
+
 ```bash
-node cli/dist/index.js config get                    # Get platform config (currencies, limits)
-node cli/dist/index.js config update --webhook-endpoint <url>
+# Get platform config (currencies, limits)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/config" | jq .
+
+# Update platform config (e.g., set webhook endpoint)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X PATCH -H "Content-Type: application/json" \
+  -d '{"webhookEndpoint": "https://example.com/webhooks"}' \
+  "$GRID_BASE_URL/config" | jq .
 ```
 
 ### Customer Management
+
 ```bash
-node cli/dist/index.js customers list [--limit N]
-node cli/dist/index.js customers get <customerId>
-node cli/dist/index.js customers create --platform-id <id> --type INDIVIDUAL --full-name "Name"
-node cli/dist/index.js customers update <customerId> --full-name "New Name"
-node cli/dist/index.js customers delete <customerId>        # Prompts for confirmation
-node cli/dist/index.js customers delete <customerId> --yes  # Skip confirmation
-node cli/dist/index.js customers kyc-link --customer-id <id> --redirect-url <url>
+# List customers
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers?limit=20" | jq .
+
+# Get customer details
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/<customerId>" | jq .
+
+# Create customer
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "platformCustomerId": "<platform-id>",
+    "customerType": "INDIVIDUAL",
+    "fullName": "Name"
+  }' \
+  "$GRID_BASE_URL/customers" | jq .
+
+# Update customer
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X PATCH -H "Content-Type: application/json" \
+  -d '{"fullName": "New Name"}' \
+  "$GRID_BASE_URL/customers/<customerId>" | jq .
+
+# Delete customer
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X DELETE \
+  "$GRID_BASE_URL/customers/<customerId>" | jq .
+
+# Generate KYC link
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "redirectUrl": "https://example.com/callback"
+  }' \
+  "$GRID_BASE_URL/customers/kyc-link" | jq .
 ```
 
 ### Account Management
+
 ```bash
-# Internal accounts (Grid-managed, for holding funds)
-node cli/dist/index.js accounts internal list [--customer-id <id>]   # Customer internal accounts
-node cli/dist/index.js accounts internal list --platform              # Platform internal accounts
+# List customer internal accounts
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/internal-accounts?customerId=<customerId>" | jq .
 
-# External accounts (bank accounts, crypto wallets - destinations for payouts)
-node cli/dist/index.js accounts external list [--customer-id <id>]
+# List platform internal accounts
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/platform/internal-accounts" | jq .
 
-# Create external accounts by country/type:
-# IMPORTANT: For INDIVIDUAL beneficiaries, ALWAYS include:
-#   --beneficiary-birth-date YYYY-MM-DD --beneficiary-nationality <2-letter-code>
-# For BUSINESS beneficiaries, use --beneficiary-name with the legal business name
+# List customer external accounts
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/external-accounts?customerId=<customerId>" | jq .
 
-# Mexico (CLABE) - Business example
-node cli/dist/index.js accounts external create --customer-id <id> --currency MXN --account-type CLABE --clabe <18-digit-number> --beneficiary-type BUSINESS --beneficiary-name "Company Name"
+# Create external account (Mexico CLABE - Individual)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "MXN",
+    "accountType": "CLABE",
+    "clabeNumber": "<18-digit-number>",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name",
+      "birthDate": "1990-01-15",
+      "nationality": "MX"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 
-# Mexico (CLABE) - Individual example
-node cli/dist/index.js accounts external create --customer-id <id> --currency MXN --account-type CLABE --clabe <18-digit-number> --beneficiary-type INDIVIDUAL --beneficiary-name "Full Name" --beneficiary-birth-date 1990-01-15 --beneficiary-nationality MX
+# Create external account (Mexico CLABE - Business)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "MXN",
+    "accountType": "CLABE",
+    "clabeNumber": "<18-digit-number>",
+    "beneficiaryType": "BUSINESS",
+    "beneficiary": {
+      "legalName": "Company Name"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 
-# India (UPI)
-node cli/dist/index.js accounts external create --customer-id <id> --currency INR --account-type UPI --upi-id "name@bank" --beneficiary-type INDIVIDUAL --beneficiary-name "Name" --beneficiary-birth-date YYYY-MM-DD --beneficiary-nationality IN
+# Create external account (India UPI)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "INR",
+    "accountType": "UPI",
+    "upiId": "name@bank",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Name",
+      "birthDate": "1990-01-15",
+      "nationality": "IN"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 
-# Nigeria (NGN) - REQUIRES: --bank-name (NOT --bank-code), --purpose
-node cli/dist/index.js accounts external create --customer-id <id> --currency NGN --account-type NGN_ACCOUNT --account-number <10-digit> --bank-name "GTBank" --purpose GOODS_OR_SERVICES --beneficiary-type INDIVIDUAL --beneficiary-name "Name" --beneficiary-birth-date YYYY-MM-DD --beneficiary-nationality NG
+# Create external account (Nigeria - REQUIRES bankName and purposeOfPayment)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "NGN",
+    "accountType": "NGN_ACCOUNT",
+    "accountNumber": "<10-digit>",
+    "bankName": "GTBank",
+    "purposeOfPayment": "GOODS_OR_SERVICES",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Name",
+      "birthDate": "1990-01-15",
+      "nationality": "NG"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 ### Quotes (Cross-Currency Transfers)
+
 ```bash
 # Account-funded to UMA: Use when funds are already in an internal account
-node cli/dist/index.js quotes create --source-account <internalAccountId> --dest-uma <address> --amount 10000 --lock-side SENDING
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "<internalAccountId>"
+    },
+    "destination": {
+      "destinationType": "UMA_ADDRESS",
+      "umaAddress": "<address>",
+      "currency": "USD"
+    },
+    "lockedCurrencyAmount": 10000,
+    "lockedCurrencySide": "SENDING"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 
-# Account-funded to external account: IMPORTANT - always include --dest-currency
-node cli/dist/index.js quotes create --source-account <internalAccountId> --dest-account <externalAccountId> --dest-currency <currency> --amount 10000 --lock-side SENDING
+# Account-funded to external account: IMPORTANT - always include destination currency
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "<internalAccountId>"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "<externalAccountId>",
+      "currency": "<currency>"
+    },
+    "lockedCurrencyAmount": 10000,
+    "lockedCurrencySide": "SENDING"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 
-# Real-time/JIT funded: Use when user will provide funds at execution time via instant payment
-# Returns paymentInstructions for funding. Only use with instant settlement methods.
-# Destination can be internal account, external account, or UMA address
-node cli/dist/index.js quotes create --source-customer <customerId> --source-currency <currency> --dest-account <accountId> --dest-currency <currency> --amount 10000 --lock-side RECEIVING
+# Real-time/JIT funded: Returns paymentInstructions for funding
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "REALTIME_FUNDING",
+      "customerId": "<customerId>",
+      "currency": "<sourceCurrency>"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "<accountId>",
+      "currency": "<destCurrency>"
+    },
+    "lockedCurrencyAmount": 100000,
+    "lockedCurrencySide": "RECEIVING"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 
-node cli/dist/index.js quotes execute <quoteId>
-node cli/dist/index.js quotes list [--status PENDING]
-node cli/dist/index.js quotes get <quoteId>
+# Execute a quote
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  "$GRID_BASE_URL/quotes/<quoteId>/execute" | jq .
+
+# List quotes
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/quotes?status=PENDING" | jq .
+
+# Get quote details
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/quotes/<quoteId>" | jq .
 ```
 
-**IMPORTANT**: When using `--dest-account`, you MUST also specify `--dest-currency`. This is required even though the external account already has a currency.
+**IMPORTANT**: When specifying a destination account, you MUST also include `currency` in the destination object. This is required even though the external account already has a currency.
 
 ### Same-Currency Transfers
+
 ```bash
-node cli/dist/index.js transfers in --source <externalAccountId> --dest <internalAccountId> --amount 10000
-node cli/dist/index.js transfers out --source <internalAccountId> --dest <externalAccountId> --amount 10000
+# Transfer in (external → internal, same currency)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "sourceAccountId": "<externalAccountId>",
+    "destinationAccountId": "<internalAccountId>",
+    "amount": 10000
+  }' \
+  "$GRID_BASE_URL/transfer-in" | jq .
+
+# Transfer out (internal → external, same currency)
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "sourceAccountId": "<internalAccountId>",
+    "destinationAccountId": "<externalAccountId>",
+    "amount": 10000
+  }' \
+  "$GRID_BASE_URL/transfer-out" | jq .
 ```
 
 ### Transactions
+
 ```bash
-node cli/dist/index.js transactions list [--status PENDING]
-node cli/dist/index.js transactions get <transactionId>
-node cli/dist/index.js transactions approve <transactionId>
-node cli/dist/index.js transactions reject <transactionId> [--reason "reason"]
+# List transactions
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions?status=PENDING" | jq .
+
+# Get transaction details
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions/<transactionId>" | jq .
+
+# Approve incoming payment
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  "$GRID_BASE_URL/transactions/<transactionId>/approve" | jq .
+
+# Reject incoming payment
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"reason": "Reason for rejection"}' \
+  "$GRID_BASE_URL/transactions/<transactionId>/reject" | jq .
 ```
 
 ### Receiver Lookup
+
 ```bash
-node cli/dist/index.js receiver lookup-uma <umaAddress>        # Get UMA payment capabilities
-node cli/dist/index.js receiver lookup-account <accountId>     # Get account payment capabilities
+# Look up UMA address capabilities
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/receiver/uma/%24alice%40example.com" | jq .
+
+# Look up external account capabilities
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/receiver/external-account/<accountId>" | jq .
 ```
 
+**Note:** UMA addresses contain `$` which must be URL-encoded as `%24` in the path.
+
 ### Sandbox Testing
+
 ```bash
-node cli/dist/index.js sandbox fund <internalAccountId> --amount 100000    # Fund account in sandbox
-node cli/dist/index.js sandbox send --quote-id <quoteId> --currency <code> # Simulate sending funds to a real-time quote
-node cli/dist/index.js sandbox receive --uma-address <addr> --amount 1000 --currency USD
+# Fund an internal account in sandbox
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"amount": 100000}' \
+  "$GRID_BASE_URL/sandbox/internal-accounts/<internalAccountId>/fund" | jq .
+
+# Simulate sending funds to a real-time quote
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"quoteId": "<quoteId>", "currency": "<code>"}' \
+  "$GRID_BASE_URL/sandbox/send" | jq .
+
+# Simulate receiving a UMA payment
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"umaAddress": "<address>", "amount": 1000, "currency": "USD"}' \
+  "$GRID_BASE_URL/sandbox/uma/receive" | jq .
 ```
 
 ## Payment Flow Patterns
@@ -206,21 +405,29 @@ node cli/dist/index.js sandbox receive --uma-address <addr> --amount 1000 --curr
 Grid supports three main payment patterns:
 
 ### 1. Prefunded (Account-Funded)
+
 Funds are already in an internal account. Quote executes immediately from existing balance.
+
 ```
 Internal Account (USD) → Quote → External Account/UMA (EUR)
 ```
-Use `--source-account` with an internal account ID.
+
+Use `sourceType: "ACCOUNT"` with an internal account ID.
 
 ### 2. Just-in-Time (Real-Time Funded)
+
 Funds will be provided at execution time. Quote returns `paymentInstructions` with multiple funding options. Grid auto-executes when deposit is received.
+
 ```
 Customer sends crypto/fiat → Grid detects deposit → Auto-executes at locked rate
 ```
-Use `--source-customer` + `--source-currency`. Only works with instant settlement methods.
+
+Use `sourceType: "REALTIME_FUNDING"` with customer ID and currency. Only works with instant settlement methods.
 
 ### 3. Same-Currency Transfers
+
 Direct transfers between accounts without currency conversion. No quote needed.
+
 ```
 External Account (USD) → Internal Account (USD)  [transfer-in]
 Internal Account (USD) → External Account (USD)  [transfer-out]
@@ -232,12 +439,18 @@ When a user wants to send a payment, guide them through these steps:
 
 ### Sending to an UMA Address
 
-1. Look up the receiver: `node cli/dist/index.js receiver lookup-uma $user@domain.com`
+1. Look up the receiver:
+
+   ```bash
+   curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+     "$GRID_BASE_URL/receiver/uma/%24user%40domain.com" | jq .
+   ```
+
 2. Show supported currencies and any required payer data
-3. Create a quote: `node cli/dist/index.js quotes create --source-account <id> --dest-uma <address> --amount <amt> --lock-side SENDING`
+3. Create a quote with the appropriate source and destination
 4. Show exchange rate and fees from the quote response
 5. Ask for confirmation before executing
-6. Execute: `node cli/dist/index.js quotes execute <quoteId>`
+6. Execute the quote
 
 ### Sending to a Bank Account (International)
 
@@ -254,7 +467,7 @@ When a user wants to send a payment, guide them through these steps:
    - Account details specific to the type
    - Beneficiary info (requirements vary by destination - check API response for errors)
 
-3. Create external account using the CLI (see Account Management section for examples)
+3. Create external account (see Account Management section for examples)
 
 4. Create quote showing exchange rate and fees
 
@@ -265,21 +478,13 @@ When a user wants to send a payment, guide them through these steps:
 Use this flow when the user asks for a "realtime quote" or "just in time" funded transfer. The quote response includes `paymentInstructions` for how to fund the transfer.
 
 **Key concept:** Real-time funding is about instant settlement, not currency type. Use this when funds will be provided at execution time via any instant payment method:
+
 - **Crypto:** BTC (Lightning, Spark), USDC (Solana, Base, Polygon), USDT (Tron)
 - **Fiat:** RTP, SEPA Instant, and other instant payment rails
 
 **Important:** Only use real-time funding with instant settlement methods. Do not use with slow methods like ACH since quotes expire quickly.
 
-1. Create a quote with `--source-customer` and `--source-currency`. Destination can be an internal account, external account, or UMA address:
-   ```bash
-   node cli/dist/index.js quotes create \
-     --source-customer <customerId> \
-     --source-currency BTC \
-     --dest-account <accountId> \
-     --dest-currency USD \
-     --amount 100000 \
-     --lock-side RECEIVING
-   ```
+1. Create a quote with `sourceType: "REALTIME_FUNDING"`. Destination can be an internal account, external account, or UMA address.
 
 2. The response includes `paymentInstructions` with **multiple funding options simultaneously**:
    - For BTC: Lightning invoice AND Spark wallet address
@@ -296,13 +501,14 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
    - Credits the destination account
    - Sends webhooks: `ACCOUNT_STATUS` on deposit, `OUTGOING_PAYMENT` on completion
 
-5. **No manual execution needed** - Do NOT call `quotes execute` for JIT quotes. The transfer executes automatically when funds are received.
+5. **No manual execution needed** - Do NOT call the execute endpoint for JIT quotes. The transfer executes automatically when funds are received.
 
 6. **Quote expiration**: Quotes expire in 1-5 minutes. If expired, create a new quote. Do not use slow settlement methods (ACH) with JIT funding.
 
 ## Documentation Resources
 
 For questions about the Grid API:
+
 - **OpenAPI Spec**: `openapi/` directory for endpoint details and request/response schemas
 - **Mintlify Docs**: `mintlify/` directory for guides, concepts, and workflow explanations
   - `mintlify/snippets/` - Reusable content on accounts, transfers, KYC, etc.
@@ -313,67 +519,75 @@ For questions about the Grid API:
 
 ## Best Practices
 
-1. **Check platform config first**: Run `config get` to see supported currencies and required fields
+1. **Check platform config first**: Call `GET /config` to see supported currencies and required fields
 2. **Use smallest currency units**: All amounts are in cents/satoshis - use `decimals` field for display
 3. **Handle quote expiration**: Quotes expire in 1-5 minutes; be prepared to create new quotes
 4. **Choose the right flow**: Use prefunded for immediate execution, JIT for crypto/instant rails
-5. **Input validation**: The CLI validates dates (YYYY-MM-DD), amounts, and currencies before making API calls - you'll get clear error messages for invalid input
-6. **Use table format for exploration**: `--format table` makes it easier to scan results interactively
+5. **Pipe through jq**: Always append `| jq .` for readable output, or `| jq -r .field` to extract specific values
+6. **URL-encode special characters**: UMA addresses contain `$` — encode as `%24` in URL paths
 
 ## Common Mistakes to Avoid
 
 ### External Account Creation
-1. **Missing individual beneficiary fields**: For `--beneficiary-type INDIVIDUAL`, you MUST include:
-   - `--beneficiary-birth-date YYYY-MM-DD`
-   - `--beneficiary-nationality <2-letter-code>`
 
-2. **Wrong option names**:
-   - Use `--bank-name` (NOT `--bank-code`) for Nigerian accounts
-   - Use `--purpose` for Nigerian accounts (required)
+1. **Missing individual beneficiary fields**: For `beneficiaryType: "INDIVIDUAL"`, you MUST include in the `beneficiary` object:
+   - `fullName`
+   - `birthDate` (YYYY-MM-DD)
+   - `nationality` (2-letter country code)
+
+2. **Wrong field names**:
+   - Use `bankName` (NOT `bankCode`) for Nigerian accounts
+   - Use `purposeOfPayment` for Nigerian accounts (required)
 
 3. **Missing country-specific fields**:
-   - Nigeria (NGN_ACCOUNT): Requires `--purpose` (e.g., `GOODS_OR_SERVICES`)
-   - Brazil (PIX): Requires `--pix-key` and `--pix-key-type`
-   - Europe (IBAN): Requires `--swift-bic`
+   - Nigeria (NGN_ACCOUNT): Requires `purposeOfPayment` (e.g., `GOODS_OR_SERVICES`)
+   - Brazil (PIX): Requires `pixKey`
+   - Europe (IBAN): Requires `swiftBic`
 
 ### Quote Creation
-1. **Missing destination currency**: When using `--dest-account`, you MUST also include `--dest-currency <code>`. This is required even though the external account already has a currency associated with it.
+
+1. **Missing destination currency**: When specifying a destination account, you MUST also include `currency` in the destination object. This is required even though the external account already has a currency associated with it.
 
 ## Error Handling
 
-All CLI commands output JSON with this structure:
+API responses follow this structure on success:
+
 ```json
 {
-  "success": true,
-  "data": { ... }
+  "id": "...",
+  "status": "...",
+  ...
 }
 ```
 
-Or on error:
+On error:
+
 ```json
 {
-  "success": false,
-  "error": {
-    "code": "ERROR_CODE",
-    "message": "Human readable message"
-  }
+  "code": "ERROR_CODE",
+  "message": "Human readable message"
 }
 ```
+
+The HTTP status code indicates the error category (400 for bad input, 401 for auth issues, 404 for not found, etc.).
 
 ### Common Error Codes
 
 **Quote/Transfer Errors:**
+
 - `QUOTE_EXPIRED` - Quote timed out; create a new quote
 - `INSUFFICIENT_BALANCE` - Check internal account balance before transfer
 - `INVALID_BANK_ACCOUNT` - Validate field formats per country requirements
 - `QUOTE_EXECUTION_FAILED` - Transient error; retry with exponential backoff
 
 **Incoming Payment Errors:**
+
 - `PAYMENT_APPROVAL_TIMED_OUT` - Webhook approval not received within 5 seconds
 - `PAYMENT_APPROVAL_WEBHOOK_ERROR` - Webhook returned error
 
 **Validation Errors:**
+
 - `INVALID_INPUT` - Check required fields; the `reason` field has details
 - `MISSING_MANDATORY_USER_INFO` - Customer or sender info missing required fields
 
-Always check the `success` field and report errors clearly to the user.
+Always check the HTTP status code and report errors clearly to the user.

--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - WebFetch
 ---
 
 # Grid API Skill
@@ -20,7 +21,7 @@ allowed-tools:
 You are a Grid API assistant that helps users manage global payments. You can:
 
 1. **Execute API Operations** - Use `curl` to interact with the Grid API directly
-2. **Answer Documentation Questions** - Read the OpenAPI spec and Mintlify docs in this repo
+2. **Answer Documentation Questions** - Fetch docs from https://grid.lightspark.com or the OpenAPI spec
 3. **Guide Payment Workflows** - Help users send payments to bank accounts, UMA addresses, and crypto wallets
 
 ## Supporting References
@@ -507,15 +508,11 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
 
 ## Documentation Resources
 
-For questions about the Grid API:
+For questions not covered by this skill's reference files, fetch additional information from the web:
 
-- **OpenAPI Spec**: `openapi/` directory for endpoint details and request/response schemas
-- **Mintlify Docs**: `mintlify/` directory for guides, concepts, and workflow explanations
-  - `mintlify/snippets/` - Reusable content on accounts, transfers, KYC, etc.
-  - `mintlify/snippets/sending/` - Cross-currency and same-currency transfer guides
-  - `mintlify/snippets/external-accounts.mdx` - Country-specific account requirements
-  - `mintlify/snippets/terminology.mdx` - Entity definitions and relationships
-- **External Account Schemas**: `openapi/components/schemas/external_accounts/` for field requirements per account type
+- **LLM-optimized docs**: Fetch `https://grid.lightspark.com/llms.txt` for a concise overview of the Grid API, or `https://grid.lightspark.com/llms-full.txt` for comprehensive documentation
+- **OpenAPI Spec**: Fetch `https://raw.githubusercontent.com/lightsparkdev/webdev/main/openapi.yaml` for the full API schema with request/response definitions
+- **Published docs**: Browse `https://grid.lightspark.com` for guides, tutorials, and API reference
 
 ## Best Practices
 

--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -2,8 +2,6 @@
 
 This reference maps countries/regions to their required account types and fields for sending payments via the Grid API.
 
-**Note:** The CLI validates date formats (YYYY-MM-DD) and currency codes before making API calls. Invalid input will return a clear error message without hitting the API.
-
 ## Account Type Summary
 
 | Country/Region | Account Type | Currency | Primary Identifier |
@@ -31,30 +29,45 @@ This reference maps countries/regions to their required account types and fields
 ### Mexico (CLABE)
 
 **Individual beneficiary:**
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency MXN \
-  --account-type CLABE \
-  --clabe <18-digit-clabe> \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name" \
-  --beneficiary-birth-date "1990-01-15" \
-  --beneficiary-nationality MX
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "MXN",
+    "accountType": "CLABE",
+    "clabeNumber": "<18-digit-clabe>",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name",
+      "birthDate": "1990-01-15",
+      "nationality": "MX"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 **Business beneficiary:**
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency MXN \
-  --account-type CLABE \
-  --clabe <18-digit-clabe> \
-  --beneficiary-type BUSINESS \
-  --beneficiary-name "Company Legal Name"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "MXN",
+    "accountType": "CLABE",
+    "clabeNumber": "<18-digit-clabe>",
+    "beneficiaryType": "BUSINESS",
+    "beneficiary": {
+      "legalName": "Company Legal Name"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 Required fields:
+
 - `clabeNumber`: 18-digit CLABE number (validates with check digit)
 - For individuals: `fullName`, `birthDate`, `nationality` (ALL THREE REQUIRED)
 - For businesses: `legalName`
@@ -62,16 +75,23 @@ Required fields:
 ### Brazil (PIX)
 
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency BRL \
-  --account-type PIX \
-  --pix-key "cpf:12345678901" \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "BRL",
+    "accountType": "PIX",
+    "pixKey": "12345678901",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 PIX key formats:
+
 - CPF: 11 digits (e.g., `12345678901`)
 - CNPJ: 14 digits (e.g., `12345678901234`)
 - Email: valid email address
@@ -81,16 +101,24 @@ PIX key formats:
 ### Europe (IBAN)
 
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency EUR \
-  --account-type IBAN \
-  --iban "DE89370400440532013000" \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name" \
-  --beneficiary-address-line1 "123 Street" \
-  --beneficiary-address-city "Berlin" \
-  --beneficiary-address-country DE
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "EUR",
+    "accountType": "IBAN",
+    "iban": "DE89370400440532013000",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name",
+      "address": {
+        "line1": "123 Street",
+        "city": "Berlin",
+        "country": "DE"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 IBAN format: Country code (2) + Check digits (2) + BBAN (up to 30)
@@ -98,23 +126,32 @@ IBAN format: Country code (2) + Check digits (2) + BBAN (up to 30)
 ### United States (US_ACCOUNT)
 
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency USD \
-  --account-type US_ACCOUNT \
-  --routing-number "123456789" \
-  --account-number "12345678901" \
-  --account-category CHECKING \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name" \
-  --beneficiary-address-line1 "123 Main St" \
-  --beneficiary-address-city "San Francisco" \
-  --beneficiary-address-state CA \
-  --beneficiary-address-postal "94105" \
-  --beneficiary-address-country US
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "USD",
+    "accountType": "US_ACCOUNT",
+    "routingNumber": "123456789",
+    "accountNumber": "12345678901",
+    "accountCategory": "CHECKING",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name",
+      "address": {
+        "line1": "123 Main St",
+        "city": "San Francisco",
+        "state": "CA",
+        "postalCode": "94105",
+        "country": "US"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 Required fields:
+
 - `routingNumber`: 9-digit ABA routing number
 - `accountNumber`: Bank account number
 - `accountCategory`: CHECKING or SAVINGS
@@ -122,13 +159,19 @@ Required fields:
 ### India (UPI)
 
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency INR \
-  --account-type UPI \
-  --upi-id "user@okbank" \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "INR",
+    "accountType": "UPI",
+    "upiId": "user@okbank",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 UPI ID format: `username@bankhandle` (e.g., `john@okaxis`, `jane@ybl`)
@@ -136,29 +179,37 @@ UPI ID format: `username@bankhandle` (e.g., `john@okaxis`, `jane@ybl`)
 ### Nigeria (NGN_ACCOUNT)
 
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency NGN \
-  --account-type NGN_ACCOUNT \
-  --account-number "1234567890" \
-  --bank-name "GTBank" \
-  --purpose GOODS_OR_SERVICES \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Full Name" \
-  --beneficiary-birth-date "1990-05-15" \
-  --beneficiary-nationality NG
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "NGN",
+    "accountType": "NGN_ACCOUNT",
+    "accountNumber": "1234567890",
+    "bankName": "GTBank",
+    "purposeOfPayment": "GOODS_OR_SERVICES",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Full Name",
+      "birthDate": "1990-05-15",
+      "nationality": "NG"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 Required fields:
+
 - `accountNumber`: 10-digit account number
 - `bankName`: Bank name (e.g., "GTBank", "Zenith Bank", "Access Bank")
 - `purposeOfPayment`: Purpose code (e.g., `GOODS_OR_SERVICES`)
 - For individuals: `fullName`, `birthDate`, `nationality`
 - For businesses: `legalName`
 
-**IMPORTANT**: Use `--bank-name` (NOT `--bank-code`). Use the bank's display name.
+**IMPORTANT**: Use `bankName` (NOT `bankCode`). Use the bank's display name.
 
 Common Nigerian banks:
+
 - GTBank
 - Zenith Bank
 - United Bank for Africa
@@ -168,41 +219,55 @@ Common Nigerian banks:
 ### Crypto Wallets
 
 #### Spark Wallet (Bitcoin)
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency BTC \
-  --account-type SPARK_WALLET \
-  --address "spark1..."
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "BTC",
+    "accountType": "SPARK_WALLET",
+    "address": "spark1..."
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 #### Solana Wallet (USDC)
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id <id> \
-  --currency USDC \
-  --account-type SOLANA_WALLET \
-  --address "..."
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "USDC",
+    "accountType": "SOLANA_WALLET",
+    "address": "..."
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 ## Beneficiary Information
 
 **CRITICAL**: All external accounts require beneficiary information. The required fields depend on the beneficiary type.
 
-### For Individuals (--beneficiary-type INDIVIDUAL)
-**All three fields are REQUIRED:**
-- `--beneficiary-name`: Full legal name
-- `--beneficiary-birth-date`: Date of birth (YYYY-MM-DD format)
-- `--beneficiary-nationality`: 2-letter ISO country code (e.g., NG, MX, IN, US)
-- `--beneficiary-address-*`: Optional but recommended
+### For Individuals (beneficiaryType: "INDIVIDUAL")
 
-### For Businesses (--beneficiary-type BUSINESS)
-- `--beneficiary-name`: Registered business/legal name (REQUIRED)
-- `--beneficiary-address-*`: Business address (optional)
+**All three fields are REQUIRED in the `beneficiary` object:**
+
+- `fullName`: Full legal name
+- `birthDate`: Date of birth (YYYY-MM-DD format)
+- `nationality`: 2-letter ISO country code (e.g., NG, MX, IN, US)
+- `address`: Optional but recommended (object with `line1`, `city`, `state`, `postalCode`, `country`)
+
+### For Businesses (beneficiaryType: "BUSINESS")
+
+- `legalName`: Registered business/legal name (REQUIRED)
+- `address`: Business address (optional)
 
 ## Sandbox Testing
 
 In sandbox mode, use these account number patterns to test scenarios:
+
 - Numbers ending in **002**: Insufficient funds
 - Numbers ending in **003**: Account closed/invalid
 - Numbers ending in **004**: Transfer rejected

--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -36,13 +36,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
-    "accountType": "CLABE",
-    "clabeNumber": "<18-digit-clabe>",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name",
-      "birthDate": "1990-01-15",
-      "nationality": "MX"
+    "accountInfo": {
+      "accountType": "CLABE",
+      "clabeNumber": "<18-digit-clabe>",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "MX"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -56,11 +58,13 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
-    "accountType": "CLABE",
-    "clabeNumber": "<18-digit-clabe>",
-    "beneficiaryType": "BUSINESS",
-    "beneficiary": {
-      "legalName": "Company Legal Name"
+    "accountInfo": {
+      "accountType": "CLABE",
+      "clabeNumber": "<18-digit-clabe>",
+      "beneficiary": {
+        "beneficiaryType": "BUSINESS",
+        "legalName": "Company Legal Name"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -80,11 +84,13 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "BRL",
-    "accountType": "PIX",
-    "pixKey": "12345678901",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name"
+    "accountInfo": {
+      "accountType": "PIX",
+      "pixKey": "12345678901",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -106,15 +112,17 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "EUR",
-    "accountType": "IBAN",
-    "iban": "DE89370400440532013000",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name",
-      "address": {
-        "line1": "123 Street",
-        "city": "Berlin",
-        "country": "DE"
+    "accountInfo": {
+      "accountType": "IBAN",
+      "iban": "DE89370400440532013000",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "address": {
+          "line1": "123 Street",
+          "city": "Berlin",
+          "country": "DE"
+        }
       }
     }
   }' \
@@ -131,19 +139,21 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "USD",
-    "accountType": "US_ACCOUNT",
-    "routingNumber": "123456789",
-    "accountNumber": "12345678901",
-    "accountCategory": "CHECKING",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name",
-      "address": {
-        "line1": "123 Main St",
-        "city": "San Francisco",
-        "state": "CA",
-        "postalCode": "94105",
-        "country": "US"
+    "accountInfo": {
+      "accountType": "US_ACCOUNT",
+      "routingNumber": "123456789",
+      "accountNumber": "12345678901",
+      "accountCategory": "CHECKING",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "address": {
+          "line1": "123 Main St",
+          "city": "San Francisco",
+          "state": "CA",
+          "postalCode": "94105",
+          "country": "US"
+        }
       }
     }
   }' \
@@ -164,11 +174,13 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "INR",
-    "accountType": "UPI",
-    "upiId": "user@okbank",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name"
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "user@okbank",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -184,15 +196,17 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "NGN",
-    "accountType": "NGN_ACCOUNT",
-    "accountNumber": "1234567890",
-    "bankName": "GTBank",
-    "purposeOfPayment": "GOODS_OR_SERVICES",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Full Name",
-      "birthDate": "1990-05-15",
-      "nationality": "NG"
+    "accountInfo": {
+      "accountType": "NGN_ACCOUNT",
+      "accountNumber": "1234567890",
+      "bankName": "GTBank",
+      "purposeOfPayment": "GOODS_OR_SERVICES",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-05-15",
+        "nationality": "NG"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -226,8 +240,10 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "BTC",
-    "accountType": "SPARK_WALLET",
-    "address": "spark1..."
+    "accountInfo": {
+      "accountType": "SPARK_WALLET",
+      "address": "spark1..."
+    }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
@@ -240,8 +256,10 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "<customerId>",
     "currency": "USDC",
-    "accountType": "SOLANA_WALLET",
-    "address": "..."
+    "accountInfo": {
+      "accountType": "SOLANA_WALLET",
+      "address": "..."
+    }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```

--- a/.claude/skills/grid-api/references/endpoints.md
+++ b/.claude/skills/grid-api/references/endpoints.md
@@ -1,6 +1,6 @@
 # Grid API Endpoints Reference
 
-Quick reference for all Grid API endpoints. For full details, see `openapi/` directory.
+Quick reference for all Grid API endpoints. For full request/response schemas, fetch the OpenAPI spec from `https://raw.githubusercontent.com/lightsparkdev/webdev/main/openapi.yaml`.
 
 ## Base URL
 

--- a/.claude/skills/grid-api/references/workflows.md
+++ b/.claude/skills/grid-api/references/workflows.md
@@ -1,10 +1,8 @@
 # Common Payment Workflows
 
-This reference describes common payment workflows using the Grid API CLI.
+This reference describes common payment workflows using the Grid API.
 
-**Tip:** Use command aliases for faster typing: `cust` (customers), `tx` (transactions), `acct` (accounts).
-
-**Tip:** Add `--format table` to any list command for human-readable output.
+**Tip:** Pipe all curl output through `jq .` for readable JSON, or `jq -r .field` to extract specific values.
 
 ## Workflow 1: Send Payment to UMA Address
 
@@ -13,34 +11,51 @@ Use this when the user wants to send money to an UMA address like `$alice@exampl
 ### Steps
 
 1. **Look up the receiver**
+
 ```bash
-node cli/dist/index.js receiver lookup-uma "\$alice@example.com"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/receiver/uma/%24alice%40example.com" | jq .
 ```
 
 This returns:
+
 - Supported currencies
 - Min/max amounts per currency
 - Required payer data fields
 
 2. **Check sender's balance**
+
 ```bash
-node cli/dist/index.js acct internal list --customer-id <customerId> --format table
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/internal-accounts?customerId=<customerId>" | jq .
 ```
 
 Identify the internal account with sufficient balance.
 
 3. **Create a quote**
+
 ```bash
-node cli/dist/index.js quotes create \
-  --source-account InternalAccount:xxx \
-  --dest-uma "\$alice@example.com" \
-  --dest-currency USD \
-  --amount 10000 \
-  --lock-side SENDING \
-  --description "Payment for services"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:xxx"
+    },
+    "destination": {
+      "destinationType": "UMA_ADDRESS",
+      "umaAddress": "$alice@example.com",
+      "currency": "USD"
+    },
+    "lockedCurrencyAmount": 10000,
+    "lockedCurrencySide": "SENDING",
+    "description": "Payment for services"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 ```
 
 The response includes:
+
 - `sendingAmount` and `sendingCurrency`
 - `receivingAmount` and `receivingCurrency`
 - `exchangeRate`
@@ -52,13 +67,18 @@ The response includes:
 Example: "You're sending $100.00 USD. The recipient will receive €92.15 EUR (rate: 0.9215). Fee: $1.50. Confirm?"
 
 5. **Execute the quote**
+
 ```bash
-node cli/dist/index.js quotes execute Quote:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  "$GRID_BASE_URL/quotes/Quote:xxx/execute" | jq .
 ```
 
 6. **Monitor the transaction**
+
 ```bash
-node cli/dist/index.js tx list --status PROCESSING --format table
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions?status=PROCESSING" | jq .
 ```
 
 ## Workflow 2: Send Payment to International Bank Account
@@ -72,52 +92,77 @@ Use this when the user wants to send money to a bank account in another country.
 Ask the user: "Which country is the bank account in?"
 
 Refer to `account-types.md` for:
+
 - Required account type (CLABE, PIX, IBAN, etc.)
 - Required fields
 
 2. **Collect account details interactively**
 
 For Mexico (CLABE):
+
 - Ask for 18-digit CLABE number
 - Ask for beneficiary name
 - Ask for beneficiary birth date
 - Ask for beneficiary nationality
 
 3. **Create the external account**
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id Customer:xxx \
-  --currency MXN \
-  --account-type CLABE \
-  --clabe 012345678901234567 \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "Juan Garcia" \
-  --beneficiary-birth-date "1985-03-15" \
-  --beneficiary-nationality MX
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "Customer:xxx",
+    "currency": "MXN",
+    "accountType": "CLABE",
+    "clabeNumber": "012345678901234567",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "Juan Garcia",
+      "birthDate": "1985-03-15",
+      "nationality": "MX"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 4. **Look up the account to get payment capabilities**
+
 ```bash
-node cli/dist/index.js receiver lookup-account ExternalAccount:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/receiver/external-account/ExternalAccount:xxx" | jq .
 ```
 
 5. **Create a quote**
+
 ```bash
-node cli/dist/index.js quotes create \
-  --source-account InternalAccount:xxx \
-  --dest-account ExternalAccount:xxx \
-  --dest-currency MXN \
-  --amount 100000 \
-  --lock-side RECEIVING
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:xxx"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "ExternalAccount:xxx",
+      "currency": "MXN"
+    },
+    "lockedCurrencyAmount": 100000,
+    "lockedCurrencySide": "RECEIVING"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 ```
 
-Note: `--lock-side RECEIVING` means the recipient gets exactly this amount.
+Note: `lockedCurrencySide: "RECEIVING"` means the recipient gets exactly this amount.
 
 6. **Show exchange details and confirm**
 
 7. **Execute the quote**
+
 ```bash
-node cli/dist/index.js quotes execute Quote:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  "$GRID_BASE_URL/quotes/Quote:xxx/execute" | jq .
 ```
 
 ## Workflow 3: On-Ramp (Fiat to Crypto)
@@ -127,8 +172,10 @@ Use this when a customer wants to convert fiat to cryptocurrency.
 ### Steps
 
 1. **Ensure customer has completed KYC**
+
 ```bash
-node cli/dist/index.js customers get Customer:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/Customer:xxx" | jq .
 ```
 
 Check `kycStatus` is `APPROVED`.
@@ -136,31 +183,49 @@ Check `kycStatus` is `APPROVED`.
 2. **Customer deposits fiat to their internal account**
 
 Show customer the `paymentInstructions` from their internal account:
+
 ```bash
-node cli/dist/index.js accounts internal list --customer-id Customer:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/internal-accounts?customerId=Customer:xxx" | jq .
 ```
 
 3. **Create external account for crypto destination**
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id Customer:xxx \
-  --currency BTC \
-  --account-type SPARK_WALLET \
-  --address "spark1..."
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "Customer:xxx",
+    "currency": "BTC",
+    "accountType": "SPARK_WALLET",
+    "address": "spark1..."
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 4. **Create and execute quote for conversion**
+
 ```bash
-node cli/dist/index.js quotes create \
-  --source-account InternalAccount:xxx \
-  --dest-account ExternalAccount:xxx \
-  --dest-currency BTC \
-  --amount 10000000 \
-  --lock-side SENDING \
-  --immediate
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:xxx"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "ExternalAccount:xxx",
+      "currency": "BTC"
+    },
+    "lockedCurrencyAmount": 10000000,
+    "lockedCurrencySide": "SENDING",
+    "immediatelyExecute": true
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 ```
 
-The `--immediate` flag executes the quote instantly.
+The `immediatelyExecute: true` flag executes the quote instantly.
 
 ## Workflow 4: Off-Ramp (Crypto to Fiat)
 
@@ -169,16 +234,23 @@ Use this when a customer wants to convert cryptocurrency to fiat.
 ### Steps
 
 1. **Create fiat external account for payout**
+
 ```bash
-node cli/dist/index.js accounts external create \
-  --customer-id Customer:xxx \
-  --currency USD \
-  --account-type US_ACCOUNT \
-  --routing-number "123456789" \
-  --account-number "12345678901" \
-  --account-category CHECKING \
-  --beneficiary-type INDIVIDUAL \
-  --beneficiary-name "John Doe"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "Customer:xxx",
+    "currency": "USD",
+    "accountType": "US_ACCOUNT",
+    "routingNumber": "123456789",
+    "accountNumber": "12345678901",
+    "accountCategory": "CHECKING",
+    "beneficiaryType": "INDIVIDUAL",
+    "beneficiary": {
+      "fullName": "John Doe"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
 2. **Customer sends crypto to their internal account**
@@ -186,13 +258,24 @@ node cli/dist/index.js accounts external create \
 Provide the deposit address from their BTC internal account.
 
 3. **Create and execute quote for conversion**
+
 ```bash
-node cli/dist/index.js quotes create \
-  --source-account InternalAccount:xxx \
-  --dest-account ExternalAccount:xxx \
-  --dest-currency USD \
-  --amount 50000 \
-  --lock-side RECEIVING
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:xxx"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "ExternalAccount:xxx",
+      "currency": "USD"
+    },
+    "lockedCurrencyAmount": 50000,
+    "lockedCurrencySide": "RECEIVING"
+  }' \
+  "$GRID_BASE_URL/quotes" | jq .
 ```
 
 ## Workflow 5: Handle Incoming Payment
@@ -202,22 +285,32 @@ Use this when your platform receives an incoming payment that needs approval.
 ### Steps
 
 1. **List pending incoming transactions**
+
 ```bash
-node cli/dist/index.js transactions list --type INCOMING --status PENDING_APPROVAL
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions?type=INCOMING&status=PENDING_APPROVAL" | jq .
 ```
 
 2. **Review transaction details**
+
 ```bash
-node cli/dist/index.js transactions get Transaction:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions/Transaction:xxx" | jq .
 ```
 
 3. **Approve or reject**
+
 ```bash
 # Approve
-node cli/dist/index.js transactions approve Transaction:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  "$GRID_BASE_URL/transactions/Transaction:xxx/approve" | jq .
 
 # Or reject
-node cli/dist/index.js transactions reject Transaction:xxx --reason "Suspicious activity"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"reason": "Suspicious activity"}' \
+  "$GRID_BASE_URL/transactions/Transaction:xxx/reject" | jq .
 ```
 
 ## Workflow 6: Bulk Customer Onboarding
@@ -233,16 +326,20 @@ The API supports bulk customer creation via CSV upload.
    - birthDate
    - address fields
 
-2. **Upload CSV** (this endpoint isn't in the CLI, use curl):
+2. **Upload CSV**
+
 ```bash
-curl -X POST https://api.lightspark.com/grid/2025-10-13/customers/bulk/csv \
-  -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
-  -F "file=@customers.csv"
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  -X POST \
+  -F "file=@customers.csv" \
+  "$GRID_BASE_URL/customers/bulk/csv" | jq .
 ```
 
 3. **Check job status**
+
 ```bash
-node cli/dist/index.js customers bulk-status <jobId>
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/customers/bulk/jobs/<jobId>" | jq .
 ```
 
 ## Error Recovery
@@ -250,17 +347,21 @@ node cli/dist/index.js customers bulk-status <jobId>
 ### Quote Expired
 
 If a quote expires before execution:
+
 1. Create a new quote with the same parameters
 2. Note: Exchange rates may have changed
 
 ### Transaction Failed
 
 Check transaction status for failure reason:
+
 ```bash
-node cli/dist/index.js transactions get Transaction:xxx
+curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+  "$GRID_BASE_URL/transactions/Transaction:xxx" | jq .
 ```
 
 Common failure reasons:
+
 - Insufficient funds
 - Invalid account details
 - Compliance rejection
@@ -269,6 +370,7 @@ Common failure reasons:
 ### Retry with Different Account
 
 If a bank account is rejected, try:
+
 1. Verify account details are correct
 2. Create a new external account with corrected details
 3. Create new quote with the new account

--- a/.claude/skills/grid-api/references/workflows.md
+++ b/.claude/skills/grid-api/references/workflows.md
@@ -113,13 +113,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "Customer:xxx",
     "currency": "MXN",
-    "accountType": "CLABE",
-    "clabeNumber": "012345678901234567",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "Juan Garcia",
-      "birthDate": "1985-03-15",
-      "nationality": "MX"
+    "accountInfo": {
+      "accountType": "CLABE",
+      "clabeNumber": "012345678901234567",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Juan Garcia",
+        "birthDate": "1985-03-15",
+        "nationality": "MX"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
@@ -197,8 +199,10 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "Customer:xxx",
     "currency": "BTC",
-    "accountType": "SPARK_WALLET",
-    "address": "spark1..."
+    "accountInfo": {
+      "accountType": "SPARK_WALLET",
+      "address": "spark1..."
+    }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
@@ -241,13 +245,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   -d '{
     "customerId": "Customer:xxx",
     "currency": "USD",
-    "accountType": "US_ACCOUNT",
-    "routingNumber": "123456789",
-    "accountNumber": "12345678901",
-    "accountCategory": "CHECKING",
-    "beneficiaryType": "INDIVIDUAL",
-    "beneficiary": {
-      "fullName": "John Doe"
+    "accountInfo": {
+      "accountType": "US_ACCOUNT",
+      "routingNumber": "123456789",
+      "accountNumber": "12345678901",
+      "accountCategory": "CHECKING",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "John Doe"
+      }
     }
   }' \
   "$GRID_BASE_URL/customers/external-accounts" | jq .


### PR DESCRIPTION
This allows it to be more portable and easily installed via `npx skills add lightsparkdev/grid-api`. The CLI isn't actually needed by the skill since it can just use curl. It just adds a extra layer of maintenance cost for the API surface anyway.
