### PR TITLE
Skip Vercel rebuild when grid-visualizer files are unchanged

### DIFF
--- a/components/grid-visualizer/vercel.json
+++ b/components/grid-visualizer/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- .",
   "installCommand": "npm install --ignore-scripts",
   "headers": [
     {


### PR DESCRIPTION
Adds `ignoreCommand` to `vercel.json` so the grid-visualizer Vercel project only rebuilds when files inside `components/grid-visualizer` change. Docs-only or OpenAPI-only commits to main won't trigger unnecessary builds.

Made with [Cursor](https://cursor.com)