### PR TITLE
Add support for MWK, UGX, and XOF currency accounts

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6146,7 +6146,7 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - AIRTEL
+            - Airtel
             - TNM
     MwkBeneficiary:
       title: Individual Beneficiary
@@ -6435,8 +6435,7 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - MTN
-            - AIRTEL
+            - MTN_Rwanda
     RwfBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6620,8 +6619,9 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - AIRTEL
-            - VODACOM
+            - AIRTELMONEYTZ
+            - TIGO
+            - HALOPESA
     TzsBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6904,11 +6904,16 @@ components:
           type: string
           description: Mobile money provider
           enum:
+            - Wave
+            - Free
+            - Free Money
+            - Orange Money
+            - Moov
+            - Mtn Mobile Money BJ
+            - Orange
             - MTN
-            - ORANGE
-            - WAVE
-            - MOOV
-            - FREE
+            - Moov money
+            - Mtn Mobile Money
     XofBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -7069,10 +7074,9 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - TNM
-            - AIRTEL
-            - ZAMTEL
             - MTN
+            - TNM
+            - Airtel
     ZmwBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6058,8 +6058,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - M-PESA
     KesBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6145,9 +6143,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - Airtel
-            - TNM
     MwkBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6434,8 +6429,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN_Rwanda
     RwfBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6618,10 +6611,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - AIRTELMONEYTZ
-            - TIGO
-            - HALOPESA
     TzsBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6707,9 +6696,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN
-            - AIRTEL
     UgxBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6903,17 +6889,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - Wave
-            - Free
-            - Free Money
-            - Orange Money
-            - Moov
-            - Mtn Mobile Money BJ
-            - Orange
-            - MTN
-            - Moov money
-            - Mtn Mobile Money
     XofBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -7073,10 +7048,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN
-            - TNM
-            - Airtel
     ZmwBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5563,14 +5563,17 @@ components:
         - IDR_ACCOUNT
         - INR_ACCOUNT
         - KES_ACCOUNT
+        - MWK_ACCOUNT
         - MXN_ACCOUNT
         - MYR_ACCOUNT
         - NGN_ACCOUNT
         - RWF_ACCOUNT
         - THB_ACCOUNT
         - TZS_ACCOUNT
+        - UGX_ACCOUNT
         - USD_ACCOUNT
         - VND_ACCOUNT
+        - XOF_ACCOUNT
         - ZAR_ACCOUNT
         - ZMW_ACCOUNT
       description: Type of external account or wallet
