### PR TITLE
Fix West African mobile money phone number validation regex

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6885,7 +6885,7 @@ components:
           type: string
           description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
           example: '+221781234567'
-          pattern: ^\+(221|225|229)[0-9]{8,10}$
+          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
         provider:
           type: string
           description: Mobile money provider

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6885,7 +6885,7 @@ components:
           type: string
           description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
           example: '+221781234567'
-          pattern: ^\+(221|225|229)[0-9]{8,10}$
+          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
         provider:
           type: string
           description: Mobile money provider


### PR DESCRIPTION
## Summary
Updated the phone number validation regex pattern for West African mobile money numbers to enforce country-specific digit requirements instead of a generic range.

## Key Changes
- **Senegal (+221)**: Changed from flexible `[0-9]{8,10}` to strict `[0-9]{9}` (9 digits after country code)
- **Ivory Coast (+225)**: Changed from flexible `[0-9]{8,10}` to strict `[0-9]{10}` (10 digits after country code)
- **Benin (+229)**: Changed from flexible `[0-9]{8,10}` to strict `[0-9]{8,9}` (8-9 digits after country code)

## Implementation Details
The previous regex pattern `^\+(221|225|229)[0-9]{8,10}$` accepted any combination of 8-10 digits for all three countries, which was too permissive and could allow invalid phone numbers. The updated pattern `^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$` now validates each country code with its correct digit length requirements, improving data quality and reducing invalid number submissions.

https://claude.ai/code/session_01S828qqdXMuJAHkXqNubQxh