### PR TITLE
Replace Snippet component with direct import for sandbox VPA validation

### DIFF
--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -5,6 +5,8 @@ icon: "/images/icons/hammer.svg"
 "og:image": "/images/og/og-payouts-b2b.png"
 ---
 
+import SandboxVpaValidation from '/snippets/sandbox-vpa-validation.mdx';
+
 ## Overview
 
 The Grid sandbox environment allows you to test your payouts integration without moving real money. All API endpoints work the same way in sandbox as they do in production, but money movements are simulated and you can control test scenarios using special test values.
@@ -101,7 +103,7 @@ For scenarios like PIX and UPI, where there's a domain part involved, append the
 
 ### INR UPI VPA validation simulation
 
-<Snippet file="sandbox-vpa-validation.mdx" />
+<SandboxVpaValidation />
 
 ### Testing Transfer-In (Pull from External Account)
 

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -5,6 +5,8 @@ icon: "/images/icons/hammer.svg"
 "og:image": "/images/og/og-ramps.png"
 ---
 
+import SandboxVpaValidation from '/snippets/sandbox-vpa-validation.mdx';
+
 The Grid Sandbox environment provides a complete testing environment for ramp operations, allowing you to validate on-ramp and off-ramp flows without using real money or cryptocurrency.
 
 ## Sandbox overview
@@ -294,7 +296,7 @@ insufficient funds scenario.
 
 ## INR UPI VPA validation simulation
 
-<Snippet file="sandbox-vpa-validation.mdx" />
+<SandboxVpaValidation />
 
 ## Test scenarios
 


### PR DESCRIPTION
=[ply@anthropic.com](mailto:noreply@anthropic.com)

feat: updating sample for v1 (#261)

### TL;DR

Updated sample applications to use Indian Rupee (INR) accounts with UPI payment rails instead of US Dollar accounts, upgraded Kotlin SDK version, and fixed environment variable names.

### What changed?

- **Frontend**: Changed external account creation from USD bank accounts to INR UPI accounts with Indian beneficiary details (Priya Sharma in Mumbai)
- **Frontend**: Added `purposeOfPayment: "GIFT"` field to quote creation
- **Kotlin SDK**: Upgraded from version 0.5.0 to 1.1.0
- **Kotlin Config**: Updated environment variable names from `GRID_API_TOKEN_ID`/`GRID_WEBHOOK_PUBLIC_KEY` to `GRID_CLIENT_ID`/`GRID_WEBHOOK_PUBKEY`
- **Kotlin API**: Migrated from US account types to INR account types with UPI payment rails and updated beneficiary structure to include email and phone number fields

### How to test?

1. Update environment variables to use the new naming convention (`GRID_CLIENT_ID`, `GRID_CLIENT_SECRET`, `GRID_WEBHOOK_PUBKEY`)
2. Test external account creation with INR/UPI configuration in the frontend
3. Verify quote creation includes the purpose of payment field
4. Test the Kotlin sample with the upgraded SDK version

### Why make this change?

This change demonstrates Grid's support for Indian market payments by showcasing INR accounts with UPI payment rails, which is essential for Indian payment processing. The SDK upgrade provides access to newer features and the environment variable changes align with updated API conventions.

docs: add sandbox VPA validation simulation for INR UPI accounts (#258)

## Summary

- Documents the sandbox VPA validation simulation for INR UPI external accounts
- Adds VPA username suffix pattern table (1xx range) to both payouts-and-b2b and ramps sandbox testing pages
- Includes curl examples for testing matched and not-matched VPA scenarios

Corresponds to webdev PR: https://github.com/lightsparkdev/webdev/pull/24531

## Test plan

- [ ] Verify sandbox testing pages render correctly in Mintlify
- [ ] Confirm VPA suffix pattern table is clear and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

![image.png](https://app.graphite.com/user-attachments/assets/f2695513-e626-46a6-9fc1-39d19b733959.png)

fix: use import syntax for sandbox VPA validation snippet

The \<Snippet> tag wasn't rendering on the docs site. Switch to the
import/component pattern used by all other snippets in the codebase.

Co-Authored-By: Claude Opus 4.6 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)