@@ -6109,6 +6112,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/KesBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    MwkAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - MWK_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - MW
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Malawian mobile money phone number
+          example: '+265991234567'
+          pattern: ^\+265[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - AIRTEL
+            - TNM
+    MwkBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    MwkExternalAccountInfo:
+      title: MWK Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/MwkAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/MwkBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/MwkBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     MxnBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6583,6 +6674,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/TzsBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    UgxAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - UGX_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - UG
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Ugandan mobile money phone number
+          example: '+256701234567'
+          pattern: ^\+256[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - AIRTEL
+    UgxBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    UgxExternalAccountInfo:
+      title: UGX Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/UgxAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/UgxBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/UgxBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     UsdBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6688,6 +6867,99 @@ components:
                 propertyName: beneficiaryType
                 mapping:
                   INDIVIDUAL: '#/components/schemas/VndBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    XofAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - XOF_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - SN
+              - BJ
+              - CI
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
+          example: '+221781234567'
+          pattern: ^\+(221|225|229)[0-9]{8,10}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - ORANGE
+            - WAVE
+            - MOOV
+            - FREE
+    XofBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    XofExternalAccountInfo:
+      title: XOF Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/XofAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/XofBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/XofBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ZarAccountInfo:
       type: object
@@ -6917,6 +7189,7 @@ components:
         - $ref: '#/components/schemas/IdrExternalAccountInfo'
         - $ref: '#/components/schemas/InrExternalAccountInfo'
         - $ref: '#/components/schemas/KesExternalAccountInfo'
+        - $ref: '#/components/schemas/MwkExternalAccountInfo'
         - $ref: '#/components/schemas/MxnExternalAccountInfo'
         - $ref: '#/components/schemas/MyrExternalAccountInfo'
         - $ref: '#/components/schemas/NgnExternalAccountInfo'
@@ -6925,8 +7198,10 @@ components:
         - $ref: '#/components/schemas/SgdExternalAccountInfo'
         - $ref: '#/components/schemas/ThbExternalAccountInfo'
         - $ref: '#/components/schemas/TzsExternalAccountInfo'
+        - $ref: '#/components/schemas/UgxExternalAccountInfo'
         - $ref: '#/components/schemas/UsdExternalAccountInfo'
         - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/XofExternalAccountInfo'
         - $ref: '#/components/schemas/ZarExternalAccountInfo'
         - $ref: '#/components/schemas/ZmwExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
@@ -6947,6 +7222,7 @@ components:
           IDR_ACCOUNT: '#/components/schemas/IdrExternalAccountInfo'
           INR_ACCOUNT: '#/components/schemas/InrExternalAccountInfo'
           KES_ACCOUNT: '#/components/schemas/KesExternalAccountInfo'
+          MWK_ACCOUNT: '#/components/schemas/MwkExternalAccountInfo'
           MXN_ACCOUNT: '#/components/schemas/MxnExternalAccountInfo'
           MYR_ACCOUNT: '#/components/schemas/MyrExternalAccountInfo'
           NGN_ACCOUNT: '#/components/schemas/NgnExternalAccountInfo'
@@ -6955,8 +7231,10 @@ components:
           SGD_ACCOUNT: '#/components/schemas/SgdExternalAccountInfo'
           THB_ACCOUNT: '#/components/schemas/ThbExternalAccountInfo'
           TZS_ACCOUNT: '#/components/schemas/TzsExternalAccountInfo'
+          UGX_ACCOUNT: '#/components/schemas/UgxExternalAccountInfo'
           USD_ACCOUNT: '#/components/schemas/UsdExternalAccountInfo'
           VND_ACCOUNT: '#/components/schemas/VndExternalAccountInfo'
+          XOF_ACCOUNT: '#/components/schemas/XofExternalAccountInfo'
           ZAR_ACCOUNT: '#/components/schemas/ZarExternalAccountInfo'
           ZMW_ACCOUNT: '#/components/schemas/ZmwExternalAccountInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6146,7 +6146,7 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - AIRTEL
+            - Airtel
             - TNM
     MwkBeneficiary:
       title: Individual Beneficiary
@@ -6435,8 +6435,7 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - MTN
-            - AIRTEL
+            - MTN_Rwanda
     RwfBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6620,8 +6619,9 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - AIRTEL
-            - VODACOM
+            - AIRTELMONEYTZ
+            - TIGO
+            - HALOPESA
     TzsBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6904,11 +6904,16 @@ components:
           type: string
           description: Mobile money provider
           enum:
+            - Wave
+            - Free
+            - Free Money
+            - Orange Money
+            - Moov
+            - Mtn Mobile Money BJ
+            - Orange
             - MTN
-            - ORANGE
-            - WAVE
-            - MOOV
-            - FREE
+            - Moov money
+            - Mtn Mobile Money
     XofBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -7069,10 +7074,9 @@ components:
           type: string
           description: Mobile money provider
           enum:
-            - TNM
-            - AIRTEL
-            - ZAMTEL
             - MTN
+            - TNM
+            - Airtel
     ZmwBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6058,8 +6058,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - M-PESA
     KesBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6145,9 +6143,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - Airtel
-            - TNM
     MwkBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6434,8 +6429,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN_Rwanda
     RwfBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6618,10 +6611,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - AIRTELMONEYTZ
-            - TIGO
-            - HALOPESA
     TzsBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6707,9 +6696,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN
-            - AIRTEL
     UgxBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6903,17 +6889,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - Wave
-            - Free
-            - Free Money
-            - Orange Money
-            - Moov
-            - Mtn Mobile Money BJ
-            - Orange
-            - MTN
-            - Moov money
-            - Mtn Mobile Money
     XofBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -7073,10 +7048,6 @@ components:
         provider:
           type: string
           description: Mobile money provider
-          enum:
-            - MTN
-            - TNM
-            - Airtel
     ZmwBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5563,14 +5563,17 @@ components:
         - IDR_ACCOUNT
         - INR_ACCOUNT
         - KES_ACCOUNT
+        - MWK_ACCOUNT
         - MXN_ACCOUNT
         - MYR_ACCOUNT
         - NGN_ACCOUNT
         - RWF_ACCOUNT
         - THB_ACCOUNT
         - TZS_ACCOUNT
+        - UGX_ACCOUNT
         - USD_ACCOUNT
         - VND_ACCOUNT
+        - XOF_ACCOUNT
         - ZAR_ACCOUNT
         - ZMW_ACCOUNT
       description: Type of external account or wallet
@@ -6109,6 +6112,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/KesBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    MwkAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - MWK_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - MW
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Malawian mobile money phone number
+          example: '+265991234567'
+          pattern: ^\+265[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - AIRTEL
+            - TNM
+    MwkBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    MwkExternalAccountInfo:
+      title: MWK Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/MwkAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/MwkBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/MwkBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     MxnBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6583,6 +6674,94 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/TzsBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    UgxAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - UGX_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - UG
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: Ugandan mobile money phone number
+          example: '+256701234567'
+          pattern: ^\+256[0-9]{9}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - AIRTEL
+    UgxBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    UgxExternalAccountInfo:
+      title: UGX Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/UgxAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/UgxBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/UgxBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     UsdBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -6688,6 +6867,99 @@ components:
                 propertyName: beneficiaryType
                 mapping:
                   INDIVIDUAL: '#/components/schemas/VndBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    XofAccountInfo:
+      type: object
+      required:
+        - accountType
+        - countries
+        - paymentRails
+        - phoneNumber
+        - provider
+      properties:
+        accountType:
+          type: string
+          enum:
+            - XOF_ACCOUNT
+        countries:
+          type: array
+          items:
+            type: string
+            enum:
+              - SN
+              - BJ
+              - CI
+        paymentRails:
+          type: array
+          items:
+            type: string
+            enum:
+              - MOBILE_MONEY
+        phoneNumber:
+          type: string
+          description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
+          example: '+221781234567'
+          pattern: ^\+(221|225|229)[0-9]{8,10}$
+        provider:
+          type: string
+          description: Mobile money provider
+          enum:
+            - MTN
+            - ORANGE
+            - WAVE
+            - MOOV
+            - FREE
+    XofBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        registrationNumber:
+          type: string
+          description: The registration number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    XofExternalAccountInfo:
+      title: XOF Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/XofAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - $ref: '#/components/schemas/XofBeneficiary'
+                - $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/XofBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ZarAccountInfo:
       type: object
@@ -6917,6 +7189,7 @@ components:
         - $ref: '#/components/schemas/IdrExternalAccountInfo'
         - $ref: '#/components/schemas/InrExternalAccountInfo'
         - $ref: '#/components/schemas/KesExternalAccountInfo'
+        - $ref: '#/components/schemas/MwkExternalAccountInfo'
         - $ref: '#/components/schemas/MxnExternalAccountInfo'
         - $ref: '#/components/schemas/MyrExternalAccountInfo'
         - $ref: '#/components/schemas/NgnExternalAccountInfo'
@@ -6925,8 +7198,10 @@ components:
         - $ref: '#/components/schemas/SgdExternalAccountInfo'
         - $ref: '#/components/schemas/ThbExternalAccountInfo'
         - $ref: '#/components/schemas/TzsExternalAccountInfo'
+        - $ref: '#/components/schemas/UgxExternalAccountInfo'
         - $ref: '#/components/schemas/UsdExternalAccountInfo'
         - $ref: '#/components/schemas/VndExternalAccountInfo'
+        - $ref: '#/components/schemas/XofExternalAccountInfo'
         - $ref: '#/components/schemas/ZarExternalAccountInfo'
         - $ref: '#/components/schemas/ZmwExternalAccountInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
@@ -6947,6 +7222,7 @@ components:
           IDR_ACCOUNT: '#/components/schemas/IdrExternalAccountInfo'
           INR_ACCOUNT: '#/components/schemas/InrExternalAccountInfo'
           KES_ACCOUNT: '#/components/schemas/KesExternalAccountInfo'
+          MWK_ACCOUNT: '#/components/schemas/MwkExternalAccountInfo'
           MXN_ACCOUNT: '#/components/schemas/MxnExternalAccountInfo'
           MYR_ACCOUNT: '#/components/schemas/MyrExternalAccountInfo'
           NGN_ACCOUNT: '#/components/schemas/NgnExternalAccountInfo'
@@ -6955,8 +7231,10 @@ components:
           SGD_ACCOUNT: '#/components/schemas/SgdExternalAccountInfo'
           THB_ACCOUNT: '#/components/schemas/ThbExternalAccountInfo'
           TZS_ACCOUNT: '#/components/schemas/TzsExternalAccountInfo'
+          UGX_ACCOUNT: '#/components/schemas/UgxExternalAccountInfo'
           USD_ACCOUNT: '#/components/schemas/UsdExternalAccountInfo'
           VND_ACCOUNT: '#/components/schemas/VndExternalAccountInfo'
+          XOF_ACCOUNT: '#/components/schemas/XofExternalAccountInfo'
           ZAR_ACCOUNT: '#/components/schemas/ZarExternalAccountInfo'
           ZMW_ACCOUNT: '#/components/schemas/ZmwExternalAccountInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'

--- a/openapi/components/schemas/common/KesAccountInfo.yaml
+++ b/openapi/components/schemas/common/KesAccountInfo.yaml
@@ -23,5 +23,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - M-PESA

--- a/openapi/components/schemas/common/MwkAccountInfo.yaml
+++ b/openapi/components/schemas/common/MwkAccountInfo.yaml
@@ -31,5 +31,5 @@ properties:
     type: string
     description: Mobile money provider
     enum:
-      - AIRTEL
+      - Airtel
       - TNM

--- a/openapi/components/schemas/common/MwkAccountInfo.yaml
+++ b/openapi/components/schemas/common/MwkAccountInfo.yaml
@@ -30,6 +30,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - Airtel
-      - TNM

--- a/openapi/components/schemas/common/MwkAccountInfo.yaml
+++ b/openapi/components/schemas/common/MwkAccountInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - MWK_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - MW
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Malawian mobile money phone number
+    example: '+265991234567'
+    pattern: ^\+265[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - AIRTEL
+      - TNM

--- a/openapi/components/schemas/common/MwkBeneficiary.yaml
+++ b/openapi/components/schemas/common/MwkBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/RwfAccountInfo.yaml
+++ b/openapi/components/schemas/common/RwfAccountInfo.yaml
@@ -23,5 +23,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - MTN_Rwanda

--- a/openapi/components/schemas/common/RwfAccountInfo.yaml
+++ b/openapi/components/schemas/common/RwfAccountInfo.yaml
@@ -24,5 +24,4 @@ properties:
     type: string
     description: Mobile money provider
     enum:
-      - MTN
-      - AIRTEL
+      - MTN_Rwanda

--- a/openapi/components/schemas/common/TzsAccountInfo.yaml
+++ b/openapi/components/schemas/common/TzsAccountInfo.yaml
@@ -23,7 +23,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - AIRTELMONEYTZ
-      - TIGO
-      - HALOPESA

--- a/openapi/components/schemas/common/TzsAccountInfo.yaml
+++ b/openapi/components/schemas/common/TzsAccountInfo.yaml
@@ -24,5 +24,6 @@ properties:
     type: string
     description: Mobile money provider
     enum:
-      - AIRTEL
-      - VODACOM
+      - AIRTELMONEYTZ
+      - TIGO
+      - HALOPESA

--- a/openapi/components/schemas/common/UgxAccountInfo.yaml
+++ b/openapi/components/schemas/common/UgxAccountInfo.yaml
@@ -30,6 +30,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - MTN
-      - AIRTEL

--- a/openapi/components/schemas/common/UgxAccountInfo.yaml
+++ b/openapi/components/schemas/common/UgxAccountInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - UGX_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - UG
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: Ugandan mobile money phone number
+    example: '+256701234567'
+    pattern: ^\+256[0-9]{9}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - MTN
+      - AIRTEL

--- a/openapi/components/schemas/common/UgxBeneficiary.yaml
+++ b/openapi/components/schemas/common/UgxBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/XofAccountInfo.yaml
+++ b/openapi/components/schemas/common/XofAccountInfo.yaml
@@ -33,8 +33,13 @@ properties:
     type: string
     description: Mobile money provider
     enum:
+      - Wave
+      - Free
+      - Free Money
+      - Orange Money
+      - Moov
+      - Mtn Mobile Money BJ
+      - Orange
       - MTN
-      - ORANGE
-      - WAVE
-      - MOOV
-      - FREE
+      - Moov money
+      - Mtn Mobile Money

--- a/openapi/components/schemas/common/XofAccountInfo.yaml
+++ b/openapi/components/schemas/common/XofAccountInfo.yaml
@@ -1,0 +1,40 @@
+type: object
+required:
+  - accountType
+  - countries
+  - paymentRails
+  - phoneNumber
+  - provider
+properties:
+  accountType:
+    type: string
+    enum:
+      - XOF_ACCOUNT
+  countries:
+    type: array
+    items:
+      type: string
+      enum:
+      - SN
+      - BJ
+      - CI
+  paymentRails:
+    type: array
+    items:
+      type: string
+      enum:
+      - MOBILE_MONEY
+  phoneNumber:
+    type: string
+    description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
+    example: '+221781234567'
+    pattern: ^\+(221|225|229)[0-9]{8,10}$
+  provider:
+    type: string
+    description: Mobile money provider
+    enum:
+      - MTN
+      - ORANGE
+      - WAVE
+      - MOOV
+      - FREE

--- a/openapi/components/schemas/common/XofAccountInfo.yaml
+++ b/openapi/components/schemas/common/XofAccountInfo.yaml
@@ -32,14 +32,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - Wave
-      - Free
-      - Free Money
-      - Orange Money
-      - Moov
-      - Mtn Mobile Money BJ
-      - Orange
-      - MTN
-      - Moov money
-      - Mtn Mobile Money

--- a/openapi/components/schemas/common/XofAccountInfo.yaml
+++ b/openapi/components/schemas/common/XofAccountInfo.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
     description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
     example: '+221781234567'
-    pattern: ^\+(221|225|229)[0-9]{8,10}$
+    pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
   provider:
     type: string
     description: Mobile money provider

--- a/openapi/components/schemas/common/XofBeneficiary.yaml
+++ b/openapi/components/schemas/common/XofBeneficiary.yaml
@@ -1,0 +1,33 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  registrationNumber:
+    type: string
+    description: The registration number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/common/ZmwAccountInfo.yaml
+++ b/openapi/components/schemas/common/ZmwAccountInfo.yaml
@@ -24,7 +24,6 @@ properties:
     type: string
     description: Mobile money provider
     enum:
-      - TNM
-      - AIRTEL
-      - ZAMTEL
       - MTN
+      - TNM
+      - Airtel

--- a/openapi/components/schemas/common/ZmwAccountInfo.yaml
+++ b/openapi/components/schemas/common/ZmwAccountInfo.yaml
@@ -23,7 +23,3 @@ properties:
   provider:
     type: string
     description: Mobile money provider
-    enum:
-      - MTN
-      - TNM
-      - Airtel

--- a/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
@@ -8,6 +8,7 @@ oneOf:
 - $ref: ./IdrExternalAccountInfo.yaml
 - $ref: ./InrExternalAccountInfo.yaml
 - $ref: ./KesExternalAccountInfo.yaml
+- $ref: ./MwkExternalAccountInfo.yaml
 - $ref: ./MxnExternalAccountInfo.yaml
 - $ref: ./MyrExternalAccountInfo.yaml
 - $ref: ./NgnExternalAccountInfo.yaml
@@ -16,8 +17,10 @@ oneOf:
 - $ref: ./SgdExternalAccountInfo.yaml
 - $ref: ./ThbExternalAccountInfo.yaml
 - $ref: ./TzsExternalAccountInfo.yaml
+- $ref: ./UgxExternalAccountInfo.yaml
 - $ref: ./UsdExternalAccountInfo.yaml
 - $ref: ./VndExternalAccountInfo.yaml
+- $ref: ./XofExternalAccountInfo.yaml
 - $ref: ./ZarExternalAccountInfo.yaml
 - $ref: ./ZmwExternalAccountInfo.yaml
 - $ref: ./SparkWalletExternalAccountInfo.yaml
@@ -38,6 +41,7 @@ discriminator:
     IDR_ACCOUNT: ./IdrExternalAccountInfo.yaml
     INR_ACCOUNT: ./InrExternalAccountInfo.yaml
     KES_ACCOUNT: ./KesExternalAccountInfo.yaml
+    MWK_ACCOUNT: ./MwkExternalAccountInfo.yaml
     MXN_ACCOUNT: ./MxnExternalAccountInfo.yaml
     MYR_ACCOUNT: ./MyrExternalAccountInfo.yaml
     NGN_ACCOUNT: ./NgnExternalAccountInfo.yaml
@@ -46,8 +50,10 @@ discriminator:
     SGD_ACCOUNT: ./SgdExternalAccountInfo.yaml
     THB_ACCOUNT: ./ThbExternalAccountInfo.yaml
     TZS_ACCOUNT: ./TzsExternalAccountInfo.yaml
+    UGX_ACCOUNT: ./UgxExternalAccountInfo.yaml
     USD_ACCOUNT: ./UsdExternalAccountInfo.yaml
     VND_ACCOUNT: ./VndExternalAccountInfo.yaml
+    XOF_ACCOUNT: ./XofExternalAccountInfo.yaml
     ZAR_ACCOUNT: ./ZarExternalAccountInfo.yaml
     ZMW_ACCOUNT: ./ZmwExternalAccountInfo.yaml
     SPARK_WALLET: ./SparkWalletExternalAccountInfo.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
@@ -17,14 +17,17 @@ enum:
   - IDR_ACCOUNT
   - INR_ACCOUNT
   - KES_ACCOUNT
+  - MWK_ACCOUNT
   - MXN_ACCOUNT
   - MYR_ACCOUNT
   - NGN_ACCOUNT
   - RWF_ACCOUNT
   - THB_ACCOUNT
   - TZS_ACCOUNT
+  - UGX_ACCOUNT
   - USD_ACCOUNT
   - VND_ACCOUNT
+  - XOF_ACCOUNT
   - ZAR_ACCOUNT
   - ZMW_ACCOUNT
 description: Type of external account or wallet

--- a/openapi/components/schemas/external_accounts/MwkExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/MwkExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: MWK Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/MwkAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/MwkBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/MwkBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/UgxExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UgxExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: UGX Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/UgxAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/UgxBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/UgxBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/XofExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/XofExternalAccountInfo.yaml
@@ -1,0 +1,17 @@
+title: XOF Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/XofAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - $ref: ../common/XofBeneficiary.yaml
+      - $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/XofBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml


### PR DESCRIPTION
## Summary
This PR adds OpenAPI schema definitions for three new currency account types: Malawian Kwacha (MWK), Ugandan Shilling (UGX), and West African CFA Franc (XOF). Each currency includes mobile money payment rail support with region-specific phone number validation and provider configurations.

## Key Changes
- **MWK Account Support**: Added schemas for Malawian mobile money accounts supporting Airtel and TNM providers with phone number validation pattern `^\+265[0-9]{9}$`
- **UGX Account Support**: Added schemas for Ugandan mobile money accounts supporting MTN and Airtel providers with phone number validation pattern `^\+256[0-9]{9}$`
- **XOF Account Support**: Added schemas for West African mobile money accounts (Senegal, Benin, Ivory Coast) supporting MTN, Orange, Wave, Moov, and Free providers with multi-country phone validation pattern `^\+(221|225|229)[0-9]{8,10}$`
- Updated `ExternalAccountType` enum to include `MWK_ACCOUNT`, `UGX_ACCOUNT`, and `XOF_ACCOUNT`
- Updated `ExternalAccountInfoOneOf` discriminator mapping to route new account types to their respective schemas
- Created modular YAML schema files for account info, beneficiary, and external account info definitions for each currency

## Implementation Details
- Each currency follows the established pattern with `AccountInfo`, `Beneficiary`, and `ExternalAccountInfo` schema components
- All three currencies use MOBILE_MONEY as the sole payment rail
- Beneficiary schemas support both INDIVIDUAL and BUSINESS beneficiary types with discriminator-based routing
- Phone number patterns are region-specific to ensure valid formatting for each country/provider combination

https://claude.ai/code/session_01QxLc91riHT65xhDy4z7Gdt