### PR TITLE
Fix West African phone number validation pattern for Benin

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6982,7 +6982,7 @@ components:
           type: string
           description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
           example: '+221781234567'
-          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
+          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229([0-9]{8}|[0-9]{10}))$
         provider:
           type: string
           description: Mobile money provider

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6982,7 +6982,7 @@ components:
           type: string
           description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
           example: '+221781234567'
-          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
+          pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229([0-9]{8}|[0-9]{10}))$
         provider:
           type: string
           description: Mobile money provider

--- a/openapi/components/schemas/common/XofAccountInfo.yaml
+++ b/openapi/components/schemas/common/XofAccountInfo.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
     description: West African mobile money phone number (Senegal, Benin, or Ivory Coast)
     example: '+221781234567'
-    pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229[0-9]{8,9})$
+    pattern: ^\+(221[0-9]{9}|225[0-9]{10}|229([0-9]{8}|[0-9]{10}))$
   provider:
     type: string
     description: Mobile money provider


### PR DESCRIPTION
## Summary
Updated the phone number validation regex pattern for West African mobile money accounts to correctly validate Benin (+229) phone numbers with either 8 or 10 digits.

## Changes
- Modified the regex pattern for the `phoneNumber` field in West African mobile money phone number validation
- Changed from `229[0-9]{8,9}` to `229([0-9]{8}|[0-9]{10})` to explicitly allow only 8 or 10 digit phone numbers for Benin, excluding the invalid 9-digit format
- Updated in three locations:
  - `mintlify/openapi.yaml`
  - `openapi.yaml`
  - `openapi/components/schemas/common/XofAccountInfo.yaml`

## Details
The previous pattern `229[0-9]{8,9}` would accept phone numbers with 8, 9, or 10 total digits (8 or 9 additional digits after the country code). The corrected pattern `229([0-9]{8}|[0-9]{10})` now explicitly validates only 8-digit or 10-digit phone numbers for Benin, removing support for the invalid 9-digit format while maintaining support for Senegal (+221) and Ivory Coast (+225) numbers.

https://claude.ai/code/session_01LSntdU8WsRYKPzLPmqK7dQ