### PR TITLE
feat: fixing transaction schema

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -417,18 +417,18 @@ openapi:
           - "$.components.schemas.UmaAddressTransactionDestination.allOf[0]"
         keys: [ "$ref" ]
 
-    # # ── beneficiaryType: beneficiary schemas ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline beneficiaryType enums from beneficiary allOf variants
-    #     to avoid conflicting types with BaseBeneficiary which defines
-    #     beneficiaryType via a shared $ref enum
-    #   args:
-    #     target:
-    #       - "$.components.schemas.IndividualBeneficiary.allOf[1].properties"
-    #       - "$.components.schemas.BusinessBeneficiary.allOf[1].properties"
-    #     keys: [ "beneficiaryType" ]
-    # ── customerType: remove from base schemas ──
+    # ── type: transaction base schema ──
+    - command: remove
+      reason: >-
+        Remove inline type enum from Transaction base schema to avoid
+        conflicting types when allOf merges with IncomingTransaction and
+        OutgoingTransaction which define type as single-value enums
+      args:
+        target:
+          - "$.components.schemas.Transaction.properties"
+        keys: [ "type" ]
+
+    # ── beneficiaryType: beneficiary schemas ──
     - command: remove
       reason: >-
         Remove customerType $ref from base schemas so the inline single-value

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -1304,7 +1304,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -1398,7 +1398,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -2062,7 +2062,7 @@ paths:
                     type: array
                     description: List of transactions matching the criteria
                     items:
-                      $ref: '#/components/schemas/Transaction'
+                      $ref: '#/components/schemas/TransactionOneOf'
                   hasMore:
                     type: boolean
                     description: Indicates if more results are available beyond this page
@@ -2112,7 +2112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '401':
           description: Unauthorized
           content:
@@ -5838,6 +5838,32 @@ components:
             Optional Plaid account ID if the customer selected a specific account.
             If not provided, the default account will be used.
           example: plaid_account_id_123
+    IncomingTransaction:
+      allOf:
+        - $ref: '#/components/schemas/Transaction'
+        - type: object
+          required:
+            - type
+            - receivedAmount
+          properties:
+            type:
+              type: string
+              enum:
+                - INCOMING
+            source:
+              $ref: '#/components/schemas/TransactionSourceOneOf'
+            receivedAmount:
+              $ref: '#/components/schemas/CurrencyAmount'
+              description: Amount received in the recipient's currency
+            reconciliationInstructions:
+              $ref: '#/components/schemas/ReconciliationInstructions'
+              description: Included for all transactions except those with "CREATED" status
+            rateDetails:
+              $ref: '#/components/schemas/IncomingRateDetails'
+              description: Details about the rate and fees for the transaction.
+            failureReason:
+              $ref: '#/components/schemas/IncomingTransactionFailureReason'
+              description: If the transaction failed, this field provides the reason for failure.
     Transaction:
       type: object
       required:
@@ -5925,6 +5951,7 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionSource'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionSource'
+          REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     UmaAddressTransactionSource:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionSource'
@@ -5942,6 +5969,27 @@ components:
               description: UMA address of the sender
               example: $sender@uma.domain.com
           description: UMA address source details
+    RealtimeFundingTransactionSource:
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionSource'
+        - type: object
+          required:
+            - currency
+            - sourceType
+          properties:
+            sourceType:
+              type: string
+              enum:
+                - REALTIME_FUNDING
+            customerId:
+              type: string
+              description: The customer on whose behalf the transaction was initiated.
+              example: Customer:019542f5-b3e7-1d02-0000-000000000009
+            currency:
+              type: string
+              description: Currency code for the funding source
+              example: USDC
+          description: Transaction was funded using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
     TransactionSourceType:
       type: string
       enum:
@@ -5956,86 +6004,14 @@ components:
           $ref: '#/components/schemas/AccountTransactionSource'
         - title: UMA Address Source
           $ref: '#/components/schemas/UmaAddressTransactionSource'
+        - title: Real-time Funding Source
+          $ref: '#/components/schemas/RealtimeFundingTransactionSource'
       discriminator:
         propertyName: sourceType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionSource'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionSource'
