### PR TITLE
feat: removing customerId from platformExternalAccount request

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -1050,7 +1050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+              $ref: '#/components/schemas/PlatformExternalAccountCreateRequest'
             examples:
               usBankAccount:
                 summary: Create external US bank account
@@ -5785,6 +5785,22 @@ components:
               default: false
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    PlatformExternalAccountCreateRequest:
+      type: object
+      required:
+        - currency
+        - accountInfo
+      properties:
+        currency:
+          type: string
+          description: The ISO 4217 currency code
+          example: USD
+        platformAccountId:
+          type: string
+          description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+          example: ext_acc_123456
+        accountInfo:
+          $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlaidLinkTokenRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1050,7 +1050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+              $ref: '#/components/schemas/PlatformExternalAccountCreateRequest'
             examples:
               usBankAccount:
                 summary: Create external US bank account
@@ -5785,6 +5785,22 @@ components:
               default: false
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    PlatformExternalAccountCreateRequest:
+      type: object
+      required:
+        - currency
+        - accountInfo
+      properties:
+        currency:
+          type: string
+          description: The ISO 4217 currency code
+          example: USD
+        platformAccountId:
+          type: string
+          description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+          example: ext_acc_123456
+        accountInfo:
+          $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlaidLinkTokenRequest:
       type: object
       required:

--- a/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - currency
+  - accountInfo
+properties:
+  currency:
+    type: string
+    description: The ISO 4217 currency code
+    example: USD
+  platformAccountId:
+    type: string
+    description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+    example: ext_acc_123456
+  accountInfo:
+    $ref: ./ExternalAccountInfoOneOf.yaml

--- a/openapi/paths/platform/platform_external_accounts.yaml
+++ b/openapi/paths/platform/platform_external_accounts.yaml
@@ -79,7 +79,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
+          $ref: ../../components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
         examples:
           usBankAccount:
             summary: Create external US bank account


### PR DESCRIPTION
### TL;DR

Added a new `PlatformExternalAccountCreateRequest` schema with a `platformAccountId` field and updated the platform external accounts endpoint to use this new schema instead of the generic `ExternalAccountCreateRequest`.

### What changed?

- Created a new `PlatformExternalAccountCreateRequest` schema that includes a `platformAccountId` field for platform-specific account identification
- Updated the platform external accounts POST endpoint to reference the new schema
- The new schema maintains the same required fields (`currency` and `accountInfo`) as the original but adds the optional `platformAccountId` field

### How to test?

- Test the platform external accounts creation endpoint with the new `platformAccountId` field
- Verify that existing requests without `platformAccountId` still work as expected
- Confirm that requests with `platformAccountId` properly store and reference the platform's identifier

### Why make this change?

This change allows platforms to associate their own internal account identifiers with external accounts, enabling easier account management and reference within their own systems while maintaining compatibility with the existing API structure.