### PR TITLE
feat: add workflow to auto-bump Grid API version in webdev

### DIFF
--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -1,0 +1,138 @@
+name: Bump Grid API in webdev
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout grid-api
+        uses: actions/checkout@v4
+        with:
+          path: grid-api
+
+      - name: Checkout webdev
+        uses: actions/checkout@v4
+        with:
+          repository: lightsparkdev/webdev
+          token: ${{ secrets.WEBDEV_GITHUB_TOKEN }}
+          path: webdev
+          sparse-checkout: |
+            grid-api
+            umaaas-api/generators/python-typed
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Copy updated OpenAPI spec
+        run: cp grid-api/openapi.yaml webdev/grid-api/openapi.yaml
+
+      - name: Build custom generator
+        working-directory: webdev/umaaas-api/generators/python-typed
+        run: mvn package -q -DskipTests
+
+      - name: Download openapi-generator CLI
+        run: |
+          OG_VERSION=7.18.0
+          curl -sL "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${OG_VERSION}/openapi-generator-cli-${OG_VERSION}.jar" \
+            -o /tmp/openapi-generator-cli.jar
+
+      - name: Run code generation
+        working-directory: webdev/grid-api
+        run: |
+          CUSTOM_JAR="../umaaas-api/generators/python-typed/target/python-alias-openapi-generator-1.0.0.jar"
+          CLI_JAR="/tmp/openapi-generator-cli.jar"
+
+          # Save previous FILES list
+          if [ -f .openapi-generator/FILES ]; then
+            cp .openapi-generator/FILES /tmp/FILES.prev
+          else
+            : > /tmp/FILES.prev
+          fi
+
+          # Generate code
+          java -cp "$CUSTOM_JAR:$CLI_JAR" org.openapitools.codegen.OpenAPIGenerator \
+            generate \
+            -g python-alias \
+            -i openapi.yaml \
+            -o . \
+            -c codegen-config/config.yml
+
+          # Remove stale generated files
+          if [ -f .openapi-generator/FILES ]; then
+            sort /tmp/FILES.prev > /tmp/FILES.prev.sorted
+            sort .openapi-generator/FILES > /tmp/FILES.new.sorted
+            comm -23 /tmp/FILES.prev.sorted /tmp/FILES.new.sorted \
+              | while IFS= read -r rel; do
+                  if [ -n "$rel" ]; then
+                    echo "Removing stale generated file: $rel"
+                    rm -f -- "$rel"
+                  fi
+                done
+          fi
+
+      - name: Bump patch version
+        working-directory: webdev/grid-api
+        run: |
+          # Read current version from pyproject.toml
+          CURRENT=$(grep -oP 'version = "\K[^"]+' pyproject.toml | head -1)
+          echo "Current version: $CURRENT"
+
+          # Increment patch version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "New version: $NEW_VERSION"
+
+          # Update pyproject.toml
+          sed -i "s/version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" pyproject.toml
+
+          # Update codegen-config/config.yml
+          sed -i "s/packageVersion: $CURRENT/packageVersion: $NEW_VERSION/" codegen-config/config.yml
+
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        working-directory: webdev
+        env:
+          GH_TOKEN: ${{ secrets.WEBDEV_GITHUB_TOKEN }}
+        run: |
+          BRANCH="grid-api/bump-v${NEW_VERSION}"
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add grid-api/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+
+          git commit -m "chore(grid-api): bump to v${NEW_VERSION} (${SHORT_SHA})"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --repo lightsparkdev/webdev \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(grid-api): bump to v${NEW_VERSION}" \
+            --body "$(cat <<EOF
+          ## Summary
+
+          Auto-generated PR to update the Grid API Python SDK based on changes to [grid-api@${SHORT_SHA}](https://github.com/lightsparkdev/grid-api/commit/${COMMIT_SHA}).
+
+          - Copies latest \`openapi.yaml\` from grid-api main
+          - Regenerates Python SDK code
+          - Bumps version from the previous release to \`${NEW_VERSION}\`
+
+          **Triggered by:** ${{ github.event.head_commit.message }}
+          EOF
+          )"

--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -31,12 +31,6 @@ jobs:
             grid-api
             umaaas-api/generators/python-typed
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-
       - name: Check if openapi.yaml changed
         id: check_diff
         run: |
@@ -45,6 +39,13 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Setup Java
+        if: steps.check_diff.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
 
       - name: Copy updated OpenAPI spec
         if: steps.check_diff.outputs.changed == 'true'

--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -57,6 +57,8 @@ jobs:
           OG_VERSION=7.18.0
           curl -sL "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${OG_VERSION}/openapi-generator-cli-${OG_VERSION}.jar" \
             -o /tmp/openapi-generator-cli.jar
+          EXPECTED_SHA=$(curl -sL "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${OG_VERSION}/openapi-generator-cli-${OG_VERSION}.jar.sha256")
+          echo "${EXPECTED_SHA}  /tmp/openapi-generator-cli.jar" | sha256sum -c -
 
       - name: Run code generation
         if: steps.check_diff.outputs.changed == 'true'
@@ -119,7 +121,7 @@ jobs:
         working-directory: webdev
         env:
           GH_TOKEN: ${{ secrets.WEBDEV_GITHUB_TOKEN }}
-          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message || format('Manual dispatch by @{0}', github.actor) }}
         run: |
           BRANCH="grid-api/bump-v${NEW_VERSION}"
           COMMIT_SHA="${{ github.sha }}"

--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: bump-webdev
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -158,4 +162,5 @@ jobs:
             --body "$PR_BODY" || \
           gh pr edit "$BRANCH" \
             --repo lightsparkdev/webdev \
+            --title "chore(grid-api): bump to v${NEW_VERSION}" \
             --body "$PR_BODY"

--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -33,20 +33,33 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      - name: Check if openapi.yaml changed
+        id: check_diff
+        run: |
+          if ! diff -q grid-api/openapi.yaml webdev/grid-api/openapi.yaml > /dev/null 2>&1; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Copy updated OpenAPI spec
+        if: steps.check_diff.outputs.changed == 'true'
         run: cp grid-api/openapi.yaml webdev/grid-api/openapi.yaml
 
       - name: Build custom generator
+        if: steps.check_diff.outputs.changed == 'true'
         working-directory: webdev/umaaas-api/generators/python-typed
         run: mvn package -q -DskipTests
 
       - name: Download openapi-generator CLI
+        if: steps.check_diff.outputs.changed == 'true'
         run: |
           OG_VERSION=7.18.0
           curl -sL "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${OG_VERSION}/openapi-generator-cli-${OG_VERSION}.jar" \
             -o /tmp/openapi-generator-cli.jar
 
       - name: Run code generation
+        if: steps.check_diff.outputs.changed == 'true'
         working-directory: webdev/grid-api
         run: |
           CUSTOM_JAR="../umaaas-api/generators/python-typed/target/python-alias-openapi-generator-1.0.0.jar"
@@ -81,6 +94,7 @@ jobs:
           fi
 
       - name: Bump patch version
+        if: steps.check_diff.outputs.changed == 'true'
         working-directory: webdev/grid-api
         run: |
           # Read current version from pyproject.toml
@@ -101,6 +115,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
 
       - name: Create pull request
+        if: steps.check_diff.outputs.changed == 'true'
         working-directory: webdev
         env:
           GH_TOKEN: ${{ secrets.WEBDEV_GITHUB_TOKEN }}

--- a/.github/workflows/bump-webdev.yml
+++ b/.github/workflows/bump-webdev.yml
@@ -119,6 +119,7 @@ jobs:
         working-directory: webdev
         env:
           GH_TOKEN: ${{ secrets.WEBDEV_GITHUB_TOKEN }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           BRANCH="grid-api/bump-v${NEW_VERSION}"
           COMMIT_SHA="${{ github.sha }}"
@@ -132,14 +133,9 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" && exit 0
 
           git commit -m "chore(grid-api): bump to v${NEW_VERSION} (${SHORT_SHA})"
-          git push origin "$BRANCH"
+          git push origin "$BRANCH" --force-with-lease
 
-          gh pr create \
-            --repo lightsparkdev/webdev \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(grid-api): bump to v${NEW_VERSION}" \
-            --body "$(cat <<EOF
+          PR_BODY="$(cat <<EOF
           ## Summary
 
           Auto-generated PR to update the Grid API Python SDK based on changes to [grid-api@${SHORT_SHA}](https://github.com/lightsparkdev/grid-api/commit/${COMMIT_SHA}).
@@ -148,6 +144,16 @@ jobs:
           - Regenerates Python SDK code
           - Bumps version from the previous release to \`${NEW_VERSION}\`
 
-          **Triggered by:** ${{ github.event.head_commit.message }}
+          **Triggered by:** ${HEAD_COMMIT_MSG}
           EOF
           )"
+
+          gh pr create \
+            --repo lightsparkdev/webdev \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(grid-api): bump to v${NEW_VERSION}" \
+            --body "$PR_BODY" || \
+          gh pr edit "$BRANCH" \
+            --repo lightsparkdev/webdev \
+            --body "$PR_BODY"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`bump-webdev.yml`) that triggers on push to `main`
- Checks out `lightsparkdev/webdev`, copies the latest bundled `openapi.yaml`
- Builds the custom openapi-generator from `umaaas-api/generators/python-typed`
- Regenerates the Grid API Python SDK and bumps the patch version
- Creates a PR in `lightsparkdev/webdev` with the changes

## Prerequisites

- A `WEBDEV_GITHUB_TOKEN` secret must be configured in this repo with permissions to push branches and create PRs in `lightsparkdev/webdev`

## Test plan

- [ ] Verify the `WEBDEV_GITHUB_TOKEN` secret is configured
- [ ] Trigger the workflow manually via `workflow_dispatch` to validate end-to-end
- [ ] Confirm a PR is created in `lightsparkdev/webdev` with regenerated SDK code and bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)