-    ReconciliationInstructions:
-      type: object
-      required:
-        - reference
-      properties:
-        reference:
-          type: string
-          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
-          example: UMA-Q12345-REF
-    IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
-      type: object
-      required:
-        - gridApiMultiplier
-        - gridApiFixedFee
-        - gridApiVariableFeeRate
-        - gridApiVariableFeeAmount
-      properties:
-        gridApiMultiplier:
-          type: number
-          format: double
-          description: The underlying multiplier from the mSATS to the receiving currency, including variable fees.
-          exclusiveMinimum: 0
-          example: 0.925
-        gridApiFixedFee:
-          type: integer
-          format: int64
-          description: The fixed fee charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents).
-          minimum: 0
-          example: 10
-        gridApiVariableFeeRate:
-          type: number
-          format: double
-          description: The variable fee rate charged by the Grid product to execute the quote as a percentage of the receiving currency amount.
-          exclusiveMinimum: 0
-          example: 0.003
-        gridApiVariableFeeAmount:
-          type: number
-          format: int64
-          description: The variable fee amount charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents). This is the receiving amount times gridApiVariableFeeRate.
-          minimum: 0
-          example: 30
-    IncomingTransactionFailureReason:
-      type: string
-      enum:
-        - LNURLP_FAILED
-        - PAY_REQUEST_FAILED
-        - PAYMENT_APPROVAL_WEBHOOK_ERROR
-        - PAYMENT_APPROVAL_TIMED_OUT
-        - OFFRAMP_FAILED
-        - MISSING_MANDATORY_PAYEE_DATA
-        - QUOTE_EXPIRED
-        - QUOTE_EXECUTION_FAILED
-      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
-    IncomingTransaction:
-      allOf:
-        - $ref: '#/components/schemas/Transaction'
-        - type: object
-          required:
-            - receivedAmount
-          properties:
-            source:
-              $ref: '#/components/schemas/TransactionSourceOneOf'
-            receivedAmount:
-              $ref: '#/components/schemas/CurrencyAmount'
-              description: Amount received in the recipient's currency
-            reconciliationInstructions:
-              $ref: '#/components/schemas/ReconciliationInstructions'
-              description: Included for all transactions except those with "CREATED" status
-            rateDetails:
-              $ref: '#/components/schemas/IncomingRateDetails'
-              description: Details about the rate and fees for the transaction.
-            failureReason:
-              $ref: '#/components/schemas/IncomingTransactionFailureReason'
-              description: If the transaction failed, this field provides the reason for failure.
+          REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     Refund:
       type: object
       required:
@@ -6118,10 +6094,14 @@ components:
         - $ref: '#/components/schemas/Transaction'
         - type: object
           required:
+            - type
             - sentAmount
-            - paymentInstructions
             - source
           properties:
+            type:
+              type: string
+              enum:
+                - OUTGOING
             source:
               $ref: '#/components/schemas/TransactionSourceOneOf'
             sentAmount:
@@ -6174,12 +6154,26 @@ components:
         - CREATED
         - PENDING
         - PROCESSING
+        - SENT
         - COMPLETED
         - REJECTED
         - FAILED
         - REFUNDED
         - EXPIRED
-      description: Status of a payment transaction
+      description: |
+        Status of a payment transaction.
+
+        | Status | Description |
+        |--------|-------------|
+        | `CREATED` | Initial lookup has been created |
+        | `PENDING` | Quote has been created |
+        | `PROCESSING` | Funding has been received and payment initiated |
+        | `SENT` | Cross border settlement has been initiated |
+        | `COMPLETED` | Cross border payment has been received, converted and payment has been sent to the offramp network |
+        | `REJECTED` | Receiving institution or wallet rejected payment, payment has been refunded |
+        | `FAILED` | An error occurred during payment |
+        | `REFUNDED` | Payment was unable to complete and refunded |
+        | `EXPIRED` | Quote has expired |
     AccountTransactionDestination:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionDestination'
@@ -6213,6 +6207,7 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+          EXTERNAL_ACCOUNT_DETAILS: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
     UmaAddressTransactionDestination:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionDestination'
