### PR TITLE
Remove IMPS as payment rail for INR accounts

### DIFF
--- a/components/grid-visualizer/src/data/currencies.ts
+++ b/components/grid-visualizer/src/data/currencies.ts
@@ -72,7 +72,7 @@ export const currencies: FiatCurrency[] = [
     accountType: 'UPI',
     accountLabel: 'UPI',
     instantRails: ['UPI'],
-    allRails: ['UPI', 'IMPS'],
+    allRails: ['UPI'],
     examplePerson: { fullName: 'Priya Sharma', nationality: 'IN' },
   },
   {

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4783,7 +4783,6 @@ components:
             type: string
             enum:
               - UPI
-              - IMPS
         vpa:
           type: string
           description: The VPA of the bank

--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -42,7 +42,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇭🇰 Hong Kong | HK | `Bank Transfer` |
 | 🇭🇺 Hungary | HU | `SEPA` `SEPA Instant` |
 | 🇮🇸 Iceland | IS | `SEPA` `SEPA Instant` |
-| 🇮🇳 India | IN | `UPI` `IMPS` |
+| 🇮🇳 India | IN | `UPI` |
 | 🇮🇩 Indonesia | ID | `Bank Transfer` |
 | 🇮🇪 Ireland | IE | `SEPA` `SEPA Instant` |
 | 🇮🇹 Italy | IT | `SEPA` `SEPA Instant` |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4783,7 +4783,6 @@ components:
             type: string
             enum:
               - UPI
-              - IMPS
         vpa:
           type: string
           description: The VPA of the bank

--- a/openapi/components/schemas/common/InrAccountInfo.yaml
+++ b/openapi/components/schemas/common/InrAccountInfo.yaml
@@ -14,7 +14,6 @@ properties:
       type: string
       enum:
       - UPI
-      - IMPS
   vpa:
     type: string
     description: The VPA of the bank


### PR DESCRIPTION
## Summary
- Removes IMPS from the `paymentRails` enum in the INR account OpenAPI schema
- Updates the country support docs to list only UPI for India
- Updates the grid visualizer currency data to remove IMPS from INR rails

## Test plan
- [ ] Verify `make build` and `make lint` pass
- [ ] Confirm API reference pages render correctly with only UPI for INR

🤖 Generated with [Claude Code](https://claude.com/claude-code)