### PR TITLE
feat: extracting inline schemas to their own schema objects for better code gen

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -82,18 +82,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                umaDomain:
-                  type: string
-                  example: mycompany.com
-                webhookEndpoint:
-                  type: string
-                  example: https://api.mycompany.com/webhooks/uma
-                supportedCurrencies:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/PlatformCurrencyConfig'
+              $ref: '#/components/schemas/PlatformConfigUpdateRequest'
             example:
               umaDomain: mycompany.com
               webhookEndpoint: https://api.mycompany.com/webhooks/uma
@@ -644,20 +633,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  kycUrl:
-                    type: string
-                    description: A hosted KYC link for your customer to complete KYC
-                    example: https://example.com/redirect
-                  platformCustomerId:
-                    type: string
-                    description: The platform id of the customer to onboard
-                    example: 019542f5-b3e7-1d02-0000-000000000001
-                  customerId:
-                    type: string
-                    description: The customer id of the newly created customer on the system
-                    example: Customer:019542f5-b3e7-1d02-0000-000000000001
+                $ref: '#/components/schemas/KycLinkResponse'
         '401':
           description: Unauthorized
           content:
@@ -1259,36 +1235,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - source
-                - destination
-              properties:
-                source:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an external account ID
-                      example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                  description: Source external account details
-                destination:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an internal account ID
-                      example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-                  description: Destination internal account details
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  example: 12550
+              $ref: '#/components/schemas/TransferInRequest'
             examples:
               transferIn:
                 summary: Transfer from external to internal account
@@ -1353,36 +1300,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - source
-                - destination
-              properties:
-                source:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an internal account ID
-                      example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-                  description: Source internal account details
-                destination:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an external account ID
-                      example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                  description: Destination external account details
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  example: 12550
+              $ref: '#/components/schemas/TransferOutRequest'
             examples:
               transferOut:
                 summary: Transfer from internal to external account
@@ -2154,12 +2072,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                receiverCustomerInfo:
-                  type: object
-                  additionalProperties: true
-                  description: Information about the recipient, provided by the platform if requested in the original webhook via `requestedReceiverCustomerInfoFields`.
+              $ref: '#/components/schemas/ApprovePaymentRequest'
       responses:
         '200':
           description: Payment approved successfully
@@ -2220,12 +2133,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-                  description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
-                  example: RESTRICTED_JURISDICTION
+              $ref: '#/components/schemas/RejectPaymentRequest'
       responses:
         '200':
           description: Payment rejected successfully
@@ -2374,20 +2282,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - jobId
-                  - status
-                properties:
-                  jobId:
-                    type: string
-                    description: Unique identifier for the bulk import job
-                    example: Job:019542f5-b3e7-1d02-0000-000000000006
-                  status:
-                    type: string
-                    enum:
-                      - PENDING
-                      - PROCESSING
+                $ref: '#/components/schemas/BulkCustomerImportJobAccepted'
         '401':
           description: Unauthorized
           content:
@@ -2464,33 +2359,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - inviterUma
-              properties:
-                inviterUma:
-                  type: string
-                  description: The UMA address of the customer creating the invitation
-                  example: $inviter@uma.domain
-                firstName:
-                  type: string
-                  description: First name of the invitee to show as part of the invite
-                  example: Alice
-                amountToSend:
-                  description: |
-                    An amount to send (in the smallest unit of the customer's currency) to the invitee when the invitation is claimed.
-                    This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of
-                    the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter
-                    platform either does not send the payment or the payment fails, the invitee will not receive this amount. This
-                    field is primarily used for display purposes on the claiming side of the invitation.
-                  type: integer
-                  format: int64
-                  example: 12550
-                expiresAt:
-                  type: string
-                  format: date-time
-                  description: When the invitation expires (if at all)
-                  example: '2025-09-01T14:30:00Z'
+              $ref: '#/components/schemas/UmaInvitationCreateRequest'
       responses:
         '201':
           description: Invitation created successfully
@@ -2587,14 +2456,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - inviteeUma
-              properties:
-                inviteeUma:
-                  type: string
-                  description: The UMA address of the customer claiming the invitation
-                  example: $invitee@uma.domain
+              $ref: '#/components/schemas/UmaInvitationClaimRequest'
       responses:
         '200':
           description: Invitation claimed successfully
@@ -2704,25 +2566,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - quoteId
-                - currencyCode
-              properties:
-                quoteId:
-                  type: string
-                  description: The unique identifier of the quote
-                  example: Quote:019542f5-b3e7-1d02-0000-000000000006
-                currencyCode:
-                  type: string
-                  description: Currency code for the funds to be sent
-                  example: USD
-                currencyAmount:
-                  type: integer
-                  format: int64
-                  description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
-                  exclusiveMinimum: 0
-                  example: 1000
+              $ref: '#/components/schemas/SandboxSendRequest'
       responses:
         '200':
           description: Funds received successfully
@@ -2776,34 +2620,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - senderUmaAddress
-                - receivingCurrencyCode
-                - receivingCurrencyAmount
-              properties:
-                senderUmaAddress:
-                  type: string
-                  description: UMA address of the sender from the sandbox
-                  example: $success.usd@sandbox.grid.uma.money
-                receiverUmaAddress:
-                  type: string
-                  description: UMA address of the receiver (optional if customerId is provided)
-                  example: $receiver@uma.domain
-                customerId:
-                  type: string
-                  description: System ID of the receiver (optional if receiverUmaAddress is provided)
-                  example: Customer:019542f5-b3e7-1d02-0000-000000000001
-                receivingCurrencyCode:
-                  type: string
-                  description: The currency code for the receiving amount
-                  example: USD
-                receivingCurrencyAmount:
-                  type: integer
-                  format: int64
-                  description: The amount to be received in the smallest unit of the currency (eg. cents)
-                  exclusiveMinimum: 0
-                  example: 1000
+              $ref: '#/components/schemas/SandboxUmaReceiveRequest'
       responses:
         '200':
           description: Payment triggered successfully
@@ -2865,17 +2682,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - amount
-              properties:
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount to add in the smallest unit of the account's currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  exclusiveMinimum: 0
-                  maximum: 100000000000
-                  example: 100000
+              $ref: '#/components/schemas/SandboxFundRequest'
             examples:
               fundUSDAccount:
                 summary: Fund USD internal account with $1,000
@@ -3025,21 +2832,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              title: tokenCreate
-              properties:
-                name:
-                  type: string
-                  description: Name of the token to help identify it
-                  example: Sandbox read-only
-                permissions:
-                  type: array
-                  description: A list of permissions to grant to the token
-                  items:
-                    $ref: '#/components/schemas/Permission'
-              required:
-                - name
-                - permissions
+              $ref: '#/components/schemas/ApiTokenCreateRequest'
       responses:
         '201':
           description: API token created successfully
@@ -4131,6 +3924,19 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    PlatformConfigUpdateRequest:
+      type: object
+      properties:
+        umaDomain:
+          type: string
+          example: mycompany.com
+        webhookEndpoint:
+          type: string
+          example: https://api.mycompany.com/webhooks/uma
+        supportedCurrencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformCurrencyConfig'
     Error400:
       type: object
       required:
@@ -4752,6 +4558,21 @@ components:
         mapping:
           INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdateRequest'
           BUSINESS: '#/components/schemas/BusinessCustomerUpdateRequest'
+    KycLinkResponse:
+      type: object
+      properties:
+        kycUrl:
+          type: string
+          description: A hosted KYC link for your customer to complete KYC
+          example: https://example.com/redirect
+        platformCustomerId:
+          type: string
+          description: The platform id of the customer to onboard
+          example: 019542f5-b3e7-1d02-0000-000000000001
+        customerId:
+          type: string
+          description: The customer id of the newly created customer on the system
+          example: Customer:019542f5-b3e7-1d02-0000-000000000001
     CurrencyAmount:
       type: object
       required:
@@ -5854,6 +5675,37 @@ components:
             Optional Plaid account ID if the customer selected a specific account.
             If not provided, the default account will be used.
           example: plaid_account_id_123
+    TransferInRequest:
+      type: object
+      required:
+        - source
+        - destination
+      properties:
+        source:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an external account ID
+              example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+          description: Source external account details
+        destination:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an internal account ID
+              example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+          description: Destination internal account details
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
     IncomingTransaction:
       allOf:
         - $ref: '#/components/schemas/Transaction'
@@ -6351,6 +6203,37 @@ components:
         mapping:
           INCOMING: '#/components/schemas/IncomingTransaction'
           OUTGOING: '#/components/schemas/OutgoingTransaction'
+    TransferOutRequest:
+      type: object
+      required:
+        - source
+        - destination
+      properties:
+        source:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an internal account ID
+              example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+          description: Source internal account details
+        destination:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an external account ID
+              example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+          description: Destination external account details
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
     CurrencyPreference:
       type: object
       required:
@@ -6792,6 +6675,20 @@ components:
           example:
             FULL_NAME: Jane Receiver
             NATIONALITY: FR
+    ApprovePaymentRequest:
+      type: object
+      properties:
+        receiverCustomerInfo:
+          type: object
+          additionalProperties: true
+          description: Information about the recipient, provided by the platform if requested in the original webhook via `requestedReceiverCustomerInfoFields`.
+    RejectPaymentRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
+          example: RESTRICTED_JURISDICTION
     TestWebhookResponse:
       type: object
       required:
@@ -6809,6 +6706,21 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    BulkCustomerImportJobAccepted:
+      type: object
+      required:
+        - jobId
+        - status
+      properties:
+        jobId:
+          type: string
+          description: Unique identifier for the bulk import job
+          example: Job:019542f5-b3e7-1d02-0000-000000000006
+        status:
+          type: string
+          enum:
+            - PENDING
+            - PROCESSING
     GridError:
       type: object
       title: GridError
@@ -6889,6 +6801,34 @@ components:
           format: date-time
           description: Timestamp when the job completed (only present for COMPLETED or FAILED status)
           example: '2025-08-15T14:32:00Z'
+    UmaInvitationCreateRequest:
+      type: object
+      required:
+        - inviterUma
+      properties:
+        inviterUma:
+          type: string
+          description: The UMA address of the customer creating the invitation
+          example: $inviter@uma.domain
+        firstName:
+          type: string
+          description: First name of the invitee to show as part of the invite
+          example: Alice
+        amountToSend:
+          description: |
+            An amount to send (in the smallest unit of the customer's currency) to the invitee when the invitation is claimed.
+            This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of
+            the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter
+            platform either does not send the payment or the payment fails, the invitee will not receive this amount. This
+            field is primarily used for display purposes on the claiming side of the invitation.
+          type: integer
+          format: int64
+          example: 12550
+        expiresAt:
+          type: string
+          format: date-time
+          description: When the invitation expires (if at all)
+          example: '2025-09-01T14:30:00Z'
     UmaInvitation:
       type: object
       required:
@@ -6947,6 +6887,15 @@ components:
           description: |-
             The amount to send to the invitee when the invitation is claimed. This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter platform either does not send the payment or the payment fails, the invitee will not receive this amount. This field is primarily used for display purposes on the claiming side of the invitation.
             This field is useful for "send-by-link" style customer flows where an inviter can send a payment simply by sharing a link without knowing the receiver's UMA address. Note that these sends can only be sender-locked, meaning that the sender will not know ahead of time how much the receiver will receive in the receiving currency.
+    UmaInvitationClaimRequest:
+      type: object
+      required:
+        - inviteeUma
+      properties:
+        inviteeUma:
+          type: string
+          description: The UMA address of the customer claiming the invitation
+          example: $invitee@uma.domain
     Error403:
       type: object
       required:
@@ -6980,6 +6929,67 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    SandboxSendRequest:
+      type: object
+      required:
+        - quoteId
+        - currencyCode
+      properties:
+        quoteId:
+          type: string
+          description: The unique identifier of the quote
+          example: Quote:019542f5-b3e7-1d02-0000-000000000006
+        currencyCode:
+          type: string
+          description: Currency code for the funds to be sent
+          example: USD
+        currencyAmount:
+          type: integer
+          format: int64
+          description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
+          exclusiveMinimum: 0
+          example: 1000
+    SandboxUmaReceiveRequest:
+      type: object
+      required:
+        - senderUmaAddress
+        - receivingCurrencyCode
+        - receivingCurrencyAmount
+      properties:
+        senderUmaAddress:
+          type: string
+          description: UMA address of the sender from the sandbox
+          example: $success.usd@sandbox.grid.uma.money
+        receiverUmaAddress:
+          type: string
+          description: UMA address of the receiver (optional if customerId is provided)
+          example: $receiver@uma.domain
+        customerId:
+          type: string
+          description: System ID of the receiver (optional if receiverUmaAddress is provided)
+          example: Customer:019542f5-b3e7-1d02-0000-000000000001
+        receivingCurrencyCode:
+          type: string
+          description: The currency code for the receiving amount
+          example: USD
+        receivingCurrencyAmount:
+          type: integer
+          format: int64
+          description: The amount to be received in the smallest unit of the currency (eg. cents)
+          exclusiveMinimum: 0
+          example: 1000
+    SandboxFundRequest:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount to add in the smallest unit of the account's currency (e.g., cents for USD/EUR, satoshis for BTC)
+          exclusiveMinimum: 0
+          maximum: 100000000000
+          example: 100000
     UmaProvider:
       type: object
       properties:
@@ -7069,6 +7079,21 @@ components:
           format: date-time
           description: Last update timestamp
           example: '2025-07-21T17:32:28Z'
+    ApiTokenCreateRequest:
+      type: object
+      required:
+        - name
+        - permissions
+      properties:
+        name:
+          type: string
+          description: Name of the token to help identify it
+          example: Sandbox read-only
+        permissions:
+          type: array
+          description: A list of permissions to grant to the token
+          items:
+            $ref: '#/components/schemas/Permission'
     IncomingPaymentWebhook:
       allOf:
         - $ref: '#/components/schemas/BaseWebhook'

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -1050,7 +1050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+              $ref: '#/components/schemas/PlatformExternalAccountCreateRequest'
             examples:
               usBankAccount:
                 summary: Create external US bank account
@@ -5785,6 +5785,22 @@ components:
               default: false
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    PlatformExternalAccountCreateRequest:
+      type: object
+      required:
+        - currency
+        - accountInfo
+      properties:
+        currency:
+          type: string
+          description: The ISO 4217 currency code
+          example: USD
+        platformAccountId:
+          type: string
+          description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+          example: ext_acc_123456
+        accountInfo:
+          $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlaidLinkTokenRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -82,18 +82,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                umaDomain:
-                  type: string
-                  example: mycompany.com
-                webhookEndpoint:
-                  type: string
-                  example: https://api.mycompany.com/webhooks/uma
-                supportedCurrencies:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/PlatformCurrencyConfig'
+              $ref: '#/components/schemas/PlatformConfigUpdateRequest'
             example:
               umaDomain: mycompany.com
               webhookEndpoint: https://api.mycompany.com/webhooks/uma
@@ -644,20 +633,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  kycUrl:
-                    type: string
-                    description: A hosted KYC link for your customer to complete KYC
-                    example: https://example.com/redirect
-                  platformCustomerId:
-                    type: string
-                    description: The platform id of the customer to onboard
-                    example: 019542f5-b3e7-1d02-0000-000000000001
-                  customerId:
-                    type: string
-                    description: The customer id of the newly created customer on the system
-                    example: Customer:019542f5-b3e7-1d02-0000-000000000001
+                $ref: '#/components/schemas/KycLinkResponse'
         '401':
           description: Unauthorized
           content:
@@ -1259,36 +1235,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - source
-                - destination
-              properties:
-                source:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an external account ID
-                      example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                  description: Source external account details
-                destination:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an internal account ID
-                      example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-                  description: Destination internal account details
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  example: 12550
+              $ref: '#/components/schemas/TransferInRequest'
             examples:
               transferIn:
                 summary: Transfer from external to internal account
@@ -1353,36 +1300,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - source
-                - destination
-              properties:
-                source:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an internal account ID
-                      example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-                  description: Source internal account details
-                destination:
-                  type: object
-                  required:
-                    - accountId
-                  properties:
-                    accountId:
-                      type: string
-                      description: Reference to an external account ID
-                      example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-                  description: Destination external account details
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  example: 12550
+              $ref: '#/components/schemas/TransferOutRequest'
             examples:
               transferOut:
                 summary: Transfer from internal to external account
@@ -2154,12 +2072,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                receiverCustomerInfo:
-                  type: object
-                  additionalProperties: true
-                  description: Information about the recipient, provided by the platform if requested in the original webhook via `requestedReceiverCustomerInfoFields`.
+              $ref: '#/components/schemas/ApprovePaymentRequest'
       responses:
         '200':
           description: Payment approved successfully
@@ -2220,12 +2133,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-                  description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
-                  example: RESTRICTED_JURISDICTION
+              $ref: '#/components/schemas/RejectPaymentRequest'
       responses:
         '200':
           description: Payment rejected successfully
@@ -2374,20 +2282,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - jobId
-                  - status
-                properties:
-                  jobId:
-                    type: string
-                    description: Unique identifier for the bulk import job
-                    example: Job:019542f5-b3e7-1d02-0000-000000000006
-                  status:
-                    type: string
-                    enum:
-                      - PENDING
-                      - PROCESSING
+                $ref: '#/components/schemas/BulkCustomerImportJobAccepted'
         '401':
           description: Unauthorized
           content:
@@ -2464,33 +2359,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - inviterUma
-              properties:
-                inviterUma:
-                  type: string
-                  description: The UMA address of the customer creating the invitation
-                  example: $inviter@uma.domain
-                firstName:
-                  type: string
-                  description: First name of the invitee to show as part of the invite
-                  example: Alice
-                amountToSend:
-                  description: |
-                    An amount to send (in the smallest unit of the customer's currency) to the invitee when the invitation is claimed.
-                    This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of
-                    the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter
-                    platform either does not send the payment or the payment fails, the invitee will not receive this amount. This
-                    field is primarily used for display purposes on the claiming side of the invitation.
-                  type: integer
-                  format: int64
-                  example: 12550
-                expiresAt:
-                  type: string
-                  format: date-time
-                  description: When the invitation expires (if at all)
-                  example: '2025-09-01T14:30:00Z'
+              $ref: '#/components/schemas/UmaInvitationCreateRequest'
       responses:
         '201':
           description: Invitation created successfully
@@ -2587,14 +2456,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - inviteeUma
-              properties:
-                inviteeUma:
-                  type: string
-                  description: The UMA address of the customer claiming the invitation
-                  example: $invitee@uma.domain
+              $ref: '#/components/schemas/UmaInvitationClaimRequest'
       responses:
         '200':
           description: Invitation claimed successfully
@@ -2704,25 +2566,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - quoteId
-                - currencyCode
-              properties:
-                quoteId:
-                  type: string
-                  description: The unique identifier of the quote
-                  example: Quote:019542f5-b3e7-1d02-0000-000000000006
-                currencyCode:
-                  type: string
-                  description: Currency code for the funds to be sent
-                  example: USD
-                currencyAmount:
-                  type: integer
-                  format: int64
-                  description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
-                  exclusiveMinimum: 0
-                  example: 1000
+              $ref: '#/components/schemas/SandboxSendRequest'
       responses:
         '200':
           description: Funds received successfully
@@ -2776,34 +2620,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - senderUmaAddress
-                - receivingCurrencyCode
-                - receivingCurrencyAmount
-              properties:
-                senderUmaAddress:
-                  type: string
-                  description: UMA address of the sender from the sandbox
-                  example: $success.usd@sandbox.grid.uma.money
-                receiverUmaAddress:
-                  type: string
-                  description: UMA address of the receiver (optional if customerId is provided)
-                  example: $receiver@uma.domain
-                customerId:
-                  type: string
-                  description: System ID of the receiver (optional if receiverUmaAddress is provided)
-                  example: Customer:019542f5-b3e7-1d02-0000-000000000001
-                receivingCurrencyCode:
-                  type: string
-                  description: The currency code for the receiving amount
-                  example: USD
-                receivingCurrencyAmount:
-                  type: integer
-                  format: int64
-                  description: The amount to be received in the smallest unit of the currency (eg. cents)
-                  exclusiveMinimum: 0
-                  example: 1000
+              $ref: '#/components/schemas/SandboxUmaReceiveRequest'
       responses:
         '200':
           description: Payment triggered successfully
@@ -2865,17 +2682,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - amount
-              properties:
-                amount:
-                  type: integer
-                  format: int64
-                  description: Amount to add in the smallest unit of the account's currency (e.g., cents for USD/EUR, satoshis for BTC)
-                  exclusiveMinimum: 0
-                  maximum: 100000000000
-                  example: 100000
+              $ref: '#/components/schemas/SandboxFundRequest'
             examples:
               fundUSDAccount:
                 summary: Fund USD internal account with $1,000
@@ -3025,21 +2832,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              title: tokenCreate
-              properties:
-                name:
-                  type: string
-                  description: Name of the token to help identify it
-                  example: Sandbox read-only
-                permissions:
-                  type: array
-                  description: A list of permissions to grant to the token
-                  items:
-                    $ref: '#/components/schemas/Permission'
-              required:
-                - name
-                - permissions
+              $ref: '#/components/schemas/ApiTokenCreateRequest'
       responses:
         '201':
           description: API token created successfully
@@ -4131,6 +3924,19 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    PlatformConfigUpdateRequest:
+      type: object
+      properties:
+        umaDomain:
+          type: string
+          example: mycompany.com
+        webhookEndpoint:
+          type: string
+          example: https://api.mycompany.com/webhooks/uma
+        supportedCurrencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformCurrencyConfig'
     Error400:
       type: object
       required:
@@ -4752,6 +4558,21 @@ components:
         mapping:
           INDIVIDUAL: '#/components/schemas/IndividualCustomerUpdateRequest'
           BUSINESS: '#/components/schemas/BusinessCustomerUpdateRequest'
+    KycLinkResponse:
+      type: object
+      properties:
+        kycUrl:
+          type: string
+          description: A hosted KYC link for your customer to complete KYC
+          example: https://example.com/redirect
+        platformCustomerId:
+          type: string
+          description: The platform id of the customer to onboard
+          example: 019542f5-b3e7-1d02-0000-000000000001
+        customerId:
+          type: string
+          description: The customer id of the newly created customer on the system
+          example: Customer:019542f5-b3e7-1d02-0000-000000000001
     CurrencyAmount:
       type: object
       required:
@@ -5854,6 +5675,37 @@ components:
             Optional Plaid account ID if the customer selected a specific account.
             If not provided, the default account will be used.
           example: plaid_account_id_123
+    TransferInRequest:
+      type: object
+      required:
+        - source
+        - destination
+      properties:
+        source:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an external account ID
+              example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+          description: Source external account details
+        destination:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an internal account ID
+              example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+          description: Destination internal account details
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
     IncomingTransaction:
       allOf:
         - $ref: '#/components/schemas/Transaction'
@@ -6351,6 +6203,37 @@ components:
         mapping:
           INCOMING: '#/components/schemas/IncomingTransaction'
           OUTGOING: '#/components/schemas/OutgoingTransaction'
+    TransferOutRequest:
+      type: object
+      required:
+        - source
+        - destination
+      properties:
+        source:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an internal account ID
+              example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+          description: Source internal account details
+        destination:
+          type: object
+          required:
+            - accountId
+          properties:
+            accountId:
+              type: string
+              description: Reference to an external account ID
+              example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+          description: Destination external account details
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
     CurrencyPreference:
       type: object
       required:
@@ -6792,6 +6675,20 @@ components:
           example:
             FULL_NAME: Jane Receiver
             NATIONALITY: FR
+    ApprovePaymentRequest:
+      type: object
+      properties:
+        receiverCustomerInfo:
+          type: object
+          additionalProperties: true
+          description: Information about the recipient, provided by the platform if requested in the original webhook via `requestedReceiverCustomerInfoFields`.
+    RejectPaymentRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
+          example: RESTRICTED_JURISDICTION
     TestWebhookResponse:
       type: object
       required:
@@ -6809,6 +6706,21 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    BulkCustomerImportJobAccepted:
+      type: object
+      required:
+        - jobId
+        - status
+      properties:
+        jobId:
+          type: string
+          description: Unique identifier for the bulk import job
+          example: Job:019542f5-b3e7-1d02-0000-000000000006
+        status:
+          type: string
+          enum:
+            - PENDING
+            - PROCESSING
     GridError:
       type: object
       title: GridError
@@ -6889,6 +6801,34 @@ components:
           format: date-time
           description: Timestamp when the job completed (only present for COMPLETED or FAILED status)
           example: '2025-08-15T14:32:00Z'
+    UmaInvitationCreateRequest:
+      type: object
+      required:
+        - inviterUma
+      properties:
+        inviterUma:
+          type: string
+          description: The UMA address of the customer creating the invitation
+          example: $inviter@uma.domain
+        firstName:
+          type: string
+          description: First name of the invitee to show as part of the invite
+          example: Alice
+        amountToSend:
+          description: |
+            An amount to send (in the smallest unit of the customer's currency) to the invitee when the invitation is claimed.
+            This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of
+            the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter
+            platform either does not send the payment or the payment fails, the invitee will not receive this amount. This
+            field is primarily used for display purposes on the claiming side of the invitation.
+          type: integer
+          format: int64
+          example: 12550
+        expiresAt:
+          type: string
+          format: date-time
+          description: When the invitation expires (if at all)
+          example: '2025-09-01T14:30:00Z'
     UmaInvitation:
       type: object
       required:
@@ -6947,6 +6887,15 @@ components:
           description: |-
             The amount to send to the invitee when the invitation is claimed. This is optional and if not provided, the invitee will not receive any amount. Note that the actual sending of the amount must be done by the inviter platform once the INVITATION_CLAIMED webhook is received. If the inviter platform either does not send the payment or the payment fails, the invitee will not receive this amount. This field is primarily used for display purposes on the claiming side of the invitation.
             This field is useful for "send-by-link" style customer flows where an inviter can send a payment simply by sharing a link without knowing the receiver's UMA address. Note that these sends can only be sender-locked, meaning that the sender will not know ahead of time how much the receiver will receive in the receiving currency.
+    UmaInvitationClaimRequest:
+      type: object
+      required:
+        - inviteeUma
+      properties:
+        inviteeUma:
+          type: string
+          description: The UMA address of the customer claiming the invitation
+          example: $invitee@uma.domain
     Error403:
       type: object
       required:
@@ -6980,6 +6929,67 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    SandboxSendRequest:
+      type: object
+      required:
+        - quoteId
+        - currencyCode
+      properties:
+        quoteId:
+          type: string
+          description: The unique identifier of the quote
+          example: Quote:019542f5-b3e7-1d02-0000-000000000006
+        currencyCode:
+          type: string
+          description: Currency code for the funds to be sent
+          example: USD
+        currencyAmount:
+          type: integer
+          format: int64
+          description: The amount to send in the smallest unit of the currency (eg. cents). If not provided, the amount will be derived from the quote.
+          exclusiveMinimum: 0
+          example: 1000
+    SandboxUmaReceiveRequest:
+      type: object
+      required:
+        - senderUmaAddress
+        - receivingCurrencyCode
+        - receivingCurrencyAmount
+      properties:
+        senderUmaAddress:
+          type: string
+          description: UMA address of the sender from the sandbox
+          example: $success.usd@sandbox.grid.uma.money
+        receiverUmaAddress:
+          type: string
+          description: UMA address of the receiver (optional if customerId is provided)
+          example: $receiver@uma.domain
+        customerId:
+          type: string
+          description: System ID of the receiver (optional if receiverUmaAddress is provided)
+          example: Customer:019542f5-b3e7-1d02-0000-000000000001
+        receivingCurrencyCode:
+          type: string
+          description: The currency code for the receiving amount
+          example: USD
+        receivingCurrencyAmount:
+          type: integer
+          format: int64
+          description: The amount to be received in the smallest unit of the currency (eg. cents)
+          exclusiveMinimum: 0
+          example: 1000
+    SandboxFundRequest:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount to add in the smallest unit of the account's currency (e.g., cents for USD/EUR, satoshis for BTC)
+          exclusiveMinimum: 0
+          maximum: 100000000000
+          example: 100000
     UmaProvider:
       type: object
       properties:
@@ -7069,6 +7079,21 @@ components:
           format: date-time
           description: Last update timestamp
           example: '2025-07-21T17:32:28Z'
+    ApiTokenCreateRequest:
+      type: object
+      required:
+        - name
+        - permissions
+      properties:
+        name:
+          type: string
+          description: Name of the token to help identify it
+          example: Sandbox read-only
+        permissions:
+          type: array
+          description: A list of permissions to grant to the token
+          items:
+            $ref: '#/components/schemas/Permission'
     IncomingPaymentWebhook:
       allOf:
         - $ref: '#/components/schemas/BaseWebhook'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1050,7 +1050,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExternalAccountCreateRequest'
+              $ref: '#/components/schemas/PlatformExternalAccountCreateRequest'
             examples:
               usBankAccount:
                 summary: Create external US bank account
@@ -5785,6 +5785,22 @@ components:
               default: false
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    PlatformExternalAccountCreateRequest:
+      type: object
+      required:
+        - currency
+        - accountInfo
+      properties:
+        currency:
+          type: string
+          description: The ISO 4217 currency code
+          example: USD
+        platformAccountId:
+          type: string
+          description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+          example: ext_acc_123456
+        accountInfo:
+          $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlaidLinkTokenRequest:
       type: object
       required:

--- a/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
+++ b/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  umaDomain:
+    type: string
+    example: mycompany.com
+  webhookEndpoint:
+    type: string
+    example: https://api.mycompany.com/webhooks/uma
+  supportedCurrencies:
+    type: array
+    items:
+      $ref: ./PlatformCurrencyConfig.yaml

--- a/openapi/components/schemas/customers/BulkCustomerImportJobAccepted.yaml
+++ b/openapi/components/schemas/customers/BulkCustomerImportJobAccepted.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - jobId
+  - status
+properties:
+  jobId:
+    type: string
+    description: Unique identifier for the bulk import job
+    example: Job:019542f5-b3e7-1d02-0000-000000000006
+  status:
+    type: string
+    enum:
+      - PENDING
+      - PROCESSING

--- a/openapi/components/schemas/customers/KycLinkResponse.yaml
+++ b/openapi/components/schemas/customers/KycLinkResponse.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  kycUrl:
+    type: string
+    description: A hosted KYC link for your customer to complete KYC
+    example: "https://example.com/redirect"
+  platformCustomerId:
+    type: string
+    description: The platform id of the customer to onboard
+    example: 019542f5-b3e7-1d02-0000-000000000001
+  customerId:
+    type: string
+    description: The customer id of the newly created customer on the system
+    example: Customer:019542f5-b3e7-1d02-0000-000000000001

--- a/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - currency
+  - accountInfo
+properties:
+  currency:
+    type: string
+    description: The ISO 4217 currency code
+    example: USD
+  platformAccountId:
+    type: string
+    description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
+    example: ext_acc_123456
+  accountInfo:
+    $ref: ./ExternalAccountInfoOneOf.yaml

--- a/openapi/components/schemas/invitations/UmaInvitationClaimRequest.yaml
+++ b/openapi/components/schemas/invitations/UmaInvitationClaimRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - inviteeUma
+properties:
+  inviteeUma:
+    type: string
+    description: The UMA address of the customer claiming the invitation
+    example: $invitee@uma.domain

--- a/openapi/components/schemas/invitations/UmaInvitationCreateRequest.yaml
+++ b/openapi/components/schemas/invitations/UmaInvitationCreateRequest.yaml
@@ -1,0 +1,36 @@
+type: object
+required:
+  - inviterUma
+properties:
+  inviterUma:
+    type: string
+    description: The UMA address of the customer creating the invitation
+    example: $inviter@uma.domain
+  firstName:
+    type: string
+    description: First name of the invitee to show as part of the invite
+    example: Alice
+  amountToSend:
+    description: >
+      An amount to send (in the smallest unit of the customer's currency)
+      to the invitee when the invitation is claimed.
+
+      This is optional and if not provided, the invitee will not
+      receive any amount. Note that the actual sending of
+
+      the amount must be done by the inviter platform once the
+      INVITATION_CLAIMED webhook is received. If the inviter
+
+      platform either does not send the payment or the payment fails,
+      the invitee will not receive this amount. This
+
+      field is primarily used for display purposes on the claiming
+      side of the invitation.
+    type: integer
+    format: int64
+    example: 12550
+  expiresAt:
+    type: string
+    format: date-time
+    description: When the invitation expires (if at all)
+    example: '2025-09-01T14:30:00Z'

--- a/openapi/components/schemas/sandbox/SandboxFundRequest.yaml
+++ b/openapi/components/schemas/sandbox/SandboxFundRequest.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - amount
+properties:
+  amount:
+    type: integer
+    format: int64
+    description: >-
+      Amount to add in the smallest unit of the account's currency (e.g.,
+      cents for USD/EUR, satoshis for BTC)
+    exclusiveMinimum: 0
+    maximum: 100000000000
+    example: 100000

--- a/openapi/components/schemas/sandbox/SandboxSendRequest.yaml
+++ b/openapi/components/schemas/sandbox/SandboxSendRequest.yaml
@@ -1,0 +1,21 @@
+type: object
+required:
+  - quoteId
+  - currencyCode
+properties:
+  quoteId:
+    type: string
+    description: The unique identifier of the quote
+    example: Quote:019542f5-b3e7-1d02-0000-000000000006
+  currencyCode:
+    type: string
+    description: Currency code for the funds to be sent
+    example: USD
+  currencyAmount:
+    type: integer
+    format: int64
+    description: >-
+      The amount to send in the smallest unit of the currency (eg.
+      cents). If not provided, the amount will be derived from the quote.
+    exclusiveMinimum: 0
+    example: 1000

--- a/openapi/components/schemas/sandbox/SandboxUmaReceiveRequest.yaml
+++ b/openapi/components/schemas/sandbox/SandboxUmaReceiveRequest.yaml
@@ -1,0 +1,32 @@
+type: object
+required:
+  - senderUmaAddress
+  - receivingCurrencyCode
+  - receivingCurrencyAmount
+properties:
+  senderUmaAddress:
+    type: string
+    description: UMA address of the sender from the sandbox
+    example: $success.usd@sandbox.grid.uma.money
+  receiverUmaAddress:
+    type: string
+    description: UMA address of the receiver (optional if customerId is provided)
+    example: $receiver@uma.domain
+  customerId:
+    type: string
+    description: >-
+      System ID of the receiver (optional if receiverUmaAddress is
+      provided)
+    example: Customer:019542f5-b3e7-1d02-0000-000000000001
+  receivingCurrencyCode:
+    type: string
+    description: The currency code for the receiving amount
+    example: USD
+  receivingCurrencyAmount:
+    type: integer
+    format: int64
+    description: >-
+      The amount to be received in the smallest unit of the currency
+      (eg. cents)
+    exclusiveMinimum: 0
+    example: 1000

--- a/openapi/components/schemas/tokens/ApiTokenCreateRequest.yaml
+++ b/openapi/components/schemas/tokens/ApiTokenCreateRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - name
+  - permissions
+properties:
+  name:
+    type: string
+    description: Name of the token to help identify it
+    example: Sandbox read-only
+  permissions:
+    type: array
+    description: A list of permissions to grant to the token
+    items:
+      $ref: ./Permission.yaml

--- a/openapi/components/schemas/transactions/ApprovePaymentRequest.yaml
+++ b/openapi/components/schemas/transactions/ApprovePaymentRequest.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  receiverCustomerInfo:
+    type: object
+    additionalProperties: true
+    description: >-
+      Information about the recipient, provided by the platform if
+      requested in the original webhook via
+      `requestedReceiverCustomerInfoFields`.

--- a/openapi/components/schemas/transactions/RejectPaymentRequest.yaml
+++ b/openapi/components/schemas/transactions/RejectPaymentRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  reason:
+    type: string
+    description: >-
+      Optional reason for rejecting the payment. This is just for
+      debugging purposes or can be used for a platform's own purposes.
+    example: RESTRICTED_JURISDICTION

--- a/openapi/components/schemas/transfers/TransferInRequest.yaml
+++ b/openapi/components/schemas/transfers/TransferInRequest.yaml
@@ -1,0 +1,32 @@
+type: object
+required:
+  - source
+  - destination
+properties:
+  source:
+    type: object
+    required:
+      - accountId
+    properties:
+      accountId:
+        type: string
+        description: Reference to an external account ID
+        example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+    description: Source external account details
+  destination:
+    type: object
+    required:
+      - accountId
+    properties:
+      accountId:
+        type: string
+        description: Reference to an internal account ID
+        example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+    description: Destination internal account details
+  amount:
+    type: integer
+    format: int64
+    description: >-
+      Amount in the smallest unit of the currency (e.g., cents for USD/EUR,
+      satoshis for BTC)
+    example: 12550

--- a/openapi/components/schemas/transfers/TransferOutRequest.yaml
+++ b/openapi/components/schemas/transfers/TransferOutRequest.yaml
@@ -1,0 +1,32 @@
+type: object
+required:
+  - source
+  - destination
+properties:
+  source:
+    type: object
+    required:
+      - accountId
+    properties:
+      accountId:
+        type: string
+        description: Reference to an internal account ID
+        example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+    description: Source internal account details
+  destination:
+    type: object
+    required:
+      - accountId
+    properties:
+      accountId:
+        type: string
+        description: Reference to an external account ID
+        example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+    description: Destination external account details
+  amount:
+    type: integer
+    format: int64
+    description: >-
+      Amount in the smallest unit of the currency (e.g., cents for USD/EUR,
+      satoshis for BTC)
+    example: 12550

--- a/openapi/paths/customers/customers_bulk_csv.yaml
+++ b/openapi/paths/customers/customers_bulk_csv.yaml
@@ -118,20 +118,7 @@ post:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - jobId
-              - status
-            properties:
-              jobId:
-                type: string
-                description: Unique identifier for the bulk import job
-                example: Job:019542f5-b3e7-1d02-0000-000000000006
-              status:
-                type: string
-                enum:
-                  - PENDING
-                  - PROCESSING
+            $ref: ../../components/schemas/customers/BulkCustomerImportJobAccepted.yaml
     '401':
       description: Unauthorized
       content:

--- a/openapi/paths/customers/customers_kyc_link.yaml
+++ b/openapi/paths/customers/customers_kyc_link.yaml
@@ -25,20 +25,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              kycUrl:
-                type: string
-                description: A hosted KYC link for your customer to complete KYC
-                example: "https://example.com/redirect"
-              platformCustomerId:
-                type: string
-                description: The platform id of the customer to onboard
-                example: 019542f5-b3e7-1d02-0000-000000000001
-              customerId:
-                type: string
-                description: The customer id of the newly created customer on the system
-                example: Customer:019542f5-b3e7-1d02-0000-000000000001
+            $ref: ../../components/schemas/customers/KycLinkResponse.yaml
     '401':
       description: Unauthorized
       content:

--- a/openapi/paths/invitations/invitations.yaml
+++ b/openapi/paths/invitations/invitations.yaml
@@ -12,42 +12,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - inviterUma
-          properties:
-            inviterUma:
-              type: string
-              description: The UMA address of the customer creating the invitation
-              example: $inviter@uma.domain
-            firstName:
-              type: string
-              description: First name of the invitee to show as part of the invite
-              example: Alice
-            amountToSend:
-              description: >
-                An amount to send (in the smallest unit of the customer's currency)
-                to the invitee when the invitation is claimed.
-
-                This is optional and if not provided, the invitee will not
-                receive any amount. Note that the actual sending of
-
-                the amount must be done by the inviter platform once the
-                INVITATION_CLAIMED webhook is received. If the inviter
-
-                platform either does not send the payment or the payment fails,
-                the invitee will not receive this amount. This
-
-                field is primarily used for display purposes on the claiming
-                side of the invitation.
-              type: integer
-              format: int64
-              example: 12550
-            expiresAt:
-              type: string
-              format: date-time
-              description: When the invitation expires (if at all)
-              example: '2025-09-01T14:30:00Z'
+          $ref: ../../components/schemas/invitations/UmaInvitationCreateRequest.yaml
   responses:
     '201':
       description: Invitation created successfully

--- a/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
@@ -33,14 +33,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - inviteeUma
-          properties:
-            inviteeUma:
-              type: string
-              description: The UMA address of the customer claiming the invitation
-              example: $invitee@uma.domain
+          $ref: ../../components/schemas/invitations/UmaInvitationClaimRequest.yaml
   responses:
     '200':
       description: Invitation claimed successfully

--- a/openapi/paths/platform/config.yaml
+++ b/openapi/paths/platform/config.yaml
@@ -38,18 +38,7 @@ patch:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            umaDomain:
-              type: string
-              example: mycompany.com
-            webhookEndpoint:
-              type: string
-              example: https://api.mycompany.com/webhooks/uma
-            supportedCurrencies:
-              type: array
-              items:
-                $ref: ../../components/schemas/config/PlatformCurrencyConfig.yaml
+          $ref: ../../components/schemas/config/PlatformConfigUpdateRequest.yaml
         example:
           umaDomain: mycompany.com
           webhookEndpoint: https://api.mycompany.com/webhooks/uma

--- a/openapi/paths/platform/platform_external_accounts.yaml
+++ b/openapi/paths/platform/platform_external_accounts.yaml
@@ -79,7 +79,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
+          $ref: ../../components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
         examples:
           usBankAccount:
             summary: Create external US bank account

--- a/openapi/paths/sandbox/sandbox_internal_accounts_{accountId}_fund.yaml
+++ b/openapi/paths/sandbox/sandbox_internal_accounts_{accountId}_fund.yaml
@@ -26,19 +26,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - amount
-          properties:
-            amount:
-              type: integer
-              format: int64
-              description: >-
-                Amount to add in the smallest unit of the account's currency (e.g.,
-                cents for USD/EUR, satoshis for BTC)
-              exclusiveMinimum: 0
-              maximum: 100000000000
-              example: 100000
+          $ref: ../../components/schemas/sandbox/SandboxFundRequest.yaml
         examples:
           fundUSDAccount:
             summary: Fund USD internal account with $1,000

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -15,27 +15,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - quoteId
-            - currencyCode
-          properties:
-            quoteId:
-              type: string
-              description: The unique identifier of the quote
-              example: Quote:019542f5-b3e7-1d02-0000-000000000006
-            currencyCode:
-              type: string
-              description: Currency code for the funds to be sent
-              example: USD
-            currencyAmount:
-              type: integer
-              format: int64
-              description: >-
-                The amount to send in the smallest unit of the currency (eg.
-                cents). If not provided, the amount will be derived from the quote.
-              exclusiveMinimum: 0
-              example: 1000
+          $ref: ../../components/schemas/sandbox/SandboxSendRequest.yaml
   responses:
     '200':
       description: Funds received successfully

--- a/openapi/paths/sandbox/sandbox_uma_receive.yaml
+++ b/openapi/paths/sandbox/sandbox_uma_receive.yaml
@@ -16,38 +16,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - senderUmaAddress
-            - receivingCurrencyCode
-            - receivingCurrencyAmount
-          properties:
-            senderUmaAddress:
-              type: string
-              description: UMA address of the sender from the sandbox
-              example: $success.usd@sandbox.grid.uma.money
-            receiverUmaAddress:
-              type: string
-              description: UMA address of the receiver (optional if customerId is provided)
-              example: $receiver@uma.domain
-            customerId:
-              type: string
-              description: >-
-                System ID of the receiver (optional if receiverUmaAddress is
-                provided)
-              example: Customer:019542f5-b3e7-1d02-0000-000000000001
-            receivingCurrencyCode:
-              type: string
-              description: The currency code for the receiving amount
-              example: USD
-            receivingCurrencyAmount:
-              type: integer
-              format: int64
-              description: >-
-                The amount to be received in the smallest unit of the currency
-                (eg. cents)
-              exclusiveMinimum: 0
-              example: 1000
+          $ref: ../../components/schemas/sandbox/SandboxUmaReceiveRequest.yaml
   responses:
     '200':
       description: Payment triggered successfully

--- a/openapi/paths/tokens/tokens.yaml
+++ b/openapi/paths/tokens/tokens.yaml
@@ -11,21 +11,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          title: tokenCreate
-          properties:
-            name:
-              type: string
-              description: Name of the token to help identify it
-              example: Sandbox read-only
-            permissions:
-              type: array
-              description: A list of permissions to grant to the token
-              items:
-                $ref: ../../components/schemas/tokens/Permission.yaml
-          required:
-            - name
-            - permissions
+          $ref: ../../components/schemas/tokens/ApiTokenCreateRequest.yaml
   responses:
     '201':
       description: API token created successfully

--- a/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
@@ -23,15 +23,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            receiverCustomerInfo:
-              type: object
-              additionalProperties: true
-              description: >-
-                Information about the recipient, provided by the platform if
-                requested in the original webhook via
-                `requestedReceiverCustomerInfoFields`.
+          $ref: ../../components/schemas/transactions/ApprovePaymentRequest.yaml
   responses:
     '200':
       description: Payment approved successfully

--- a/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
@@ -23,14 +23,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            reason:
-              type: string
-              description: >-
-                Optional reason for rejecting the payment. This is just for
-                debugging purposes or can be used for a platform's own purposes.
-              example: RESTRICTED_JURISDICTION
+          $ref: ../../components/schemas/transactions/RejectPaymentRequest.yaml
   responses:
     '200':
       description: Payment rejected successfully

--- a/openapi/paths/transfers/transfer_in.yaml
+++ b/openapi/paths/transfers/transfer_in.yaml
@@ -24,38 +24,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - source
-            - destination
-          properties:
-            source:
-              type: object
-              required:
-                - accountId
-              properties:
-                accountId:
-                  type: string
-                  description: Reference to an external account ID
-                  example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-              description: Source external account details
-            destination:
-              type: object
-              required:
-                - accountId
-              properties:
-                accountId:
-                  type: string
-                  description: Reference to an internal account ID
-                  example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-              description: Destination internal account details
-            amount:
-              type: integer
-              format: int64
-              description: >-
-                Amount in the smallest unit of the currency (e.g., cents for USD/EUR,
-                satoshis for BTC)
-              example: 12550
+          $ref: ../../components/schemas/transfers/TransferInRequest.yaml
         examples:
           transferIn:
             summary: Transfer from external to internal account

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -22,38 +22,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - source
-            - destination
-          properties:
-            source:
-              type: object
-              required:
-                - accountId
-              properties:
-                accountId:
-                  type: string
-                  description: Reference to an internal account ID
-                  example: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
-              description: Source internal account details
-            destination:
-              type: object
-              required:
-                - accountId
-              properties:
-                accountId:
-                  type: string
-                  description: Reference to an external account ID
-                  example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
-              description: Destination external account details
-            amount:
-              type: integer
-              format: int64
-              description: >-
-                Amount in the smallest unit of the currency (e.g., cents for USD/EUR,
-                satoshis for BTC)
-              example: 12550
+          $ref: ../../components/schemas/transfers/TransferOutRequest.yaml
         examples:
           transferOut:
             summary: Transfer from internal to external account


### PR DESCRIPTION
### TL;DR

Refactored OpenAPI specification by extracting inline schema definitions into reusable schema components.

### What changed?

Extracted inline schema definitions from API endpoints into separate reusable schema components in the `components/schemas` section. This affects multiple endpoints including:

- Platform configuration updates (`PlatformConfigUpdateRequest`)
- Customer KYC links (`KycLinkResponse`) 
- Transfer operations (`TransferInRequest`, `TransferOutRequest`)
- Payment approvals/rejections (`ApprovePaymentRequest`, `RejectPaymentRequest`)
- Bulk customer imports (`BulkCustomerImportJobAccepted`)
- UMA invitations (`UmaInvitationCreateRequest`, `UmaInvitationClaimRequest`)
- Sandbox operations (`SandboxSendRequest`, `SandboxUmaReceiveRequest`, `SandboxFundRequest`)
- API token creation (`ApiTokenCreateRequest`)

Each inline schema definition was replaced with a `$ref` reference to the corresponding component schema.

### How to test?

1. Validate the OpenAPI specification using an OpenAPI validator
2. Generate API documentation to ensure all schemas render correctly
3. Test API client generation to verify schema references resolve properly
4. Verify that all endpoint request/response schemas maintain the same structure and validation rules

### Why make this change?

This refactoring improves the OpenAPI specification by:
- Reducing duplication of schema definitions
- Making schemas reusable across multiple endpoints
- Improving maintainability by centralizing schema definitions
- Following OpenAPI best practices for schema organization
- Making the specification more modular and easier to manage