@@ -6230,11 +6225,27 @@ components:
               description: UMA address of the recipient
               example: $receiver@uma.domain.com
           description: UMA address destination details
+    ExternalAccountDetailsTransactionDestination:
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionDestination'
+        - type: object
+          required:
+            - externalAccountDetails
+            - destinationType
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - EXTERNAL_ACCOUNT_DETAILS
+            externalAccountDetails:
+              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+          description: Transaction destination where external account details were provided inline at quote creation rather than using a pre-registered external account.
     TransactionDestinationType:
       type: string
       enum:
         - ACCOUNT
         - UMA_ADDRESS
+        - EXTERNAL_ACCOUNT_DETAILS
       description: Type of transaction destination
       example: ACCOUNT
     TransactionDestinationOneOf:
@@ -6243,11 +6254,14 @@ components:
           $ref: '#/components/schemas/AccountTransactionDestination'
         - title: UMA Address Destination
           $ref: '#/components/schemas/UmaAddressTransactionDestination'
+        - title: External Account Details Destination
+          $ref: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+          EXTERNAL_ACCOUNT_DETAILS: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
     CounterpartyInformation:
       type: object
       description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
@@ -6256,6 +6270,71 @@ components:
         FULL_NAME: John Sender
         BIRTH_DATE: '1985-06-15'
         NATIONALITY: DE
+    ReconciliationInstructions:
+      type: object
+      required:
+        - reference
+      properties:
+        reference:
+          type: string
+          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
+          example: UMA-Q12345-REF
+    IncomingRateDetails:
+      description: Details about the rate and fees for an incoming transaction.
+      type: object
+      required:
+        - gridApiMultiplier
+        - gridApiFixedFee
+        - gridApiVariableFeeRate
+        - gridApiVariableFeeAmount
+      properties:
+        gridApiMultiplier:
+          type: number
+          format: double
+          description: The underlying multiplier from the mSATS to the receiving currency, including variable fees.
+          exclusiveMinimum: 0
+          example: 0.925
+        gridApiFixedFee:
+          type: integer
+          format: int64
+          description: The fixed fee charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents).
+          minimum: 0
+          example: 10
+        gridApiVariableFeeRate:
+          type: number
+          format: double
+          description: The variable fee rate charged by the Grid product to execute the quote as a percentage of the receiving currency amount.
+          exclusiveMinimum: 0
+          example: 0.003
+        gridApiVariableFeeAmount:
+          type: number
+          format: int64
+          description: The variable fee amount charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents). This is the receiving amount times gridApiVariableFeeRate.
+          minimum: 0
+          example: 30
+    IncomingTransactionFailureReason:
+      type: string
+      enum:
+        - LNURLP_FAILED
+        - PAY_REQUEST_FAILED
+        - PAYMENT_APPROVAL_WEBHOOK_ERROR
+        - PAYMENT_APPROVAL_TIMED_OUT
+        - OFFRAMP_FAILED
+        - MISSING_MANDATORY_PAYEE_DATA
+        - QUOTE_EXPIRED
+        - QUOTE_EXECUTION_FAILED
+      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+    TransactionOneOf:
+      oneOf:
+        - title: Incoming Transaction
+          $ref: '#/components/schemas/IncomingTransaction'
+        - title: Outgoing Transaction
+          $ref: '#/components/schemas/OutgoingTransaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          INCOMING: '#/components/schemas/IncomingTransaction'
+          OUTGOING: '#/components/schemas/OutgoingTransaction'
     CurrencyPreference:
       type: object
       required:
@@ -6378,7 +6457,7 @@ components:
             accountId:
               type: string
               description: Source account identifier
-              example: InternalAccount:85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+              example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
             customerId:
               type: string
               description: Required when funding from an FBO account to identify the customer on whose behalf the transaction is being initiated.  Otherwise, will default to the customerId of the account owner.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1304,7 +1304,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -1398,7 +1398,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -2062,7 +2062,7 @@ paths:
                     type: array
                     description: List of transactions matching the criteria
                     items:
