### PR TITLE
fix: remove remaining title/$ref siblings and add missing titles

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5733,6 +5733,7 @@ components:
                   INDIVIDUAL: '#/components/schemas/BrlBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     CadBeneficiary:
+      title: Individual Beneficiary
       type: object
       required:
         - beneficiaryType
@@ -5776,10 +5777,8 @@ components:
           properties:
             beneficiary:
               oneOf:
-                - title: Individual Beneficiary
-                  $ref: '#/components/schemas/CadBeneficiary'
-                - title: Business Beneficiary
-                  $ref: '#/components/schemas/BusinessBeneficiary'
+                - $ref: '#/components/schemas/CadBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
               discriminator:
                 propertyName: beneficiaryType
                 mapping:
@@ -6202,6 +6201,7 @@ components:
                   INDIVIDUAL: '#/components/schemas/MyrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     NgnBeneficiary:
+      title: Individual Beneficiary
       type: object
       required:
         - beneficiaryType
@@ -6245,10 +6245,8 @@ components:
           properties:
             beneficiary:
               oneOf:
-                - title: Individual Beneficiary
-                  $ref: '#/components/schemas/NgnBeneficiary'
-                - title: Business Beneficiary
-                  $ref: '#/components/schemas/BusinessBeneficiary'
+                - $ref: '#/components/schemas/NgnBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
               discriminator:
                 propertyName: beneficiaryType
                 mapping:
@@ -6571,50 +6569,28 @@ components:
         - $ref: '#/components/schemas/BaseWalletInfo'
     ExternalAccountInfoOneOf:
       oneOf:
-        - title: BRL Account
-          $ref: '#/components/schemas/BrlExternalAccountInfo'
-        - title: CAD Account
-          $ref: '#/components/schemas/CadExternalAccountInfo'
-        - title: DKK Account
-          $ref: '#/components/schemas/DkkExternalAccountInfo'
-        - title: EUR Account
-          $ref: '#/components/schemas/EurExternalAccountInfo'
-        - title: GBP Account
-          $ref: '#/components/schemas/GbpExternalAccountInfo'
-        - title: HKD Account
-          $ref: '#/components/schemas/HkdExternalAccountInfo'
-        - title: IDR Account
-          $ref: '#/components/schemas/IdrExternalAccountInfo'
-        - title: INR Account
-          $ref: '#/components/schemas/InrExternalAccountInfo'
-        - title: MXN Account
-          $ref: '#/components/schemas/MxnExternalAccountInfo'
-        - title: MYR Account
-          $ref: '#/components/schemas/MyrExternalAccountInfo'
-        - title: NGN Account
-          $ref: '#/components/schemas/NgnExternalAccountInfo'
-        - title: PHP Account
-          $ref: '#/components/schemas/PhpExternalAccountInfo'
-        - title: SGD Account
-          $ref: '#/components/schemas/SgdExternalAccountInfo'
-        - title: THB Account
-          $ref: '#/components/schemas/ThbExternalAccountInfo'
-        - title: USD Account
-          $ref: '#/components/schemas/UsdExternalAccountInfo'
-        - title: VND Account
-          $ref: '#/components/schemas/VndExternalAccountInfo'
-        - title: Spark Wallet
-          $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
-        - title: Lightning
-          $ref: '#/components/schemas/LightningExternalAccountInfo'
-        - title: Solana Wallet
-          $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
-        - title: Tron Wallet
-          $ref: '#/components/schemas/TronWalletExternalAccountInfo'
-        - title: Polygon Wallet
-          $ref: '#/components/schemas/PolygonWalletExternalAccountInfo'
-        - title: Base Wallet
-          $ref: '#/components/schemas/BaseWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/BrlExternalAccountInfo'
+        - $ref: '#/components/schemas/CadExternalAccountInfo'
+        - $ref: '#/components/schemas/DkkExternalAccountInfo'
+        - $ref: '#/components/schemas/EurExternalAccountInfo'
+        - $ref: '#/components/schemas/GbpExternalAccountInfo'
+        - $ref: '#/components/schemas/HkdExternalAccountInfo'
+        - $ref: '#/components/schemas/IdrExternalAccountInfo'
+        - $ref: '#/components/schemas/InrExternalAccountInfo'
+        - $ref: '#/components/schemas/MxnExternalAccountInfo'
+        - $ref: '#/components/schemas/MyrExternalAccountInfo'
+        - $ref: '#/components/schemas/NgnExternalAccountInfo'
+        - $ref: '#/components/schemas/PhpExternalAccountInfo'
+        - $ref: '#/components/schemas/SgdExternalAccountInfo'
+        - $ref: '#/components/schemas/ThbExternalAccountInfo'
+        - $ref: '#/components/schemas/UsdExternalAccountInfo'
+        - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/LightningExternalAccountInfo'
+        - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/TronWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/PolygonWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/BaseWalletExternalAccountInfo'
       discriminator:
         propertyName: accountType
         mapping:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5733,6 +5733,7 @@ components:
                   INDIVIDUAL: '#/components/schemas/BrlBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     CadBeneficiary:
