### PR TITLE
fix: add overflow hidden to code group containers for corner radius clipping

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1648,6 +1648,7 @@ div.callout,
 [data-testid="code-group-select"] {
   border-radius: var(--ls-radius-md) !important;
   padding: 0 !important;
+  overflow: hidden !important;
   border: 0.5px solid var(--ls-black-10) !important;
 }
 


### PR DESCRIPTION
## Summary

- Adds `overflow: hidden !important` to the general `.code-group, [data-testid="code-group-select"]` CSS rule in `mintlify/style.css`
- Fixes sharp corners and border clipping on API reference code blocks in production, where Mintlify's Tailwind `overflow-hidden` class is no longer being applied to code group containers

## Context

The content-area scoped rule (`#content .code-group`, etc.) already had `overflow: hidden`, but the general selector used by API reference pages did not. Without it, inner elements with `border-radius: 0` bleed through the parent's rounded border, making corners appear sharp.

## Test plan

- [x] Verified the fix resolves the issue in production (via browser dev tools)
- [x] Confirm code blocks on API reference pages render with rounded corners after deploy
- [x] Confirm code blocks in content pages (guides, quickstarts) are unaffected


Made with [Cursor](https://cursor.com)