-                      $ref: '#/components/schemas/Transaction'
+                      $ref: '#/components/schemas/TransactionOneOf'
                   hasMore:
                     type: boolean
                     description: Indicates if more results are available beyond this page
@@ -2112,7 +2112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Transaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '401':
           description: Unauthorized
           content:
@@ -5838,6 +5838,32 @@ components:
             Optional Plaid account ID if the customer selected a specific account.
             If not provided, the default account will be used.
           example: plaid_account_id_123
+    IncomingTransaction:
+      allOf:
+        - $ref: '#/components/schemas/Transaction'
+        - type: object
+          required:
+            - type
+            - receivedAmount
+          properties:
+            type:
+              type: string
+              enum:
+                - INCOMING
+            source:
+              $ref: '#/components/schemas/TransactionSourceOneOf'
+            receivedAmount:
+              $ref: '#/components/schemas/CurrencyAmount'
+              description: Amount received in the recipient's currency
+            reconciliationInstructions:
+              $ref: '#/components/schemas/ReconciliationInstructions'
+              description: Included for all transactions except those with "CREATED" status
+            rateDetails:
+              $ref: '#/components/schemas/IncomingRateDetails'
+              description: Details about the rate and fees for the transaction.
+            failureReason:
+              $ref: '#/components/schemas/IncomingTransactionFailureReason'
+              description: If the transaction failed, this field provides the reason for failure.
     Transaction:
       type: object
       required:
@@ -5925,6 +5951,7 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionSource'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionSource'
+          REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     UmaAddressTransactionSource:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionSource'
@@ -5942,6 +5969,27 @@ components:
               description: UMA address of the sender
               example: $sender@uma.domain.com
           description: UMA address source details
+    RealtimeFundingTransactionSource:
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionSource'
+        - type: object
+          required:
+            - currency
+            - sourceType
+          properties:
+            sourceType:
+              type: string
+              enum:
+                - REALTIME_FUNDING
+            customerId:
+              type: string
+              description: The customer on whose behalf the transaction was initiated.
+              example: Customer:019542f5-b3e7-1d02-0000-000000000009
+            currency:
+              type: string
+              description: Currency code for the funding source
+              example: USDC
+          description: Transaction was funded using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
     TransactionSourceType:
       type: string
       enum:
@@ -5956,86 +6004,14 @@ components:
           $ref: '#/components/schemas/AccountTransactionSource'
         - title: UMA Address Source
           $ref: '#/components/schemas/UmaAddressTransactionSource'
+        - title: Real-time Funding Source
+          $ref: '#/components/schemas/RealtimeFundingTransactionSource'
       discriminator:
         propertyName: sourceType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionSource'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionSource'
-    ReconciliationInstructions:
-      type: object
-      required:
-        - reference
-      properties:
-        reference:
-          type: string
-          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
-          example: UMA-Q12345-REF
-    IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
-      type: object
-      required:
-        - gridApiMultiplier
-        - gridApiFixedFee
-        - gridApiVariableFeeRate
-        - gridApiVariableFeeAmount
-      properties:
-        gridApiMultiplier:
-          type: number
-          format: double
-          description: The underlying multiplier from the mSATS to the receiving currency, including variable fees.
-          exclusiveMinimum: 0
-          example: 0.925
-        gridApiFixedFee:
-          type: integer
-          format: int64
-          description: The fixed fee charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents).
-          minimum: 0
-          example: 10
-        gridApiVariableFeeRate:
-          type: number
-          format: double
-          description: The variable fee rate charged by the Grid product to execute the quote as a percentage of the receiving currency amount.
-          exclusiveMinimum: 0
-          example: 0.003
-        gridApiVariableFeeAmount:
-          type: number
-          format: int64
-          description: The variable fee amount charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents). This is the receiving amount times gridApiVariableFeeRate.
-          minimum: 0
-          example: 30
-    IncomingTransactionFailureReason:
-      type: string
-      enum:
-        - LNURLP_FAILED
-        - PAY_REQUEST_FAILED
-        - PAYMENT_APPROVAL_WEBHOOK_ERROR
-        - PAYMENT_APPROVAL_TIMED_OUT
-        - OFFRAMP_FAILED
-        - MISSING_MANDATORY_PAYEE_DATA
-        - QUOTE_EXPIRED
-        - QUOTE_EXECUTION_FAILED
-      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
-    IncomingTransaction:
-      allOf:
-        - $ref: '#/components/schemas/Transaction'
-        - type: object
-          required:
-            - receivedAmount
-          properties:
-            source:
-              $ref: '#/components/schemas/TransactionSourceOneOf'
-            receivedAmount:
-              $ref: '#/components/schemas/CurrencyAmount'
-              description: Amount received in the recipient's currency
-            reconciliationInstructions:
-              $ref: '#/components/schemas/ReconciliationInstructions'
-              description: Included for all transactions except those with "CREATED" status
-            rateDetails:
-              $ref: '#/components/schemas/IncomingRateDetails'
-              description: Details about the rate and fees for the transaction.
-            failureReason:
-              $ref: '#/components/schemas/IncomingTransactionFailureReason'
-              description: If the transaction failed, this field provides the reason for failure.
+          REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     Refund:
       type: object
       required:
@@ -6118,10 +6094,14 @@ components:
         - $ref: '#/components/schemas/Transaction'
         - type: object
           required:
+            - type
             - sentAmount
-            - paymentInstructions
             - source
           properties:
+            type:
+              type: string
+              enum:
+                - OUTGOING
             source:
               $ref: '#/components/schemas/TransactionSourceOneOf'
             sentAmount:
@@ -6174,12 +6154,26 @@ components:
         - CREATED
         - PENDING
         - PROCESSING
+        - SENT
         - COMPLETED
         - REJECTED
         - FAILED
         - REFUNDED
         - EXPIRED
-      description: Status of a payment transaction
+      description: |
+        Status of a payment transaction.
+
+        | Status | Description |
+        |--------|-------------|
+        | `CREATED` | Initial lookup has been created |
+        | `PENDING` | Quote has been created |
+        | `PROCESSING` | Funding has been received and payment initiated |
+        | `SENT` | Cross border settlement has been initiated |
+        | `COMPLETED` | Cross border payment has been received, converted and payment has been sent to the offramp network |
+        | `REJECTED` | Receiving institution or wallet rejected payment, payment has been refunded |
+        | `FAILED` | An error occurred during payment |
+        | `REFUNDED` | Payment was unable to complete and refunded |
+        | `EXPIRED` | Quote has expired |
     AccountTransactionDestination:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionDestination'
@@ -6213,6 +6207,7 @@ components:
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+          EXTERNAL_ACCOUNT_DETAILS: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
     UmaAddressTransactionDestination:
       allOf:
         - $ref: '#/components/schemas/BaseTransactionDestination'
@@ -6230,11 +6225,27 @@ components:
               description: UMA address of the recipient
               example: $receiver@uma.domain.com
           description: UMA address destination details
+    ExternalAccountDetailsTransactionDestination:
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionDestination'
+        - type: object
+          required:
+            - externalAccountDetails
+            - destinationType
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - EXTERNAL_ACCOUNT_DETAILS
+            externalAccountDetails:
+              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+          description: Transaction destination where external account details were provided inline at quote creation rather than using a pre-registered external account.
     TransactionDestinationType:
       type: string
       enum:
         - ACCOUNT
         - UMA_ADDRESS
+        - EXTERNAL_ACCOUNT_DETAILS
       description: Type of transaction destination
       example: ACCOUNT
     TransactionDestinationOneOf:
@@ -6243,11 +6254,14 @@ components:
           $ref: '#/components/schemas/AccountTransactionDestination'
         - title: UMA Address Destination
           $ref: '#/components/schemas/UmaAddressTransactionDestination'
+        - title: External Account Details Destination
+          $ref: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
+          EXTERNAL_ACCOUNT_DETAILS: '#/components/schemas/ExternalAccountDetailsTransactionDestination'
     CounterpartyInformation:
       type: object
       description: Additional information about the counterparty, if available and relevant to the transaction and platform. Only applicable for transactions to/from UMA addresses.
@@ -6256,6 +6270,71 @@ components:
         FULL_NAME: John Sender
         BIRTH_DATE: '1985-06-15'
         NATIONALITY: DE
