### PR TITLE
feat: adding country code to external account response

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -7414,6 +7414,12 @@ components:
               type: string
               description: 'The blockchain network for this external account, if applicable. Present when the account is a cryptocurrency wallet. Example values: SOLANA_MAINNET, ETHEREUM_MAINNET, POLYGON_MAINNET, TRON_MAINNET.'
               example: SOLANA_MAINNET
+            countryCode:
+              type: string
+              description: ISO 3166-1 alpha-2 country code for the receiving external account, derived from the provided rail and account information.
+              minLength: 2
+              maxLength: 2
+              example: IN
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7414,6 +7414,12 @@ components:
               type: string
               description: 'The blockchain network for this external account, if applicable. Present when the account is a cryptocurrency wallet. Example values: SOLANA_MAINNET, ETHEREUM_MAINNET, POLYGON_MAINNET, TRON_MAINNET.'
               example: SOLANA_MAINNET
+            countryCode:
+              type: string
+              description: ISO 3166-1 alpha-2 country code for the receiving external account, derived from the provided rail and account information.
+              minLength: 2
+              maxLength: 2
+              example: IN
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:

--- a/openapi/components/schemas/external_accounts/ExternalAccount.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccount.yaml
@@ -47,5 +47,13 @@ allOf:
           is a cryptocurrency wallet. Example values: SOLANA_MAINNET, ETHEREUM_MAINNET,
           POLYGON_MAINNET, TRON_MAINNET.
         example: SOLANA_MAINNET
+      countryCode:
+        type: string
+        description: >-
+          ISO 3166-1 alpha-2 country code for the receiving external account,
+          derived from the provided rail and account information.
+        minLength: 2
+        maxLength: 2
+        example: IN
       accountInfo:
         $ref: ./ExternalAccountInfoOneOf.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccount.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccount.yaml
@@ -54,6 +54,7 @@ allOf:
           derived from the provided rail and account information.
         minLength: 2
         maxLength: 2
+        pattern: '^[A-Z]{2}$'
         example: IN
       accountInfo:
         $ref: ./ExternalAccountInfoOneOf.yaml


### PR DESCRIPTION
### TL;DR

Added `countryCode` field to the ExternalAccount schema to capture the ISO 3166-1 alpha-2 country code for receiving external accounts.

### What changed?

Added a new `countryCode` property to the ExternalAccount schema with the following specifications:
- Type: string
- Description: ISO 3166-1 alpha-2 country code for the receiving external account, derived from the provided rail and account information
- Validation: minLength and maxLength of 2 characters
- Example value: "IN"

### How to test?

1. Create or retrieve an external account and verify the `countryCode` field is present in the response
2. Validate that the country code follows ISO 3166-1 alpha-2 format (2-character codes)
3. Test with different rails and account types to ensure the country code is properly derived from the provided information

### Why make this change?

This enhancement provides better geographical context for external accounts, enabling improved compliance, routing decisions, and user experience by clearly identifying the country associated with each receiving account.