### PR TITLE
Update flow builder iframe to Lightspark Vercel deployment

### DIFF
--- a/components/grid-visualizer/CLAUDE.md
+++ b/components/grid-visualizer/CLAUDE.md
@@ -17,7 +17,7 @@ Grid Visualizer is an interactive tool that helps integrators understand and get
 - **Docs site**: grid.lightspark.com
 - **Marketing site**: lightspark.com/grid
 - **Direct links** shared in sales conversations
-- Currently deployed at: https://grid-visualizer-opal.vercel.app/
+- Currently deployed at: https://grid-flow-builder.vercel.app/
 
 ## Tech Stack
 

--- a/mintlify/flow-builder.mdx
+++ b/mintlify/flow-builder.mdx
@@ -10,7 +10,7 @@ export const FlowBuilderEmbed = () => {
 
   React.useEffect(() => {
     const isDark = document.documentElement.classList.contains('dark');
-    setSrc('https://grid-visualizer-opal.vercel.app/?embed=true&theme=' + (isDark ? 'dark' : 'light'));
+    setSrc('https://grid-flow-builder.vercel.app/?embed=true&theme=' + (isDark ? 'dark' : 'light'));
 
     let ignoreNextMutation = false;
 


### PR DESCRIPTION
## Summary

Points the flow builder iframe in the docs from the personal Vercel deployment (`grid-visualizer-opal.vercel.app`) to the Lightspark team deployment (`grid-flow-builder.vercel.app`).

One-line change in `mintlify/flow-builder.mdx`.

## Test plan

- [ ] Verify flow builder loads on grid.lightspark.com/flow-builder after merge
- [ ] Check both light and dark theme sync works

Made with [Cursor](https://cursor.com)