+    ReconciliationInstructions:
+      type: object
+      required:
+        - reference
+      properties:
+        reference:
+          type: string
+          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
+          example: UMA-Q12345-REF
+    IncomingRateDetails:
+      description: Details about the rate and fees for an incoming transaction.
+      type: object
+      required:
+        - gridApiMultiplier
+        - gridApiFixedFee
+        - gridApiVariableFeeRate
+        - gridApiVariableFeeAmount
+      properties:
+        gridApiMultiplier:
+          type: number
+          format: double
+          description: The underlying multiplier from the mSATS to the receiving currency, including variable fees.
+          exclusiveMinimum: 0
+          example: 0.925
+        gridApiFixedFee:
+          type: integer
+          format: int64
+          description: The fixed fee charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents).
+          minimum: 0
+          example: 10
+        gridApiVariableFeeRate:
+          type: number
+          format: double
+          description: The variable fee rate charged by the Grid product to execute the quote as a percentage of the receiving currency amount.
+          exclusiveMinimum: 0
+          example: 0.003
+        gridApiVariableFeeAmount:
+          type: number
+          format: int64
+          description: The variable fee amount charged by the Grid product to execute the quote in the smallest unit of the receiving currency (eg. cents). This is the receiving amount times gridApiVariableFeeRate.
+          minimum: 0
+          example: 30
+    IncomingTransactionFailureReason:
+      type: string
+      enum:
+        - LNURLP_FAILED
+        - PAY_REQUEST_FAILED
+        - PAYMENT_APPROVAL_WEBHOOK_ERROR
+        - PAYMENT_APPROVAL_TIMED_OUT
+        - OFFRAMP_FAILED
+        - MISSING_MANDATORY_PAYEE_DATA
+        - QUOTE_EXPIRED
+        - QUOTE_EXECUTION_FAILED
+      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+    TransactionOneOf:
+      oneOf:
+        - title: Incoming Transaction
+          $ref: '#/components/schemas/IncomingTransaction'
+        - title: Outgoing Transaction
+          $ref: '#/components/schemas/OutgoingTransaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          INCOMING: '#/components/schemas/IncomingTransaction'
+          OUTGOING: '#/components/schemas/OutgoingTransaction'
     CurrencyPreference:
       type: object
       required:
@@ -6378,7 +6457,7 @@ components:
             accountId:
               type: string
               description: Source account identifier
-              example: InternalAccount:85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+              example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
             customerId:
               type: string
               description: Required when funding from an FBO account to identify the customer on whose behalf the transaction is being initiated.  Otherwise, will default to the customerId of the account owner.

--- a/openapi/components/schemas/quotes/AccountQuoteSource.yaml
+++ b/openapi/components/schemas/quotes/AccountQuoteSource.yaml
@@ -12,7 +12,7 @@ allOf:
       accountId:
         type: string
         description: Source account identifier
-        example: InternalAccount:85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+        example: InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
       customerId:
         type: string
         description: Required when funding from an FBO account to identify the customer on whose behalf the transaction is being initiated.  Otherwise, will default to the customerId of the account owner.

--- a/openapi/components/schemas/transactions/BaseTransactionDestination.yaml
+++ b/openapi/components/schemas/transactions/BaseTransactionDestination.yaml
@@ -13,3 +13,4 @@ discriminator:
   mapping:
     ACCOUNT: ./AccountTransactionDestination.yaml
     UMA_ADDRESS: ./UmaAddressTransactionDestination.yaml
+    EXTERNAL_ACCOUNT_DETAILS: ./ExternalAccountDetailsTransactionDestination.yaml

--- a/openapi/components/schemas/transactions/BaseTransactionSource.yaml
+++ b/openapi/components/schemas/transactions/BaseTransactionSource.yaml
@@ -13,3 +13,4 @@ discriminator:
   mapping:
     ACCOUNT: ./AccountTransactionSource.yaml
     UMA_ADDRESS: ./UmaAddressTransactionSource.yaml
+    REALTIME_FUNDING: ./RealtimeFundingTransactionSource.yaml

