### PR TITLE
feat: pointing mintlify docs at stainless generated openapi

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -259,7 +259,7 @@
           },
           {
             "group": "API documentation",
-            "openapi": "openapi.yaml"
+            "openapi": "https://app.stainless.com/api/spec/documented/grid/openapi.documented.yml"
           }
         ]
       }


### PR DESCRIPTION
### TL;DR

Updated the OpenAPI specification URL in the Mintlify documentation configuration.

### What changed?

Changed the OpenAPI specification source from a local file `openapi.yaml` to a remote URL `https://app.stainless.com/api/spec/documented/grid/openapi.documented.yml` in the `docs.json` file.

### How to test?

1. Build and deploy the Mintlify documentation
2. Navigate to the API documentation section
3. Verify that the API documentation is properly loading from the new URL
4. Check that all endpoints and schemas are correctly displayed

### Why make this change?

This change points our documentation to the official Stainless API specification, ensuring that our documentation always reflects the most up-to-date API definitions. Using the remote URL eliminates the need to manually update a local copy of the OpenAPI specification file whenever the API changes.