### PR TITLE
docs: add sandbox VPA validation simulation for INR UPI accounts

### DIFF
--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -101,64 +101,7 @@ For scenarios like PIX and UPI, where there's a domain part involved, append the
 
 ### INR UPI VPA validation simulation
 
-For INR accounts with a UPI VPA, Grid validates the VPA and verifies the beneficiary name at account creation time. In sandbox, this validation is simulated based on the **VPA username suffix** (the part before `@`). These use a `1xx` suffix range to avoid conflicts with the transfer-level test patterns above.
-
-| Username ending | `beneficiaryVerificationStatus` | Behavior |
-|---|---|---|
-| `105` | _(error)_ | Returns `400` — invalid VPA |
-| `109` | _(error)_ | Returns `500` — simulated API error |
-| `102` | `NOT_MATCHED` | VPA is valid but name does not match |
-| `103` | `PARTIAL_MATCH` | VPA is valid, name is a fuzzy match |
-| `104` | `PENDING` | Verification still in progress |
-| **Any other** | `MATCHED` | VPA is valid, name matches exactly |
-
-**Example — Testing a matched VPA:**
-
-```bash
-curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "customerId": "Customer:sandbox001",
-    "currency": "INR",
-    "accountInfo": {
-      "accountType": "UPI",
-      "vpa": "testuser001@paytm",
-      "beneficiary": {
-        "beneficiaryType": "INDIVIDUAL",
-        "fullName": "Rahul Sharma"
-      }
-    }
-  }'
-```
-
-The response includes `beneficiaryVerificationStatus: "MATCHED"` and `beneficiaryVerifiedData` with the verified name.
-
-**Example — Testing a name mismatch:**
-
-```bash
-curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "customerId": "Customer:sandbox001",
-    "currency": "INR",
-    "accountInfo": {
-      "accountType": "UPI",
-      "vpa": "testuser102@paytm",
-      "beneficiary": {
-        "beneficiaryType": "INDIVIDUAL",
-        "fullName": "Rahul Sharma"
-      }
-    }
-  }'
-```
-
-The response includes `beneficiaryVerificationStatus: "NOT_MATCHED"` — the account is still created, but the name check failed.
-
-<Note>
-VPA validation simulation only applies to INR UPI accounts. Other account types use the transfer-level test patterns described above.
-</Note>
+<Snippet file="sandbox-vpa-validation.mdx" />
 
 ### Testing Transfer-In (Pull from External Account)
 

--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -99,6 +99,67 @@ For scenarios like PIX and UPI, where there's a domain part involved, append the
 "testuser.002@pix.com.br" to trigger the insufficient funds scenario.
 </Note>
 
+### INR UPI VPA validation simulation
+
+For INR accounts with a UPI VPA, Grid validates the VPA and verifies the beneficiary name at account creation time. In sandbox, this validation is simulated based on the **VPA username suffix** (the part before `@`). These use a `1xx` suffix range to avoid conflicts with the transfer-level test patterns above.
+
+| Username ending | `beneficiaryVerificationStatus` | Behavior |
+|---|---|---|
+| `105` | _(error)_ | Returns `400` — invalid VPA |
+| `109` | _(error)_ | Returns `500` — simulated API error |
+| `102` | `NOT_MATCHED` | VPA is valid but name does not match |
+| `103` | `PARTIAL_MATCH` | VPA is valid, name is a fuzzy match |
+| `104` | `PENDING` | Verification still in progress |
+| **Any other** | `MATCHED` | VPA is valid, name matches exactly |
+
+**Example — Testing a matched VPA:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "rahul@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "MATCHED"` and `beneficiaryVerifiedData` with the verified name.
+
+**Example — Testing a name mismatch:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "testuser102@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "NOT_MATCHED"` — the account is still created, but the name check failed.
+
+<Note>
+VPA validation simulation only applies to INR UPI accounts. Other account types use the transfer-level test patterns described above.
+</Note>
+
 ### Testing Transfer-In (Pull from External Account)
 
 When you call `/transfer-in` with an external account created using test patterns, the transfer will complete instantly in sandbox with the behavior determined by the account number:

--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -123,7 +123,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "INR",
     "accountInfo": {
       "accountType": "UPI",
-      "vpa": "rahul@paytm",
+      "vpa": "testuser001@paytm",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Rahul Sharma"

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -292,6 +292,67 @@ For example, if testing email addresses as a PIX key, the full identifier would 
 insufficient funds scenario.
 </Tip>
 
+## INR UPI VPA validation simulation
+
+For INR accounts with a UPI VPA, Grid validates the VPA and verifies the beneficiary name at account creation time. In sandbox, this validation is simulated based on the **VPA username suffix** (the part before `@`). These use a `1xx` suffix range to avoid conflicts with the transfer-level test patterns above.
+
+| Username ending | `beneficiaryVerificationStatus` | Behavior |
+|---|---|---|
+| `105` | _(error)_ | Returns `400` — invalid VPA |
+| `109` | _(error)_ | Returns `500` — simulated API error |
+| `102` | `NOT_MATCHED` | VPA is valid but name does not match |
+| `103` | `PARTIAL_MATCH` | VPA is valid, name is a fuzzy match |
+| `104` | `PENDING` | Verification still in progress |
+| **Any other** | `MATCHED` | VPA is valid, name matches exactly |
+
+**Example — Testing a matched VPA:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "rahul@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "MATCHED"` and `beneficiaryVerifiedData` with the verified name.
+
+**Example — Testing a name mismatch:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "testuser102@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "NOT_MATCHED"` — the account is still created, but the name check failed.
+
+<Note>
+VPA validation simulation only applies to INR UPI accounts. Other account types use the transfer-level test patterns described above.
+</Note>
+
 ## Test scenarios
 
 ### Successful conversions

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -294,64 +294,7 @@ insufficient funds scenario.
 
 ## INR UPI VPA validation simulation
 
-For INR accounts with a UPI VPA, Grid validates the VPA and verifies the beneficiary name at account creation time. In sandbox, this validation is simulated based on the **VPA username suffix** (the part before `@`). These use a `1xx` suffix range to avoid conflicts with the transfer-level test patterns above.
-
-| Username ending | `beneficiaryVerificationStatus` | Behavior |
-|---|---|---|
-| `105` | _(error)_ | Returns `400` — invalid VPA |
-| `109` | _(error)_ | Returns `500` — simulated API error |
-| `102` | `NOT_MATCHED` | VPA is valid but name does not match |
-| `103` | `PARTIAL_MATCH` | VPA is valid, name is a fuzzy match |
-| `104` | `PENDING` | Verification still in progress |
-| **Any other** | `MATCHED` | VPA is valid, name matches exactly |
-
-**Example — Testing a matched VPA:**
-
-```bash
-curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "customerId": "Customer:sandbox001",
-    "currency": "INR",
-    "accountInfo": {
-      "accountType": "UPI",
-      "vpa": "testuser001@paytm",
-      "beneficiary": {
-        "beneficiaryType": "INDIVIDUAL",
-        "fullName": "Rahul Sharma"
-      }
-    }
-  }'
-```
-
-The response includes `beneficiaryVerificationStatus: "MATCHED"` and `beneficiaryVerifiedData` with the verified name.
-
-**Example — Testing a name mismatch:**
-
-```bash
-curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "customerId": "Customer:sandbox001",
-    "currency": "INR",
-    "accountInfo": {
-      "accountType": "UPI",
-      "vpa": "testuser102@paytm",
-      "beneficiary": {
-        "beneficiaryType": "INDIVIDUAL",
-        "fullName": "Rahul Sharma"
-      }
-    }
-  }'
-```
-
-The response includes `beneficiaryVerificationStatus: "NOT_MATCHED"` — the account is still created, but the name check failed.
-
-<Note>
-VPA validation simulation only applies to INR UPI accounts. Other account types use the transfer-level test patterns described above.
-</Note>
+<Snippet file="sandbox-vpa-validation.mdx" />
 
 ## Test scenarios
 

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -316,7 +316,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "INR",
     "accountInfo": {
       "accountType": "UPI",
-      "vpa": "rahul@paytm",
+      "vpa": "testuser001@paytm",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Rahul Sharma"

--- a/mintlify/snippets/sandbox-vpa-validation.mdx
+++ b/mintlify/snippets/sandbox-vpa-validation.mdx
@@ -1,0 +1,58 @@
+For INR accounts with a UPI VPA, Grid validates the VPA and verifies the beneficiary name at account creation time. In sandbox, this validation is simulated based on the **VPA username suffix** (the part before `@`). These use a `1xx` suffix range to avoid conflicts with the transfer-level test patterns above.
+
+| Username ending | `beneficiaryVerificationStatus` | Behavior |
+|---|---|---|
+| `105` | _(error)_ | Returns `400` — invalid VPA |
+| `109` | _(error)_ | Returns `500` — simulated API error |
+| `102` | `NOT_MATCHED` | VPA is valid but name does not match |
+| `103` | `PARTIAL_MATCH` | VPA is valid, name is a fuzzy match |
+| `104` | `PENDING` | Verification still in progress |
+| **Any other** | `MATCHED` | VPA is valid, name matches exactly |
+
+**Example — Testing a matched VPA:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "testuser001@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "MATCHED"` and `beneficiaryVerifiedData` with the verified name.
+
+**Example — Testing a name mismatch:**
+
+```bash
+curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
+  -u "$SANDBOX_API_KEY:$SANDBOX_API_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "Customer:sandbox001",
+    "currency": "INR",
+    "accountInfo": {
+      "accountType": "UPI",
+      "vpa": "testuser102@paytm",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Rahul Sharma"
+      }
+    }
+  }'
+```
+
+The response includes `beneficiaryVerificationStatus: "NOT_MATCHED"` — the account is still created, but the name check failed.
+
+<Note>
+VPA validation simulation only applies to INR UPI accounts. Other account types use the transfer-level test patterns described above.
+</Note>


### PR DESCRIPTION
## Summary

- Documents the sandbox VPA validation simulation for INR UPI external accounts
- Adds VPA username suffix pattern table (1xx range) to both payouts-and-b2b and ramps sandbox testing pages
- Includes curl examples for testing matched and not-matched VPA scenarios

Corresponds to webdev PR: https://github.com/lightsparkdev/webdev/pull/24531

## Test plan

- [ ] Verify sandbox testing pages render correctly in Mintlify
- [ ] Confirm VPA suffix pattern table is clear and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)  
  
![image.png](https://app.graphite.com/user-attachments/assets/f2695513-e626-46a6-9fc1-39d19b733959.png)

