### PR TITLE
feat: adding external account validation schema

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5242,6 +5242,33 @@ components:
         - UNDER_REVIEW
         - INACTIVE
       description: Status of an external account
+    BeneficiaryVerificationStatus:
+      type: string
+      enum:
+        - MATCHED
+        - PARTIAL_MATCH
+        - NOT_MATCHED
+        - UNSUPPORTED
+        - CHECKED_BY_RECEIVING_FI
+        - PENDING
+      description: |
+        The result of verifying the beneficiary name against the account holder name.
+
+        | Status | Description |
+        |--------|-------------|
+        | `MATCHED` | The beneficiary name is an exact match |
+        | `PARTIAL_MATCH` | The beneficiary name is a fuzzy match |
+        | `NOT_MATCHED` | The beneficiary name does not match |
+        | `UNSUPPORTED` | The payment rail does not support name verification |
+        | `CHECKED_BY_RECEIVING_FI` | Verification is deferred to the receiving financial institution (e.g. ACH) |
+        | `PENDING` | Verification is still in progress |
+    BeneficiaryVerifiedData:
+      type: object
+      properties:
+        fullName:
+          type: string
+          description: The verified full name of the account holder as returned by the payment rail
+          example: John Doe
     UsAccountExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
@@ -5725,6 +5752,12 @@ components:
               type: boolean
               description: Whether this account is the default UMA deposit account for the customer. If true, incoming UMA payments to this customer's UMA address will be automatically deposited into this account instead of the primary internal account. False if not provided. Note that at most, one external account can be set as the default UMA deposit account for a customer. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
               example: false
+            beneficiaryVerificationStatus:
+              $ref: '#/components/schemas/BeneficiaryVerificationStatus'
+              description: The result of verifying the beneficiary name against the account holder name
+            beneficiaryVerifiedData:
+              $ref: '#/components/schemas/BeneficiaryVerifiedData'
+              description: Verified beneficiary data returned by the payment rail, if available
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5242,6 +5242,33 @@ components:
         - UNDER_REVIEW
         - INACTIVE
       description: Status of an external account
+    BeneficiaryVerificationStatus:
+      type: string
+      enum:
+        - MATCHED
+        - PARTIAL_MATCH
+        - NOT_MATCHED
+        - UNSUPPORTED
+        - CHECKED_BY_RECEIVING_FI
+        - PENDING
+      description: |
+        The result of verifying the beneficiary name against the account holder name.
+
+        | Status | Description |
+        |--------|-------------|
+        | `MATCHED` | The beneficiary name is an exact match |
+        | `PARTIAL_MATCH` | The beneficiary name is a fuzzy match |
+        | `NOT_MATCHED` | The beneficiary name does not match |
+        | `UNSUPPORTED` | The payment rail does not support name verification |
+        | `CHECKED_BY_RECEIVING_FI` | Verification is deferred to the receiving financial institution (e.g. ACH) |
+        | `PENDING` | Verification is still in progress |
+    BeneficiaryVerifiedData:
+      type: object
+      properties:
+        fullName:
+          type: string
+          description: The verified full name of the account holder as returned by the payment rail
+          example: John Doe
     UsAccountExternalAccountInfo:
       allOf:
         - $ref: '#/components/schemas/BaseExternalAccountInfo'
@@ -5725,6 +5752,12 @@ components:
               type: boolean
               description: Whether this account is the default UMA deposit account for the customer. If true, incoming UMA payments to this customer's UMA address will be automatically deposited into this account instead of the primary internal account. False if not provided. Note that at most, one external account can be set as the default UMA deposit account for a customer. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
               example: false
+            beneficiaryVerificationStatus:
+              $ref: '#/components/schemas/BeneficiaryVerificationStatus'
+              description: The result of verifying the beneficiary name against the account holder name
+            beneficiaryVerifiedData:
+              $ref: '#/components/schemas/BeneficiaryVerifiedData'
+              description: Verified beneficiary data returned by the payment rail, if available
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:

--- a/openapi/components/schemas/external_accounts/BeneficiaryVerificationStatus.yaml
+++ b/openapi/components/schemas/external_accounts/BeneficiaryVerificationStatus.yaml
@@ -1,0 +1,19 @@
+type: string
+enum:
+  - MATCHED
+  - PARTIAL_MATCH
+  - NOT_MATCHED
+  - UNSUPPORTED
+  - CHECKED_BY_RECEIVING_FI
+  - PENDING
+description: |
+  The result of verifying the beneficiary name against the account holder name.
+
+  | Status | Description |
+  |--------|-------------|
+  | `MATCHED` | The beneficiary name is an exact match |
+  | `PARTIAL_MATCH` | The beneficiary name is a fuzzy match |
+  | `NOT_MATCHED` | The beneficiary name does not match |
+  | `UNSUPPORTED` | The payment rail does not support name verification |
+  | `CHECKED_BY_RECEIVING_FI` | Verification is deferred to the receiving financial institution (e.g. ACH) |
+  | `PENDING` | Verification is still in progress |

--- a/openapi/components/schemas/external_accounts/BeneficiaryVerifiedData.yaml
+++ b/openapi/components/schemas/external_accounts/BeneficiaryVerifiedData.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  fullName:
+    type: string
+    description: The verified full name of the account holder as returned by the payment rail
+    example: John Doe

--- a/openapi/components/schemas/external_accounts/ExternalAccount.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccount.yaml
@@ -34,5 +34,11 @@ allOf:
           False if not provided. Note that at most, one external account can be set as the default UMA deposit account for a customer.
           If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
         example: false
+      beneficiaryVerificationStatus:
+        $ref: ./BeneficiaryVerificationStatus.yaml
+        description: The result of verifying the beneficiary name against the account holder name
+      beneficiaryVerifiedData:
+        $ref: ./BeneficiaryVerifiedData.yaml
+        description: Verified beneficiary data returned by the payment rail, if available
       accountInfo:
         $ref: ./ExternalAccountInfoOneOf.yaml


### PR DESCRIPTION
### TL;DR

Added beneficiary name verification fields to the External Account schema.

### What changed?

- Added a new `BeneficiaryVerificationStatus` enum with values: `MATCHED`, `PARTIAL_MATCH`, `NOT_MATCHED`, `UNSUPPORTED`, `CHECKED_BY_RECEIVING_FI`, and `PENDING`
- Added a new `VerifiedBeneficiaryData` object schema with a `fullName` property
- Extended the `ExternalAccount` schema to include:
  - `beneficiaryVerificationStatus` field to indicate the result of name verification
  - `beneficiaryVerifiedData` field to store verified account holder information

### How to test?

1. Create an external account with a beneficiary name
2. Verify that the API returns the appropriate verification status and verified data
3. Test each possible verification status to ensure proper handling

### Why make this change?

This change enables beneficiary name verification for external accounts, which helps prevent misdirected payments by confirming that the account holder name matches the expected beneficiary. This feature enhances security and reduces the risk of fraud or errors when sending payments to external accounts.