### PR TITLE
feat: updating stainless.yml to remove base external account

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -400,6 +400,32 @@ openapi:
           - "$.components.schemas.ExternalAccountDetailsDestination.allOf[1].properties"
         keys: [ "destinationType" ]
 
+    # ── BaseExternalAccountInfo: ExternalAccountInfo allOf schemas ──
+    - command: remove
+      reason: >-
+        Remove BaseExternalAccountInfo allOf reference from ExternalAccountInfo
+        schemas to avoid conflicting types when allOf merges them with the
+        base schema
+      args:
+        target:
+          - "$.components.schemas.UsAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.ClabeAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.PixAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.IbanAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.UpiAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.NgnAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.CadAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.GbpAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.PhpAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.SgdAccountExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.SparkWalletExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.LightningExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.SolanaWalletExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.TronWalletExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.PolygonWalletExternalAccountInfo.allOf[0]"
+          - "$.components.schemas.BaseWalletExternalAccountInfo.allOf[0]"
+        keys: [ "$ref" ]
+
     # ── beneficiaryType: beneficiary schemas ──
     - command: remove
       reason: >-


### PR DESCRIPTION
### TL;DR

Remove BaseExternalAccountInfo allOf reference from ExternalAccountInfo schemas to fix type conflicts.

### What changed?

Added a new transformation in the Stainless configuration to remove the `$ref` key from the `allOf[0]` property in multiple ExternalAccountInfo schemas. This affects 16 different account types including UsAccount, ClabeAccount, PixAccount, IbanAccount, and various wallet types.

### How to test?

1. Verify that the OpenAPI schema generation works correctly
2. Ensure that the ExternalAccountInfo schemas no longer have conflicting types when merged with the base schema
3. Confirm that client code generation works as expected with the updated schema

### Why make this change?

The BaseExternalAccountInfo allOf references were causing type conflicts when the allOf operation merged them with the base schema. This change prevents these conflicts by removing the problematic references, resulting in more consistent and accurate type definitions.