### PR TITLE
fix: constrain chat assistant to 384px on desktop and remove dark background

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -587,6 +587,16 @@ html.dark .navbar-link svg {
   transition: none !important;
 }
 
+/* Remove dark background behind chat area (sticky container + pseudo-elements) */
+div:has(> .chat-assistant-floating-input) {
+  background: transparent !important;
+}
+
+div:has(> .chat-assistant-floating-input)::before,
+.chat-assistant-floating-input > div::before {
+  background: transparent !important;
+}
+
 /* Mobile assistant bar placeholder - make transparent so it doesn't cover content */
 #assistant-bar-placeholder {
   background: transparent !important;
@@ -602,6 +612,14 @@ html.dark .navbar-link svg {
 
   .chat-assistant-floating-input {
     width: calc(100% + 16px) !important;
+  }
+}
+
+/* Desktop: constrain chat bar to 384px and center */
+@media (min-width: 640px) {
+  .chat-assistant-floating-input {
+    max-width: 384px !important;
+    margin: 0 auto !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- Constrains the chat assistant floating input to `max-width: 384px` and centers it on desktop (`>=640px`), overriding Mintlify's new full-width default
- Removes the dark background behind the chat area by making the sticky container and its `::before` pseudo-elements transparent
- Mobile behavior (8px edge-to-edge overflow) is unchanged

## Context

Mintlify pushed a platform update that made the chat assistant `w-full` (confirmed on their Palm theme starter). This is not caused by our CSS — we need to override their new default.

## Test plan

- [x] Desktop: chat bar is ~384px wide, centered, no dark background behind it
- [x] Mobile: chat bar extends 8px past content edges as before
- [x] Light and dark mode both look correct

Made with [Cursor](https://cursor.com)