### PR TITLE
feat: add cryptoNetwork field to RealtimeFundingQuoteSource

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -7751,6 +7751,10 @@ components:
               type: string
               description: Currency code for the funding source. See [Supported Currencies](https://grid.lightspark.com/platform-overview/core-concepts/currencies-and-rails) for the full list of supported fiat and crypto currencies.
               example: USD
+            cryptoNetwork:
+              type: string
+              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`.'
+              example: SOLANA_MAINNET
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:
       oneOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7751,6 +7751,10 @@ components:
               type: string
               description: Currency code for the funding source. See [Supported Currencies](https://grid.lightspark.com/platform-overview/core-concepts/currencies-and-rails) for the full list of supported fiat and crypto currencies.
               example: USD
+            cryptoNetwork:
+              type: string
+              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`.'
+              example: SOLANA_MAINNET
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:
       oneOf:

--- a/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
+++ b/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
@@ -23,6 +23,14 @@ allOf:
           [Supported Currencies](https://grid.lightspark.com/platform-overview/core-concepts/currencies-and-rails)
           for the full list of supported fiat and crypto currencies.
         example: USD
+      cryptoNetwork:
+        type: string
+        description: >-
+          The crypto network to use for the funding source. Required when `currency` is a
+          stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit
+          on, so the correct deposit address can be generated. Example values:
+          `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`.
+        example: SOLANA_MAINNET
     description: >-
       Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
       This will require manual just-in-time funding using `paymentInstructions` in the response.


### PR DESCRIPTION
## Summary

Adds an optional `cryptoNetwork` field to `RealtimeFundingQuoteSource`.

Callers depositing stablecoins (USDC, USDT) via realtime funding need to specify which network they are depositing on so the server can generate a deposit address on the correct network. Without this field, the server has to hardcode the network (e.g. Solana devnet for sandbox), which won't work when production supports multiple networks.

The field is **optional** for backward compatibility — existing fiat realtime funding sources (USD, MXN, etc.) are unaffected.

## Usage

```json
{
  "source": {
    "sourceType": "REALTIME_FUNDING",
    "currency": "USDC",
    "cryptoNetwork": "SOLANA_MAINNET",
    "customerId": "Customer:..."
  }
}
```

## Test plan

- [ ] Confirm existing fiat realtime funding quote tests still pass (no `cryptoNetwork` required)
- [ ] Confirm USDC realtime funding quote with `cryptoNetwork: "SOLANA_MAINNET"` returns a Solana deposit address
- [ ] OpenAPI lint passes (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)