### PR TITLE
fix: extracting counterparty information to fix webhook generation

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5848,13 +5848,7 @@ components:
           description: Optional memo or description for the payment
           example: 'Payment for invoice #1234'
         counterpartyInformation:
-          type: object
-          description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
-          additionalProperties: true
-          example:
-            FULL_NAME: John Sender
-            BIRTH_DATE: '1985-06-15'
-            NATIONALITY: DE
+          $ref: '#/components/schemas/CounterpartyInformation'
       discriminator:
         propertyName: type
         mapping:
@@ -6220,6 +6214,14 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+    CounterpartyInformation:
+      type: object
+      description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
+      additionalProperties: true
+      example:
+        FULL_NAME: John Sender
+        BIRTH_DATE: '1985-06-15'
+        NATIONALITY: DE
     CurrencyPreference:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5848,13 +5848,7 @@ components:
           description: Optional memo or description for the payment
           example: 'Payment for invoice #1234'
         counterpartyInformation:
-          type: object
-          description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
-          additionalProperties: true
-          example:
-            FULL_NAME: John Sender
-            BIRTH_DATE: '1985-06-15'
-            NATIONALITY: DE
+          $ref: '#/components/schemas/CounterpartyInformation'
       discriminator:
         propertyName: type
         mapping:
@@ -6220,6 +6214,14 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+    CounterpartyInformation:
+      type: object
+      description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
+      additionalProperties: true
+      example:
+        FULL_NAME: John Sender
+        BIRTH_DATE: '1985-06-15'
+        NATIONALITY: DE
     CurrencyPreference:
       type: object
       required:

--- a/openapi/components/schemas/transactions/CounterpartyInformation.yaml
+++ b/openapi/components/schemas/transactions/CounterpartyInformation.yaml
@@ -1,0 +1,7 @@
+type: object
+description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
+additionalProperties: true
+example:
+  FULL_NAME: John Sender
+  BIRTH_DATE: '1985-06-15'
+  NATIONALITY: DE

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -47,13 +47,7 @@ properties:
     description: Optional memo or description for the payment
     example: 'Payment for invoice #1234'
   counterpartyInformation:
-    type: object
-    description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
-    additionalProperties: true
-    example:
-      FULL_NAME: John Sender
-      BIRTH_DATE: '1985-06-15'
-      NATIONALITY: DE
+    $ref: ./CounterpartyInformation.yaml
 discriminator:
   propertyName: type
   mapping:


### PR DESCRIPTION
### TL;DR

Extracted `CounterpartyInformation` into a separate reusable schema component.

### What changed?

- Created a new schema component `CounterpartyInformation` that was previously defined inline
- Updated references in the `Transaction` schema to use the new component via `$ref`
- Applied these changes consistently across both the main OpenAPI file and the modular component files

### How to test?

1. Validate that the OpenAPI spec still compiles correctly
2. Verify that API documentation renders the `CounterpartyInformation` schema properly
3. Confirm that any endpoints using transactions with counterparty information still function as expected

### Why make this change?

This refactoring improves the OpenAPI specification by:
- Promoting reusability of the `CounterpartyInformation` schema
- Making the schema more maintainable by defining it in a single location
- Following best practices for OpenAPI schema organization
- Ensuring consistency if this schema needs to be referenced from other components in the future