+      title: Individual Beneficiary
       type: object
       required:
         - beneficiaryType
@@ -5776,10 +5777,8 @@ components:
           properties:
             beneficiary:
               oneOf:
-                - title: Individual Beneficiary
-                  $ref: '#/components/schemas/CadBeneficiary'
-                - title: Business Beneficiary
-                  $ref: '#/components/schemas/BusinessBeneficiary'
+                - $ref: '#/components/schemas/CadBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
               discriminator:
                 propertyName: beneficiaryType
                 mapping:
@@ -6202,6 +6201,7 @@ components:
                   INDIVIDUAL: '#/components/schemas/MyrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     NgnBeneficiary:
+      title: Individual Beneficiary
       type: object
       required:
         - beneficiaryType
@@ -6245,10 +6245,8 @@ components:
           properties:
             beneficiary:
               oneOf:
-                - title: Individual Beneficiary
-                  $ref: '#/components/schemas/NgnBeneficiary'
-                - title: Business Beneficiary
-                  $ref: '#/components/schemas/BusinessBeneficiary'
+                - $ref: '#/components/schemas/NgnBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
               discriminator:
                 propertyName: beneficiaryType
                 mapping:
@@ -6571,50 +6569,28 @@ components:
         - $ref: '#/components/schemas/BaseWalletInfo'
     ExternalAccountInfoOneOf:
       oneOf:
-        - title: BRL Account
-          $ref: '#/components/schemas/BrlExternalAccountInfo'
-        - title: CAD Account
-          $ref: '#/components/schemas/CadExternalAccountInfo'
-        - title: DKK Account
-          $ref: '#/components/schemas/DkkExternalAccountInfo'
-        - title: EUR Account
-          $ref: '#/components/schemas/EurExternalAccountInfo'
-        - title: GBP Account
-          $ref: '#/components/schemas/GbpExternalAccountInfo'
-        - title: HKD Account
-          $ref: '#/components/schemas/HkdExternalAccountInfo'
-        - title: IDR Account
-          $ref: '#/components/schemas/IdrExternalAccountInfo'
-        - title: INR Account
-          $ref: '#/components/schemas/InrExternalAccountInfo'
-        - title: MXN Account
-          $ref: '#/components/schemas/MxnExternalAccountInfo'
-        - title: MYR Account
-          $ref: '#/components/schemas/MyrExternalAccountInfo'
-        - title: NGN Account
-          $ref: '#/components/schemas/NgnExternalAccountInfo'
-        - title: PHP Account
-          $ref: '#/components/schemas/PhpExternalAccountInfo'
-        - title: SGD Account
-          $ref: '#/components/schemas/SgdExternalAccountInfo'
-        - title: THB Account
-          $ref: '#/components/schemas/ThbExternalAccountInfo'
-        - title: USD Account
-          $ref: '#/components/schemas/UsdExternalAccountInfo'
-        - title: VND Account
-          $ref: '#/components/schemas/VndExternalAccountInfo'
-        - title: Spark Wallet
-          $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
-        - title: Lightning
-          $ref: '#/components/schemas/LightningExternalAccountInfo'
-        - title: Solana Wallet
-          $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
-        - title: Tron Wallet
-          $ref: '#/components/schemas/TronWalletExternalAccountInfo'
-        - title: Polygon Wallet
-          $ref: '#/components/schemas/PolygonWalletExternalAccountInfo'
-        - title: Base Wallet
-          $ref: '#/components/schemas/BaseWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/BrlExternalAccountInfo'
+        - $ref: '#/components/schemas/CadExternalAccountInfo'
+        - $ref: '#/components/schemas/DkkExternalAccountInfo'
+        - $ref: '#/components/schemas/EurExternalAccountInfo'
+        - $ref: '#/components/schemas/GbpExternalAccountInfo'
+        - $ref: '#/components/schemas/HkdExternalAccountInfo'
+        - $ref: '#/components/schemas/IdrExternalAccountInfo'
+        - $ref: '#/components/schemas/InrExternalAccountInfo'
+        - $ref: '#/components/schemas/MxnExternalAccountInfo'
+        - $ref: '#/components/schemas/MyrExternalAccountInfo'
+        - $ref: '#/components/schemas/NgnExternalAccountInfo'
+        - $ref: '#/components/schemas/PhpExternalAccountInfo'
+        - $ref: '#/components/schemas/SgdExternalAccountInfo'
+        - $ref: '#/components/schemas/ThbExternalAccountInfo'
+        - $ref: '#/components/schemas/UsdExternalAccountInfo'
+        - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/LightningExternalAccountInfo'
+        - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/TronWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/PolygonWalletExternalAccountInfo'
+        - $ref: '#/components/schemas/BaseWalletExternalAccountInfo'
       discriminator:
         propertyName: accountType
         mapping:

--- a/openapi/components/schemas/common/CadBeneficiary.yaml
+++ b/openapi/components/schemas/common/CadBeneficiary.yaml
@@ -1,3 +1,4 @@
+title: Individual Beneficiary
 type: object
 required:
 - beneficiaryType

--- a/openapi/components/schemas/common/NgnBeneficiary.yaml
+++ b/openapi/components/schemas/common/NgnBeneficiary.yaml
@@ -1,3 +1,4 @@
+title: Individual Beneficiary
 type: object
 required:
 - beneficiaryType

--- a/openapi/components/schemas/external_accounts/CadExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/CadExternalAccountInfo.yaml
@@ -8,10 +8,8 @@ allOf:
   properties:
     beneficiary:
       oneOf:
-      - title: Individual Beneficiary
-        $ref: ../common/CadBeneficiary.yaml
-      - title: Business Beneficiary
-        $ref: ../common/BusinessBeneficiary.yaml
+      - $ref: ../common/CadBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
       discriminator:
         propertyName: beneficiaryType
         mapping:

--- a/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
@@ -1,48 +1,26 @@
 oneOf:
-- title: BRL Account
-  $ref: ./BrlExternalAccountInfo.yaml
-- title: CAD Account
-  $ref: ./CadExternalAccountInfo.yaml
-- title: DKK Account
-  $ref: ./DkkExternalAccountInfo.yaml
-- title: EUR Account
-  $ref: ./EurExternalAccountInfo.yaml
-- title: GBP Account
-  $ref: ./GbpExternalAccountInfo.yaml
-- title: HKD Account
-  $ref: ./HkdExternalAccountInfo.yaml
-- title: IDR Account
-  $ref: ./IdrExternalAccountInfo.yaml
-- title: INR Account
-  $ref: ./InrExternalAccountInfo.yaml
-- title: MXN Account
-  $ref: ./MxnExternalAccountInfo.yaml
-- title: MYR Account
-  $ref: ./MyrExternalAccountInfo.yaml
-- title: NGN Account
-  $ref: ./NgnExternalAccountInfo.yaml
-- title: PHP Account
-  $ref: ./PhpExternalAccountInfo.yaml
-- title: SGD Account
-  $ref: ./SgdExternalAccountInfo.yaml
-- title: THB Account
-  $ref: ./ThbExternalAccountInfo.yaml
-- title: USD Account
-  $ref: ./UsdExternalAccountInfo.yaml
-- title: VND Account
-  $ref: ./VndExternalAccountInfo.yaml
-- title: Spark Wallet
-  $ref: ./SparkWalletExternalAccountInfo.yaml
-- title: Lightning
-  $ref: ./LightningExternalAccountInfo.yaml
-- title: Solana Wallet
-  $ref: ./SolanaWalletExternalAccountInfo.yaml
-- title: Tron Wallet
-  $ref: ./TronWalletExternalAccountInfo.yaml
-- title: Polygon Wallet
-  $ref: ./PolygonWalletExternalAccountInfo.yaml
-- title: Base Wallet
-  $ref: ./BaseWalletExternalAccountInfo.yaml
+- $ref: ./BrlExternalAccountInfo.yaml
+- $ref: ./CadExternalAccountInfo.yaml
+- $ref: ./DkkExternalAccountInfo.yaml
+- $ref: ./EurExternalAccountInfo.yaml
+- $ref: ./GbpExternalAccountInfo.yaml
+- $ref: ./HkdExternalAccountInfo.yaml
+- $ref: ./IdrExternalAccountInfo.yaml
+- $ref: ./InrExternalAccountInfo.yaml
+- $ref: ./MxnExternalAccountInfo.yaml
+- $ref: ./MyrExternalAccountInfo.yaml
+- $ref: ./NgnExternalAccountInfo.yaml
+- $ref: ./PhpExternalAccountInfo.yaml
+- $ref: ./SgdExternalAccountInfo.yaml
+- $ref: ./ThbExternalAccountInfo.yaml
+- $ref: ./UsdExternalAccountInfo.yaml
+- $ref: ./VndExternalAccountInfo.yaml
+- $ref: ./SparkWalletExternalAccountInfo.yaml
+- $ref: ./LightningExternalAccountInfo.yaml
+- $ref: ./SolanaWalletExternalAccountInfo.yaml
+- $ref: ./TronWalletExternalAccountInfo.yaml
+- $ref: ./PolygonWalletExternalAccountInfo.yaml
+- $ref: ./BaseWalletExternalAccountInfo.yaml
 discriminator:
   propertyName: accountType
   mapping:

--- a/openapi/components/schemas/external_accounts/NgnExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/NgnExternalAccountInfo.yaml
@@ -8,10 +8,8 @@ allOf:
   properties:
     beneficiary:
       oneOf:
-      - title: Individual Beneficiary
-        $ref: ../common/NgnBeneficiary.yaml
-      - title: Business Beneficiary
-        $ref: ../common/BusinessBeneficiary.yaml
+      - $ref: ../common/NgnBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
       discriminator:
         propertyName: beneficiaryType
         mapping:


### PR DESCRIPTION
## Summary
- Remove `title:` lines that were siblings to `$ref:` in `ExternalAccountInfoOneOf.yaml` (22 entries) — these are ignored per the OpenAPI spec and cause Mintlify to not display titles correctly
- Remove the same `title:/$ref:` sibling pattern from `CadExternalAccountInfo` and `NgnExternalAccountInfo` beneficiary oneOf entries (added in #226)
- Add missing `title: Individual Beneficiary` to `CadBeneficiary.yaml` and `NgnBeneficiary.yaml` so Mintlify renders the oneOf type selector properly

## Test plan
- [x] `make build` passes
- [x] `make lint` passes (22 pre-existing warnings, 0 errors)
- [ ] Verify Mintlify renders external account info oneOf type selector with correct labels
- [ ] Verify beneficiary oneOf renders correctly for CAD and NGN accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)