--- a/openapi/components/schemas/transactions/ExternalAccountDetailsTransactionDestination.yaml
+++ b/openapi/components/schemas/transactions/ExternalAccountDetailsTransactionDestination.yaml
@@ -1,0 +1,16 @@
+allOf:
+  - $ref: ./BaseTransactionDestination.yaml
+  - type: object
+    required:
+      - externalAccountDetails
+      - destinationType
+    properties:
+      destinationType:
+        type: string
+        enum:
+          - EXTERNAL_ACCOUNT_DETAILS
+      externalAccountDetails:
+        $ref: ../external_accounts/ExternalAccountCreateRequest.yaml
+    description: >-
+      Transaction destination where external account details were provided
+      inline at quote creation rather than using a pre-registered external account.

--- a/openapi/components/schemas/transactions/IncomingTransaction.yaml
+++ b/openapi/components/schemas/transactions/IncomingTransaction.yaml
@@ -2,8 +2,13 @@ allOf:
   - $ref: ./Transaction.yaml
   - type: object
     required:
+      - type
       - receivedAmount
     properties:
+      type:
+        type: string
+        enum:
+          - INCOMING
       source:
         $ref: ./TransactionSourceOneOf.yaml
       receivedAmount:

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -2,10 +2,14 @@ allOf:
   - $ref: ./Transaction.yaml
   - type: object
     required:
+      - type
       - sentAmount
-      - paymentInstructions
       - source
     properties:
+      type:
+        type: string
+        enum:
+          - OUTGOING
       source:
         $ref: ./TransactionSourceOneOf.yaml
       sentAmount:

--- a/openapi/components/schemas/transactions/RealtimeFundingTransactionSource.yaml
+++ b/openapi/components/schemas/transactions/RealtimeFundingTransactionSource.yaml
@@ -1,0 +1,22 @@
+allOf:
+  - $ref: ./BaseTransactionSource.yaml
+  - type: object
+    required:
+      - currency
+      - sourceType
+    properties:
+      sourceType:
+        type: string
+        enum:
+          - REALTIME_FUNDING
+      customerId:
+        type: string
+        description: The customer on whose behalf the transaction was initiated.
+        example: Customer:019542f5-b3e7-1d02-0000-000000000009
+      currency:
+        type: string
+        description: Currency code for the funding source
+        example: USDC
+    description: >-
+      Transaction was funded using a real-time funding source
+      (RTP, SEPA Instant, Spark, Stables, etc.).

--- a/openapi/components/schemas/transactions/TransactionDestinationOneOf.yaml
+++ b/openapi/components/schemas/transactions/TransactionDestinationOneOf.yaml
@@ -3,8 +3,11 @@ oneOf:
     $ref: ./AccountTransactionDestination.yaml
   - title: UMA Address Destination
     $ref: ./UmaAddressTransactionDestination.yaml
+  - title: External Account Details Destination
+    $ref: ./ExternalAccountDetailsTransactionDestination.yaml
 discriminator:
   propertyName: destinationType
   mapping:
     ACCOUNT: ./AccountTransactionDestination.yaml
     UMA_ADDRESS: ./UmaAddressTransactionDestination.yaml
+    EXTERNAL_ACCOUNT_DETAILS: ./ExternalAccountDetailsTransactionDestination.yaml

--- a/openapi/components/schemas/transactions/TransactionDestinationType.yaml
+++ b/openapi/components/schemas/transactions/TransactionDestinationType.yaml
@@ -2,5 +2,6 @@ type: string
 enum:
   - ACCOUNT
   - UMA_ADDRESS
+  - EXTERNAL_ACCOUNT_DETAILS
 description: Type of transaction destination
 example: ACCOUNT

--- a/openapi/components/schemas/transactions/TransactionOneOf.yaml
+++ b/openapi/components/schemas/transactions/TransactionOneOf.yaml
@@ -1,0 +1,10 @@
+oneOf:
+  - title: Incoming Transaction
+    $ref: ./IncomingTransaction.yaml
+  - title: Outgoing Transaction
+    $ref: ./OutgoingTransaction.yaml
+discriminator:
+  propertyName: type
+  mapping:
+    INCOMING: ./IncomingTransaction.yaml
+    OUTGOING: ./OutgoingTransaction.yaml

