### PR TITLE
fix: correct USD external account examples to match schema

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -870,7 +870,11 @@ paths:
                   customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                   currency: USD
                   accountInfo:
-                    accountType: US_ACCOUNT
+                    accountType: USD_ACCOUNT
+                    countries:
+                      - US
+                    paymentRails:
+                      - ACH
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
                     accountCategory: CHECKING
@@ -1006,7 +1010,11 @@ paths:
                 value:
                   currency: USD
                   accountInfo:
-                    accountType: US_ACCOUNT
+                    accountType: USD_ACCOUNT
+                    countries:
+                      - US
+                    paymentRails:
+                      - ACH
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
                     accountCategory: CHECKING

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -870,7 +870,11 @@ paths:
                   customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                   currency: USD
                   accountInfo:
-                    accountType: US_ACCOUNT
+                    accountType: USD_ACCOUNT
+                    countries:
+                      - US
+                    paymentRails:
+                      - ACH
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
                     accountCategory: CHECKING
@@ -1006,7 +1010,11 @@ paths:
                 value:
                   currency: USD
                   accountInfo:
-                    accountType: US_ACCOUNT
+                    accountType: USD_ACCOUNT
+                    countries:
+                      - US
+                    paymentRails:
+                      - ACH
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
                     accountCategory: CHECKING

--- a/openapi/paths/customers/customers_external_accounts.yaml
+++ b/openapi/paths/customers/customers_external_accounts.yaml
@@ -124,7 +124,11 @@ post:
               customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
               currency: USD
               accountInfo:
-                accountType: US_ACCOUNT
+                accountType: USD_ACCOUNT
+                countries:
+                  - US
+                paymentRails:
+                  - ACH
                 accountNumber: "12345678901"
                 routingNumber: "123456789"
                 accountCategory: CHECKING

--- a/openapi/paths/platform/platform_external_accounts.yaml
+++ b/openapi/paths/platform/platform_external_accounts.yaml
@@ -86,7 +86,11 @@ post:
             value:
               currency: USD
               accountInfo:
-                accountType: US_ACCOUNT
+                accountType: USD_ACCOUNT
+                countries:
+                  - US
+                paymentRails:
+                  - ACH
                 accountNumber: "12345678901"
                 routingNumber: "123456789"
                 accountCategory: CHECKING


### PR DESCRIPTION
## Summary
- Fixed `usBankAccount` examples in both customer and platform external account endpoints
- Changed invalid `accountType: US_ACCOUNT` to `USD_ACCOUNT` to match the `UsdAccountInfo` schema discriminator
- Added missing required fields `countries` and `paymentRails`

## Test plan
- [x] `make lint` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)