### PR TITLE
fix: correcting resource id names

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6613,7 +6613,7 @@ components:
     Quote:
       type: object
       required:
-        - quoteId
+        - id
         - status
         - expiresAt
         - createdAt
@@ -6627,7 +6627,7 @@ components:
         - feesIncluded
         - transactionId
       properties:
-        quoteId:
+        id:
           type: string
           description: Unique identifier for this quote
           example: Quote:019542f5-b3e7-1d02-0000-000000000006
@@ -6822,11 +6822,11 @@ components:
     BulkCustomerImportJob:
       type: object
       required:
-        - jobId
+        - id
         - status
         - progress
       properties:
-        jobId:
+        id:
           type: string
           description: Unique identifier for the bulk import job
           example: Job:019542f5-b3e7-1d02-0000-000000000006
@@ -7075,7 +7075,7 @@ components:
       type: object
       required:
         - timestamp
-        - webhookId
+        - id
         - type
       properties:
         timestamp:
@@ -7083,7 +7083,7 @@ components:
           format: date-time
           description: ISO8601 timestamp when the webhook was sent (can be used to prevent replay attacks)
           example: '2025-08-15T14:32:00Z'
-        webhookId:
+        id:
           type: string
           description: Unique identifier for this webhook delivery (can be used for idempotency)
           example: Webhook:019542f5-b3e7-1d02-0000-000000000007

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6613,7 +6613,7 @@ components:
     Quote:
       type: object
       required:
-        - quoteId
+        - id
         - status
         - expiresAt
         - createdAt
@@ -6627,7 +6627,7 @@ components:
         - feesIncluded
         - transactionId
       properties:
-        quoteId:
+        id:
           type: string
           description: Unique identifier for this quote
           example: Quote:019542f5-b3e7-1d02-0000-000000000006
@@ -6822,11 +6822,11 @@ components:
     BulkCustomerImportJob:
       type: object
       required:
-        - jobId
+        - id
         - status
         - progress
       properties:
-        jobId:
+        id:
           type: string
           description: Unique identifier for the bulk import job
           example: Job:019542f5-b3e7-1d02-0000-000000000006
@@ -7075,7 +7075,7 @@ components:
       type: object
       required:
         - timestamp
-        - webhookId
+        - id
         - type
       properties:
         timestamp:
@@ -7083,7 +7083,7 @@ components:
           format: date-time
           description: ISO8601 timestamp when the webhook was sent (can be used to prevent replay attacks)
           example: '2025-08-15T14:32:00Z'
-        webhookId:
+        id:
           type: string
           description: Unique identifier for this webhook delivery (can be used for idempotency)
           example: Webhook:019542f5-b3e7-1d02-0000-000000000007

--- a/openapi/components/schemas/customers/BulkCustomerImportJob.yaml
+++ b/openapi/components/schemas/customers/BulkCustomerImportJob.yaml
@@ -1,10 +1,10 @@
 type: object
 required:
-  - jobId
+  - id
   - status
   - progress
 properties:
-  jobId:
+  id:
     type: string
     description: Unique identifier for the bulk import job
     example: Job:019542f5-b3e7-1d02-0000-000000000006

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -1,6 +1,6 @@
 type: object
 required:
-  - quoteId
+  - id
   - status
   - expiresAt
   - createdAt
@@ -14,7 +14,7 @@ required:
   - feesIncluded
   - transactionId
 properties:
-  quoteId:
+  id:
     type: string
     description: Unique identifier for this quote
     example: Quote:019542f5-b3e7-1d02-0000-000000000006

--- a/openapi/components/schemas/webhooks/BaseWebhook.yaml
+++ b/openapi/components/schemas/webhooks/BaseWebhook.yaml
@@ -1,7 +1,7 @@
 type: object
 required:
   - timestamp
-  - webhookId
+  - id
   - type
 properties:
   timestamp:
@@ -11,7 +11,7 @@ properties:
       ISO8601 timestamp when the webhook was sent (can be used to
       prevent replay attacks)
     example: '2025-08-15T14:32:00Z'
-  webhookId:
+  id:
     type: string
     description: >-
       Unique identifier for this webhook delivery (can be used for


### PR DESCRIPTION
### TL;DR

Standardized ID field names across API schemas by renaming specific identifier fields to simply `id`.

### What changed?

Renamed identifier fields in three schema components to follow a consistent naming pattern:
- Changed `quoteId` to `id` in the Quote schema
- Changed `jobId` to `id` in the BulkCustomerImportJob schema
- Changed `webhookId` to `id` in the BaseWebhook schema

These changes were applied to both the combined OpenAPI file and the individual component files.

### How to test?

1. Verify that the API documentation renders correctly with the updated field names
2. Ensure that any client code using these schemas is updated to reference the new field names
3. Confirm that API responses match the updated schema definitions

### Why make this change?

This change standardizes our API response format by using consistent field naming conventions across all resources. Having a uniform `id` field instead of resource-specific identifiers (`quoteId`, `jobId`, `webhookId`) makes the API more intuitive and easier to work with for developers.