### PR TITLE
Add ZAR KES TSZ ZMW RWF account beneficiary information for grid

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5634,12 +5634,17 @@ components:
         - HKD_ACCOUNT
         - IDR_ACCOUNT
         - INR_ACCOUNT
+        - KES_ACCOUNT
         - MXN_ACCOUNT
         - MYR_ACCOUNT
         - NGN_ACCOUNT
+        - RWF_ACCOUNT
         - THB_ACCOUNT
+        - TZS_ACCOUNT
         - USD_ACCOUNT
         - VND_ACCOUNT
+        - ZAR_ACCOUNT
+        - ZMW_ACCOUNT
       description: Type of external account or wallet
       example: GBP_ACCOUNT
     BaseExternalAccountInfo:
@@ -6096,6 +6101,93 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/InrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    KesAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - KES_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - KE
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Kenyan mobile money phone number
+          example: '+254712345678'
+          pattern: ^\+254[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - M-PESA
+    KesBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    KesExternalAccountInfo:
+      title: KES Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/KesAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/KesBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/KesBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     MxnBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6304,6 +6396,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PhpBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    RwfAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - RWF_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - RW
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Rwandan mobile money phone number
+          example: '+250781234567'
+          pattern: ^\+250[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - AIRTEL
+    RwfBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    RwfExternalAccountInfo:
+      title: RWF Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/RwfAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/RwfBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/RwfBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     SgdBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6407,6 +6587,94 @@ components:
                 propertyName: beneficiaryType
                 mapping:
                   INDIVIDUAL: '#/components/schemas/ThbBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    TzsAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - TZS_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - TZ
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Tanzanian mobile money phone number
+          example: '+255712345678'
+          pattern: ^\+255[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - AIRTEL
+            - VODACOM
+    TzsBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    TzsExternalAccountInfo:
+      title: TZS Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/TzsAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/TzsBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/TzsBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     UsdBeneficiary:
       title: Individual Beneficiary
@@ -6514,6 +6782,184 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/VndBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    ZarAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - accountNumber
+        - bankName
+      properties:
+        accountType:
+          type: string
+          enum:
+            - ZAR_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - ZA
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - BANK_TRANSFER
+        accountNumber:
+          type: string
+          description: South African bank account number
+          example: '1234567890'
+          minLength: 9
+          maxLength: 13
+          pattern: ^[0-9]{9,13}$
+        bankName:
+          type: string
+          description: Name of the bank
+          example: Standard Bank
+    ZarBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    ZarExternalAccountInfo:
+      title: ZAR Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/ZarAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/ZarBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/ZarBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    ZmwAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - ZMW_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - ZM
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Zambian mobile money phone number
+          example: '+260971234567'
+          pattern: ^\+260[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - TNM
+            - AIRTEL
+            - ZAMTEL
+            - MTN
+    ZmwBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    ZmwExternalAccountInfo:
+      title: ZMW Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/ZmwAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/ZmwBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/ZmwBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     SparkWalletExternalAccountInfo:
       title: Spark Wallet
       allOf:
@@ -6577,14 +7023,19 @@ components:
         - $ref: '#/components/schemas/HkdExternalAccountInfo'
         - $ref: '#/components/schemas/IdrExternalAccountInfo'
         - $ref: '#/components/schemas/InrExternalAccountInfo'
+        - $ref: '#/components/schemas/KesExternalAccountInfo'
         - $ref: '#/components/schemas/MxnExternalAccountInfo'
         - $ref: '#/components/schemas/MyrExternalAccountInfo'
         - $ref: '#/components/schemas/NgnExternalAccountInfo'
         - $ref: '#/components/schemas/PhpExternalAccountInfo'
+        - $ref: '#/components/schemas/RwfExternalAccountInfo'
         - $ref: '#/components/schemas/SgdExternalAccountInfo'
         - $ref: '#/components/schemas/ThbExternalAccountInfo'
+        - $ref: '#/components/schemas/TzsExternalAccountInfo'
         - $ref: '#/components/schemas/UsdExternalAccountInfo'
         - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/ZarExternalAccountInfo'
+        - $ref: '#/components/schemas/ZmwExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
         - $ref: '#/components/schemas/LightningExternalAccountInfo'
         - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
@@ -6602,14 +7053,19 @@ components:
           HKD_ACCOUNT: '#/components/schemas/HkdExternalAccountInfo'
           IDR_ACCOUNT: '#/components/schemas/IdrExternalAccountInfo'
           INR_ACCOUNT: '#/components/schemas/InrExternalAccountInfo'
+          KES_ACCOUNT: '#/components/schemas/KesExternalAccountInfo'
           MXN_ACCOUNT: '#/components/schemas/MxnExternalAccountInfo'
           MYR_ACCOUNT: '#/components/schemas/MyrExternalAccountInfo'
           NGN_ACCOUNT: '#/components/schemas/NgnExternalAccountInfo'
           PHP_ACCOUNT: '#/components/schemas/PhpExternalAccountInfo'
+          RWF_ACCOUNT: '#/components/schemas/RwfExternalAccountInfo'
           SGD_ACCOUNT: '#/components/schemas/SgdExternalAccountInfo'
           THB_ACCOUNT: '#/components/schemas/ThbExternalAccountInfo'
+          TZS_ACCOUNT: '#/components/schemas/TzsExternalAccountInfo'
           USD_ACCOUNT: '#/components/schemas/UsdExternalAccountInfo'
           VND_ACCOUNT: '#/components/schemas/VndExternalAccountInfo'
+          ZAR_ACCOUNT: '#/components/schemas/ZarExternalAccountInfo'
+          ZMW_ACCOUNT: '#/components/schemas/ZmwExternalAccountInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'
           LIGHTNING: '#/components/schemas/LightningExternalAccountInfo'
           SOLANA_WALLET: '#/components/schemas/SolanaWalletExternalAccountInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5634,12 +5634,17 @@ components:
         - HKD_ACCOUNT
         - IDR_ACCOUNT
         - INR_ACCOUNT
+        - KES_ACCOUNT
         - MXN_ACCOUNT
         - MYR_ACCOUNT
         - NGN_ACCOUNT
+        - RWF_ACCOUNT
         - THB_ACCOUNT
+        - TZS_ACCOUNT
         - USD_ACCOUNT
         - VND_ACCOUNT
+        - ZAR_ACCOUNT
+        - ZMW_ACCOUNT
       description: Type of external account or wallet
       example: GBP_ACCOUNT
     BaseExternalAccountInfo:
@@ -6096,6 +6101,93 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/InrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    KesAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - KES_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - KE
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Kenyan mobile money phone number
+          example: '+254712345678'
+          pattern: ^\+254[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - M-PESA
+    KesBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    KesExternalAccountInfo:
+      title: KES Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/KesAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/KesBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/KesBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     MxnBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6304,6 +6396,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PhpBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    RwfAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - RWF_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - RW
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Rwandan mobile money phone number
+          example: '+250781234567'
+          pattern: ^\+250[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - AIRTEL
+    RwfBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    RwfExternalAccountInfo:
+      title: RWF Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/RwfAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/RwfBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/RwfBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     SgdBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6407,6 +6587,94 @@ components:
                 propertyName: beneficiaryType
                 mapping:
                   INDIVIDUAL: '#/components/schemas/ThbBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    TzsAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - TZS_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - TZ
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Tanzanian mobile money phone number
+          example: '+255712345678'
+          pattern: ^\+255[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - AIRTEL
+            - VODACOM
+    TzsBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    TzsExternalAccountInfo:
+      title: TZS Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/TzsAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/TzsBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/TzsBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     UsdBeneficiary:
       title: Individual Beneficiary
@@ -6514,6 +6782,184 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/VndBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    ZarAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - accountNumber
+        - bankName
+      properties:
+        accountType:
+          type: string
+          enum:
+            - ZAR_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - ZA
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - BANK_TRANSFER
+        accountNumber:
+          type: string
+          description: South African bank account number
+          example: '1234567890'
+          minLength: 9
+          maxLength: 13
+          pattern: ^[0-9]{9,13}$
+        bankName:
+          type: string
+          description: Name of the bank
+          example: Standard Bank
+    ZarBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    ZarExternalAccountInfo:
+      title: ZAR Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/ZarAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/ZarBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/ZarBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    ZmwAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - ZMW_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - ZM
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Zambian mobile money phone number
+          example: '+260971234567'
+          pattern: ^\+260[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - TNM
+            - AIRTEL
+            - ZAMTEL
+            - MTN
+    ZmwBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    ZmwExternalAccountInfo:
+      title: ZMW Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/ZmwAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/ZmwBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/ZmwBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     SparkWalletExternalAccountInfo:
       title: Spark Wallet
       allOf:
@@ -6577,14 +7023,19 @@ components:
         - $ref: '#/components/schemas/HkdExternalAccountInfo'
         - $ref: '#/components/schemas/IdrExternalAccountInfo'
         - $ref: '#/components/schemas/InrExternalAccountInfo'
+        - $ref: '#/components/schemas/KesExternalAccountInfo'
         - $ref: '#/components/schemas/MxnExternalAccountInfo'
         - $ref: '#/components/schemas/MyrExternalAccountInfo'
         - $ref: '#/components/schemas/NgnExternalAccountInfo'
         - $ref: '#/components/schemas/PhpExternalAccountInfo'
+        - $ref: '#/components/schemas/RwfExternalAccountInfo'
         - $ref: '#/components/schemas/SgdExternalAccountInfo'
         - $ref: '#/components/schemas/ThbExternalAccountInfo'
+        - $ref: '#/components/schemas/TzsExternalAccountInfo'
         - $ref: '#/components/schemas/UsdExternalAccountInfo'
         - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/ZarExternalAccountInfo'
+        - $ref: '#/components/schemas/ZmwExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
         - $ref: '#/components/schemas/LightningExternalAccountInfo'
         - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
@@ -6602,14 +7053,19 @@ components:
           HKD_ACCOUNT: '#/components/schemas/HkdExternalAccountInfo'
           IDR_ACCOUNT: '#/components/schemas/IdrExternalAccountInfo'
           INR_ACCOUNT: '#/components/schemas/InrExternalAccountInfo'
+          KES_ACCOUNT: '#/components/schemas/KesExternalAccountInfo'
           MXN_ACCOUNT: '#/components/schemas/MxnExternalAccountInfo'
           MYR_ACCOUNT: '#/components/schemas/MyrExternalAccountInfo'
           NGN_ACCOUNT: '#/components/schemas/NgnExternalAccountInfo'
           PHP_ACCOUNT: '#/components/schemas/PhpExternalAccountInfo'
+          RWF_ACCOUNT: '#/components/schemas/RwfExternalAccountInfo'
           SGD_ACCOUNT: '#/components/schemas/SgdExternalAccountInfo'
           THB_ACCOUNT: '#/components/schemas/ThbExternalAccountInfo'
+          TZS_ACCOUNT: '#/components/schemas/TzsExternalAccountInfo'
           USD_ACCOUNT: '#/components/schemas/UsdExternalAccountInfo'
           VND_ACCOUNT: '#/components/schemas/VndExternalAccountInfo'
+          ZAR_ACCOUNT: '#/components/schemas/ZarExternalAccountInfo'
+          ZMW_ACCOUNT: '#/components/schemas/ZmwExternalAccountInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'
           LIGHTNING: '#/components/schemas/LightningExternalAccountInfo'
           SOLANA_WALLET: '#/components/schemas/SolanaWalletExternalAccountInfo'

--- a/openapi/components/schemas/common/KesAccountInfo.yaml
+++ b/openapi/components/schemas/common/KesAccountInfo.yaml
@@ -1,0 +1,34 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - KES_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - KE
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Kenyan mobile money phone number
+    example: '+254712345678'
+    pattern: ^\+254[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - M-PESA

--- a/openapi/components/schemas/common/KesBeneficiary.yaml
+++ b/openapi/components/schemas/common/KesBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/RwfAccountInfo.yaml
+++ b/openapi/components/schemas/common/RwfAccountInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - RWF_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - RW
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Rwandan mobile money phone number
+    example: '+250781234567'
+    pattern: ^\+250[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - MTN
+      - AIRTEL

--- a/openapi/components/schemas/common/RwfBeneficiary.yaml
+++ b/openapi/components/schemas/common/RwfBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/TzsAccountInfo.yaml
+++ b/openapi/components/schemas/common/TzsAccountInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - TZS_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - TZ
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Tanzanian mobile money phone number
+    example: '+255712345678'
+    pattern: ^\+255[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - AIRTEL
+      - VODACOM

--- a/openapi/components/schemas/common/TzsBeneficiary.yaml
+++ b/openapi/components/schemas/common/TzsBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/ZarAccountInfo.yaml
+++ b/openapi/components/schemas/common/ZarAccountInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - accountNumber
+  - bankName
+properties:
+  accountType:
+    type: string
+    enum:
+      - ZAR_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - ZA
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - BANK_TRANSFER
+  accountNumber:
+    type: string
+    description: South African bank account number
+    example: '1234567890'
+    minLength: 9
+    maxLength: 13
+    pattern: ^[0-9]{9,13}$
+  bankName:
+    type: string
+    description: Name of the bank
+    example: Standard Bank

--- a/openapi/components/schemas/common/ZarBeneficiary.yaml
+++ b/openapi/components/schemas/common/ZarBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/ZmwAccountInfo.yaml
+++ b/openapi/components/schemas/common/ZmwAccountInfo.yaml
@@ -1,0 +1,37 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - ZMW_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - ZM
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Zambian mobile money phone number
+    example: '+260971234567'
+    pattern: ^\+260[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - TNM
+      - AIRTEL
+      - ZAMTEL
+      - MTN

--- a/openapi/components/schemas/common/ZmwBeneficiary.yaml
+++ b/openapi/components/schemas/common/ZmwBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
@@ -7,14 +7,19 @@ oneOf:
 - $ref: ./HkdExternalAccountInfo.yaml
 - $ref: ./IdrExternalAccountInfo.yaml
 - $ref: ./InrExternalAccountInfo.yaml
+- $ref: ./KesExternalAccountInfo.yaml
 - $ref: ./MxnExternalAccountInfo.yaml
 - $ref: ./MyrExternalAccountInfo.yaml
 - $ref: ./NgnExternalAccountInfo.yaml
 - $ref: ./PhpExternalAccountInfo.yaml
+- $ref: ./RwfExternalAccountInfo.yaml
 - $ref: ./SgdExternalAccountInfo.yaml
 - $ref: ./ThbExternalAccountInfo.yaml
+- $ref: ./TzsExternalAccountInfo.yaml
 - $ref: ./UsdExternalAccountInfo.yaml
 - $ref: ./VndExternalAccountInfo.yaml
+- $ref: ./ZarExternalAccountInfo.yaml
+- $ref: ./ZmwExternalAccountInfo.yaml
 - $ref: ./SparkWalletExternalAccountInfo.yaml
 - $ref: ./LightningExternalAccountInfo.yaml
 - $ref: ./SolanaWalletExternalAccountInfo.yaml
@@ -32,14 +37,19 @@ discriminator:
     HKD_ACCOUNT: ./HkdExternalAccountInfo.yaml
     IDR_ACCOUNT: ./IdrExternalAccountInfo.yaml
     INR_ACCOUNT: ./InrExternalAccountInfo.yaml
+    KES_ACCOUNT: ./KesExternalAccountInfo.yaml
     MXN_ACCOUNT: ./MxnExternalAccountInfo.yaml
     MYR_ACCOUNT: ./MyrExternalAccountInfo.yaml
     NGN_ACCOUNT: ./NgnExternalAccountInfo.yaml
     PHP_ACCOUNT: ./PhpExternalAccountInfo.yaml
+    RWF_ACCOUNT: ./RwfExternalAccountInfo.yaml
     SGD_ACCOUNT: ./SgdExternalAccountInfo.yaml
     THB_ACCOUNT: ./ThbExternalAccountInfo.yaml
+    TZS_ACCOUNT: ./TzsExternalAccountInfo.yaml
     USD_ACCOUNT: ./UsdExternalAccountInfo.yaml
     VND_ACCOUNT: ./VndExternalAccountInfo.yaml
+    ZAR_ACCOUNT: ./ZarExternalAccountInfo.yaml
+    ZMW_ACCOUNT: ./ZmwExternalAccountInfo.yaml
     SPARK_WALLET: ./SparkWalletExternalAccountInfo.yaml
     LIGHTNING: ./LightningExternalAccountInfo.yaml
     SOLANA_WALLET: ./SolanaWalletExternalAccountInfo.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
@@ -16,11 +16,16 @@ enum:
   - HKD_ACCOUNT
   - IDR_ACCOUNT
   - INR_ACCOUNT
+  - KES_ACCOUNT
   - MXN_ACCOUNT
   - MYR_ACCOUNT
   - NGN_ACCOUNT
+  - RWF_ACCOUNT
   - THB_ACCOUNT
+  - TZS_ACCOUNT
   - USD_ACCOUNT
   - VND_ACCOUNT
+  - ZAR_ACCOUNT
+  - ZMW_ACCOUNT
 description: Type of external account or wallet
 example: GBP_ACCOUNT

--- a/openapi/components/schemas/external_accounts/KesExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/KesExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: KES Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/KesAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/KesBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/KesBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/RwfExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/RwfExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: RWF Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/RwfAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/RwfBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/RwfBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/TzsExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/TzsExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: TZS Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/TzsAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/TzsBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/TzsBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/ZarExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/ZarExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: ZAR Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/ZarAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/ZarBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/ZarBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/ZmwExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/ZmwExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: ZMW Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/ZmwAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/ZmwBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/ZmwBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml


### PR DESCRIPTION
### TL;DR

Added support for 5 new African currencies (KES, RWF, TZS, ZAR, ZMW) with mobile money and bank transfer payment methods, plus set minimum Node.js version requirement to 18.0.0.

### What changed?

- Added 5 new external account types: KES_ACCOUNT, RWF_ACCOUNT, TZS_ACCOUNT, ZAR_ACCOUNT, ZMW_ACCOUNT
- Implemented mobile money support for Kenya (M-PESA), Rwanda (MTN, AIRTEL), Tanzania (AIRTEL, VODACOM), and Zambia (TNM, AIRTEL, ZAMTEL, MTN)
- Added bank transfer support for South Africa with account number and bank name validation
- Created complete schema definitions including account info, beneficiary info, and external account info for each new currency
- Added phone number validation patterns specific to each country's format
- Integrated all new account types into the discriminator mappings and oneOf schemas

### How to test?

- Test creating external accounts for each new currency type (KES, RWF, TZS, ZAR, ZMW)
- Validate phone number formats for mobile money accounts match country-specific patterns
- Test bank account creation for ZAR accounts with proper account number validation
- Confirm all mobile money providers are accepted for their respective countries

### Why make this change?

This change expands payment coverage to key African markets by adding support for popular local payment methods like M-PESA in Kenya and various mobile money providers across East and Southern Africa.