### PR TITLE
Docs.json webhooks template

### DIFF
--- a/mintlify/api-reference/webhooks.mdx
+++ b/mintlify/api-reference/webhooks.mdx
@@ -1,0 +1,8 @@
+---
+title: "Webhooks"
+description: "Learn how to receive and verify webhook notifications from the Grid API"
+---
+
+import Webhooks from '/snippets/webhooks.mdx';
+
+<Webhooks />

--- a/mintlify/api-reference/webhooks.mdx
+++ b/mintlify/api-reference/webhooks.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Webhooks"
+icon: "/images/icons/bell.svg"
 description: "Learn how to receive and verify webhook notifications from the Grid API"
+"og:image": "/images/og/og-api-reference.png"
 ---
 
 import Webhooks from '/snippets/webhooks.mdx';

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -252,7 +252,8 @@
             "pages": [
               "api-reference/environments",
               "api-reference/terminology",
-              "api-reference/authentication"
+              "api-reference/authentication",
+              "api-reference/webhooks"
             ]
           },
           {


### PR DESCRIPTION
Add webhooks documentation to the API Reference tab to improve accessibility and consistency.

This change addresses feedback that webhook information should be more accessible within the API reference section, aligning it with other key API topics.

---
[Slack Thread](https://lightsparkgroup.slack.com/archives/C09H6AEERDF/p1770403148012139?thread_ts=1770403148.012139&cid=C09H6AEERDF)

<p><a href="https://cursor.com/background-agent?bcId=bc-b914b4e9-fbdf-5440-945f-fd0911acc782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b914b4e9-fbdf-5440-945f-fd0911acc782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