--- a/openapi/components/schemas/transactions/TransactionSourceOneOf.yaml
+++ b/openapi/components/schemas/transactions/TransactionSourceOneOf.yaml
@@ -3,8 +3,11 @@ oneOf:
     $ref: ./AccountTransactionSource.yaml
   - title: UMA Address Source
     $ref: ./UmaAddressTransactionSource.yaml
+  - title: Real-time Funding Source
+    $ref: ./RealtimeFundingTransactionSource.yaml
 discriminator:
   propertyName: sourceType
   mapping:
     ACCOUNT: ./AccountTransactionSource.yaml
     UMA_ADDRESS: ./UmaAddressTransactionSource.yaml
+    REALTIME_FUNDING: ./RealtimeFundingTransactionSource.yaml

--- a/openapi/components/schemas/transactions/TransactionStatus.yaml
+++ b/openapi/components/schemas/transactions/TransactionStatus.yaml
@@ -3,9 +3,23 @@ enum:
   - CREATED
   - PENDING
   - PROCESSING
+  - SENT
   - COMPLETED
   - REJECTED
   - FAILED
   - REFUNDED
   - EXPIRED
-description: Status of a payment transaction
+description: |
+  Status of a payment transaction.
+
+  | Status | Description |
+  |--------|-------------|
+  | `CREATED` | Initial lookup has been created |
+  | `PENDING` | Quote has been created |
+  | `PROCESSING` | Funding has been received and payment initiated |
+  | `SENT` | Cross border settlement has been initiated |
+  | `COMPLETED` | Cross border payment has been received, converted and payment has been sent to the offramp network |
+  | `REJECTED` | Receiving institution or wallet rejected payment, payment has been refunded |
+  | `FAILED` | An error occurred during payment |
+  | `REFUNDED` | Payment was unable to complete and refunded |
+  | `EXPIRED` | Quote has expired |

--- a/openapi/paths/transactions/transactions.yaml
+++ b/openapi/paths/transactions/transactions.yaml
@@ -106,7 +106,7 @@ get:
                 type: array
                 description: List of transactions matching the criteria
                 items:
-                  $ref: ../../components/schemas/transactions/Transaction.yaml
+                  $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
               hasMore:
                 type: boolean
                 description: Indicates if more results are available beyond this page

--- a/openapi/paths/transactions/transactions_{transactionId}.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}.yaml
@@ -19,7 +19,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/transactions/Transaction.yaml
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
     '401':
       description: Unauthorized
       content:

--- a/openapi/paths/transfers/transfer_in.yaml
+++ b/openapi/paths/transfers/transfer_in.yaml
@@ -71,7 +71,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/transactions/Transaction.yaml
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
     '400':
       description: Bad request - Invalid parameters
       content:

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -69,7 +69,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/transactions/Transaction.yaml
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
     '400':
       description: Bad request - Invalid parameters
       content:


### PR DESCRIPTION
### TL;DR

Fixed transaction schema inheritance by implementing proper polymorphic type handling for transactions.

### What changed?

- Removed the `type` property from the base `Transaction` schema to avoid conflicts when merging with child schemas
- Added required `type` property with specific enum values to both `IncomingTransaction` and `OutgoingTransaction` schemas
- Created a new `TransactionOneOf` schema that uses proper polymorphic discrimination between transaction types
- Updated all API endpoints to reference `TransactionOneOf` instead of the base `Transaction` schema
- Reorganized schema definitions for better clarity and proper inheritance

### How to test?

1. Verify that transaction-related API endpoints return the correct schema based on transaction type
2. Confirm that the OpenAPI documentation correctly shows the discriminated transaction types
3. Test both incoming and outgoing transaction flows to ensure proper type handling

### Why make this change?

The previous schema structure had conflicting type definitions when the base `Transaction` schema was merged with specific transaction type schemas through `allOf`. This change implements proper polymorphic inheritance using the `oneOf` discriminator pattern, ensuring that transaction types are correctly differentiated and validated. This prevents potential issues with schema validation and improves API documentation clarity.