### PR TITLE
fix: updating claude skill for latest grid api changes

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -6,8 +6,9 @@ description: >
   "what currencies does Grid support", "how do I use the Grid API", "send money to [country]",
   "pay [UMA address]", "send to CLABE", "send to PIX", "send to IBAN", "send to UPI",
   "fund sandbox account", "test a payment", "on-ramp", "off-ramp", "convert crypto to fiat",
-  "convert fiat to crypto", "look up UMA", "real-time quote", "JIT funding", or any payment
-  operations using the Grid API CLI.
+  "convert fiat to crypto", "look up UMA", "real-time quote", "JIT funding", "check exchange rate",
+  "FX rate", "payment corridor", "what rate will I get", "estimate withdrawal fee",
+  "crypto withdrawal fee", or any payment operations using the Grid API CLI.
 allowed-tools:
   - Bash
   - Read
@@ -28,7 +29,7 @@ Assist users with global payment operations via the Grid API. Core capabilities:
 
 For detailed information, read these reference files in the `references/` directory:
 
-- **`references/account-types.md`** - Country-specific external account requirements (CLABE, PIX, IBAN, UPI, etc.) with field requirements and curl examples. Read this when creating external accounts for international payments.
+- **`references/account-types.md`** - Country-specific external account requirements (MXN, BRL, EUR, INR, GBP, NGN, and 18 more) with field requirements and curl examples. Read this when creating external accounts for international payments.
 - **`references/endpoints.md`** - Complete API endpoint reference with methods, paths, and response codes. Read this when answering questions about specific API capabilities.
 - **`references/workflows.md`** - Step-by-step payment workflow guides for common scenarios (UMA payments, international transfers, on-ramp, off-ramp). Read this when guiding users through multi-step payment flows.
 
@@ -46,7 +47,7 @@ For detailed information, read these reference files in the `references/` direct
 
 - **Platform internal accounts**: For pooled funds, rewards distribution, treasury
 - **Customer internal accounts**: Per-currency holding accounts created automatically for each customer
-- **External accounts**: Traditional bank accounts (CLABE, IBAN, UPI, etc.) or crypto wallets
+- **External accounts**: Traditional bank accounts (MXN_ACCOUNT, EUR_ACCOUNT, USD_ACCOUNT, etc.) or crypto wallets
 
 ### Account Status Lifecycle
 
@@ -62,15 +63,15 @@ For detailed information, read these reference files in the `references/` direct
 
 The Grid API uses HTTP Basic Auth. Before making any API calls, ensure credentials and base URL are set as environment variables:
 
-- `GRID_API_TOKEN_ID` - API token ID
-- `GRID_API_CLIENT_SECRET` - API client secret
+- `GRID_CLIENT_ID` - API client ID
+- `GRID_CLIENT_SECRET` - API client secret
 - `GRID_BASE_URL` - API base URL
 
 If not set, load them from `~/.grid-credentials`:
 
 ```bash
-export GRID_API_TOKEN_ID=$(jq -r .apiTokenId ~/.grid-credentials)
-export GRID_API_CLIENT_SECRET=$(jq -r .apiClientSecret ~/.grid-credentials)
+export GRID_CLIENT_ID=$(jq -r '.clientId // .apiTokenId' ~/.grid-credentials)
+export GRID_CLIENT_SECRET=$(jq -r '.clientSecret // .apiClientSecret' ~/.grid-credentials)
 export GRID_BASE_URL=$(jq -r '.baseUrl // "https://api.lightspark.com/grid/2025-10-13"' ~/.grid-credentials)
 ```
 
@@ -94,14 +95,14 @@ For questions not covered by this skill's reference files, fetch additional info
 All API calls use HTTP Basic Auth via `curl -u`:
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/<endpoint>"
 ```
 
 For POST/PATCH requests, add the JSON body:
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   -H "Content-Type: application/json" \
   -d '<json-body>' \
@@ -116,11 +117,11 @@ Pipe through `jq` for readable output: `| jq .`
 
 ```bash
 # Get platform config (currencies, limits)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/config" | jq .
 
 # Update platform config (e.g., set webhook endpoint)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X PATCH -H "Content-Type: application/json" \
   -d '{"webhookEndpoint": "https://example.com/webhooks"}' \
   "$GRID_BASE_URL/config" | jq .
@@ -130,15 +131,15 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # List customers
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers?limit=20" | jq .
 
 # Get customer details
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/<customerId>" | jq .
 
 # Create customer
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "platformCustomerId": "<platform-id>",
@@ -148,18 +149,18 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers" | jq .
 
 # Update customer (customerType is required)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X PATCH -H "Content-Type: application/json" \
   -d '{"customerType": "INDIVIDUAL", "fullName": "New Name"}' \
   "$GRID_BASE_URL/customers/<customerId>" | jq .
 
 # Delete customer
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X DELETE \
   "$GRID_BASE_URL/customers/<customerId>" | jq .
 
 # Generate KYC link (GET with query params)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/kyc-link?platformCustomerId=<platformCustomerId>&redirectUri=https://example.com/callback" | jq .
 ```
 
@@ -167,25 +168,26 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # List customer internal accounts
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/internal-accounts?customerId=<customerId>" | jq .
 
 # List platform internal accounts
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/platform/internal-accounts" | jq .
 
 # List customer external accounts
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/external-accounts?customerId=<customerId>" | jq .
 
-# Create external account (example: Mexico CLABE - Individual)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+# Create external account (example: Mexico MXN_ACCOUNT - Individual)
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
     "accountInfo": {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
+      "paymentRails": ["SPEI"],
       "clabeNumber": "<18-digit-number>",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -198,13 +200,72 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
-For all supported account types (PIX, IBAN, UPI, NGN, US, crypto wallets) and their field requirements, read `references/account-types.md`.
+For all 24 supported fiat account types and 6 crypto wallet types with their field requirements, read `references/account-types.md`.
+
+### Exchange Rates (Pre-Quote FX Rates)
+
+Use this to check indicative FX rates for a payment corridor **before** creating a receiving account or a quote. Rates are cached ~5 minutes and include platform-specific fees.
+
+```bash
+# Get all available corridors from USD
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  "$GRID_BASE_URL/exchange-rates?sourceCurrency=USD" | jq .
+
+# Get rate for a specific corridor (USD → INR)
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  "$GRID_BASE_URL/exchange-rates?sourceCurrency=USD&destinationCurrency=INR" | jq .
+
+# Get rate with a specific sending amount (10000 = $100.00 in cents)
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  "$GRID_BASE_URL/exchange-rates?sourceCurrency=USD&destinationCurrency=INR&sendingAmount=10000" | jq .
+
+# Get rates for multiple destination currencies
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  "$GRID_BASE_URL/exchange-rates?sourceCurrency=USD&destinationCurrency=INR&destinationCurrency=EUR" | jq .
+```
+
+The response includes per-corridor:
+- `sourceCurrency` / `destinationCurrency` with code, decimals, name, symbol
+- `destinationPaymentRail` (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+- `sendingAmount` / `receivingAmount` in smallest currency units
+- `minSendingAmount` / `maxSendingAmount` — corridor limits
+- `exchangeRate` — units of destination per unit of source
+- `fees.fixed` — fixed fee in smallest unit of sending currency
+- `updatedAt` — when the rate was last refreshed
+
+**Note:** These are indicative cached rates. For a locked, executable rate, create a quote via `POST /quotes`.
+
+### Crypto Withdrawal Fee Estimation
+
+Estimate network and application fees before a crypto withdrawal:
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "internalAccountId": "<internalAccountId>",
+    "currency": "USDC",
+    "cryptoNetwork": "SOLANA_MAINNET",
+    "amount": 1000000,
+    "destinationAddress": "<blockchain-address>"
+  }' \
+  "$GRID_BASE_URL/crypto/estimate-withdrawal-fee" | jq .
+```
+
+Returns:
+- `networkFee` — gas fee in `networkFeeAsset` units (e.g., lamports for SOL)
+- `networkFeeAsset` — asset used for network fee (e.g., SOL)
+- `applicationFee` — platform fee in withdrawal currency units
+- `totalFee` — total cost in withdrawal currency (network fee converted + application fee)
+- `netAmount` — amount recipient receives after all fees
+
+Supported networks: `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`, `POLYGON_MAINNET`, `TRON_MAINNET`
 
 ### Quotes (Cross-Currency Transfers)
 
 ```bash
 # Account-funded to UMA: Use when funds are already in an internal account
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -222,7 +283,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/quotes" | jq .
 
 # Account-funded to external account: IMPORTANT - always include destination currency
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -240,7 +301,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/quotes" | jq .
 
 # Real-time/JIT funded: Returns paymentInstructions for funding
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -259,16 +320,16 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/quotes" | jq .
 
 # Execute a quote
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   "$GRID_BASE_URL/quotes/<quoteId>/execute" | jq .
 
 # List quotes
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/quotes?status=PENDING" | jq .
 
 # Get quote details
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/quotes/<quoteId>" | jq .
 ```
 
@@ -276,7 +337,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # Transfer in (external → internal, same currency)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {"accountId": "<externalAccountId>"},
@@ -286,7 +347,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/transfer-in" | jq .
 
 # Transfer out (internal → external, same currency)
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {"accountId": "<internalAccountId>"},
@@ -300,20 +361,20 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # List transactions
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions?status=PENDING" | jq .
 
 # Get transaction details
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions/<transactionId>" | jq .
 
 # Approve incoming payment
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   "$GRID_BASE_URL/transactions/<transactionId>/approve" | jq .
 
 # Reject incoming payment
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{"reason": "Reason for rejection"}' \
   "$GRID_BASE_URL/transactions/<transactionId>/reject" | jq .
@@ -323,11 +384,11 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # Look up UMA address capabilities
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/receiver/uma/%24alice%40example.com" | jq .
 
 # Look up external account capabilities
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/receiver/external-account/<accountId>" | jq .
 ```
 
@@ -337,19 +398,19 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # Fund an internal account in sandbox
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{"amount": 100000}' \
   "$GRID_BASE_URL/sandbox/internal-accounts/<internalAccountId>/fund" | jq .
 
 # Simulate sending funds to a real-time quote
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{"quoteId": "<quoteId>", "currencyCode": "<code>"}' \
   "$GRID_BASE_URL/sandbox/send" | jq .
 
 # Simulate receiving a UMA payment
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "senderUmaAddress": "$sender@sandbox.grid.uma.money",
@@ -397,6 +458,7 @@ Internal Account (USD) → External Account (USD)  [transfer-out]
 
 For step-by-step payment workflows, read `references/workflows.md`. Common workflows:
 
+- **Check FX Rate (Pre-Quote)**: Query `GET /exchange-rates` for indicative rates before setting up accounts or quotes
 - **UMA Payment**: Receiver lookup -> Quote -> Confirm -> Execute
 - **International Bank Transfer**: Create external account -> Receiver lookup -> Quote -> Confirm -> Execute
 - **On-Ramp (Fiat to Crypto)**: Verify KYC -> Deposit fiat -> Create crypto external account -> Quote with `immediatelyExecute`
@@ -416,7 +478,7 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
 
 1. Create a quote with `sourceType: "REALTIME_FUNDING"`. Destination can be an internal account, external account, or UMA address.
 2. The response includes `paymentInstructions` with **multiple funding options simultaneously** (e.g., Lightning + Spark for BTC, Solana + Base + Polygon for USDC). Show all options to the user.
-3. **Auto-execution**: Once the user sends funds to ANY of the provided addresses, Grid automatically detects the deposit and executes at the locked rate. Do NOT call the execute endpoint for JIT quotes. Webhooks sent: `ACCOUNT_STATUS` on deposit, `OUTGOING_PAYMENT` on completion.
+3. **Auto-execution**: Once the user sends funds to ANY of the provided addresses, Grid automatically detects the deposit and executes at the locked rate. Do NOT call the execute endpoint for JIT quotes. Webhooks sent: `internal-account-status` on deposit, `outgoing-payment` on completion.
 4. **Quote expiration**: Quotes expire in 1-5 minutes. If expired, create a new quote.
 
 ## Best Practices and Common Pitfalls
@@ -428,9 +490,9 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
 5. **Pipe through jq**: Always append `| jq .` for readable output, or `| jq -r .field` to extract specific values
 6. **URL-encode special characters**: UMA addresses contain `$` — encode as `%24` in URL paths
 7. **Always include destination currency in quotes**: When specifying a destination account, you MUST include `currency` in the destination object even though the external account already has a currency
-8. **Individual beneficiary fields are all required**: For `beneficiaryType: "INDIVIDUAL"`, you MUST include `fullName`, `birthDate` (YYYY-MM-DD), and `nationality` (2-letter code) in the `beneficiary` object
+8. **Individual beneficiary requires fullName**: For `beneficiaryType: "INDIVIDUAL"`, `fullName` is required. `birthDate` (YYYY-MM-DD) and `nationality` (2-letter code) are optional but recommended
 9. **Use correct Nigerian field names**: Use `bankName` (NOT `bankCode`) and include `purposeOfPayment`
-10. **Don't forget country-specific required fields**: Brazil (PIX) requires `pixKey`, `pixKeyType`, and `taxId`; Europe (IBAN) requires `swiftBic`
+10. **Don't forget country-specific required fields**: Brazil (BRL_ACCOUNT) requires `pixKey`, `pixKeyType`, and `taxId`; Europe (EUR_ACCOUNT) requires `iban`; all fiat accounts require `paymentRails`
 
 ## Error Handling
 

--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -4,44 +4,61 @@ This reference maps countries/regions to their required account types and fields
 
 ## Account Type Summary
 
-| Country/Region | Account Type | Currency | Primary Identifier |
-|----------------|--------------|----------|-------------------|
-| Mexico | CLABE | MXN | 18-digit CLABE number |
-| Brazil | PIX | BRL | PIX key (CPF/CNPJ/email/phone/random) |
-| Europe (SEPA) | IBAN | EUR | IBAN number |
-| United States | US_ACCOUNT | USD | Account + Routing number |
-| India | UPI | INR | UPI ID (user@bank) |
-| Nigeria | NGN_ACCOUNT | NGN | Account number + Bank code |
-| Canada | CAD_ACCOUNT | CAD | Bank code + Branch code + Account number |
-| United Kingdom | GBP_ACCOUNT | GBP | Sort code + Account number |
-| Philippines | PHP_ACCOUNT | PHP | Bank name + Account number |
-| Singapore | SGD_ACCOUNT | SGD | SWIFT code + Account number |
+| Country/Region | Account Type | Currency | Payment Rail(s) | Primary Identifier |
+|----------------|--------------|----------|-----------------|-------------------|
+| Brazil | BRL_ACCOUNT | BRL | PIX | PIX key |
+| Canada | CAD_ACCOUNT | CAD | BANK_TRANSFER | Bank code + Branch code + Account number |
+| Denmark | DKK_ACCOUNT | DKK | SEPA, SEPA_INSTANT | IBAN |
+| Europe (SEPA) | EUR_ACCOUNT | EUR | SEPA, SEPA_INSTANT | IBAN |
+| Hong Kong | HKD_ACCOUNT | HKD | BANK_TRANSFER | Bank name + SWIFT + Account number |
+| India | INR_ACCOUNT | INR | UPI | UPI VPA (user@bank) |
+| Indonesia | IDR_ACCOUNT | IDR | BANK_TRANSFER | Bank name + SWIFT + Account number + Phone |
+| Kenya | KES_ACCOUNT | KES | MOBILE_MONEY | Phone number + Provider |
+| Malawi | MWK_ACCOUNT | MWK | MOBILE_MONEY | Phone number + Provider |
+| Malaysia | MYR_ACCOUNT | MYR | BANK_TRANSFER | Bank name + SWIFT + Account number |
+| Mexico | MXN_ACCOUNT | MXN | SPEI | 18-digit CLABE number |
+| Nigeria | NGN_ACCOUNT | NGN | BANK_TRANSFER | Bank name + Account number |
+| Philippines | PHP_ACCOUNT | PHP | BANK_TRANSFER | Bank name + Account number |
+| Rwanda | RWF_ACCOUNT | RWF | MOBILE_MONEY | Phone number + Provider |
+| Singapore | SGD_ACCOUNT | SGD | PAYNOW, FAST, BANK_TRANSFER | Bank name + SWIFT + Account number |
+| South Africa | ZAR_ACCOUNT | ZAR | BANK_TRANSFER | Bank name + Account number |
+| Tanzania | TZS_ACCOUNT | TZS | MOBILE_MONEY | Phone number + Provider |
+| Thailand | THB_ACCOUNT | THB | BANK_TRANSFER | Bank name + SWIFT + Account number |
+| Uganda | UGX_ACCOUNT | UGX | MOBILE_MONEY | Phone number + Provider |
+| United Kingdom | GBP_ACCOUNT | GBP | FASTER_PAYMENTS | Sort code + Account number |
+| United States | USD_ACCOUNT | USD | ACH, WIRE, RTP, FEDNOW | Routing number + Account number |
+| Vietnam | VND_ACCOUNT | VND | BANK_TRANSFER | Bank name + SWIFT + Account number |
+| West Africa (CFA) | XOF_ACCOUNT | XOF | MOBILE_MONEY | Phone number + Provider |
+| Zambia | ZMW_ACCOUNT | ZMW | MOBILE_MONEY | Phone number + Provider |
 
 ## Crypto/Wallet Types
 
 | Type | Currency | Primary Identifier |
 |------|----------|-------------------|
 | SPARK_WALLET | BTC | Spark wallet address |
-| LIGHTNING | BTC | Lightning invoice or address |
+| LIGHTNING | BTC | Lightning invoice, bolt12 offer, or lightning address |
 | SOLANA_WALLET | USDC | Solana wallet address |
-| TRON_WALLET | USDT | Tron wallet address |
-| POLYGON_WALLET | USDC | Polygon wallet address |
-| BASE_WALLET | USDC | Base wallet address |
+| TRON_WALLET | USDT | TRON wallet address |
+| POLYGON_WALLET | USDC | Polygon wallet address (0x...) |
+| BASE_WALLET | USDC | Base wallet address (0x...) |
 
 ## Detailed Field Requirements
 
-### Mexico (CLABE)
+**IMPORTANT**: All fiat account types now require a `paymentRails` field specifying the payment rail to use.
+
+### Mexico (MXN_ACCOUNT)
 
 **Individual beneficiary:**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
     "accountInfo": {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
+      "paymentRails": ["SPEI"],
       "clabeNumber": "<18-digit-clabe>",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -57,13 +74,14 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 **Business beneficiary:**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "MXN",
     "accountInfo": {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
+      "paymentRails": ["SPEI"],
       "clabeNumber": "<18-digit-clabe>",
       "beneficiary": {
         "beneficiaryType": "BUSINESS",
@@ -77,19 +95,20 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 Required fields:
 
 - `clabeNumber`: 18-digit CLABE number (validates with check digit)
-- For individuals: `fullName`, `birthDate`, `nationality` (ALL THREE REQUIRED)
+- For individuals: `fullName` (required), `birthDate`, `nationality` (optional but recommended)
 - For businesses: `legalName`
 
-### Brazil (PIX)
+### Brazil (BRL_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "BRL",
     "accountInfo": {
-      "accountType": "PIX",
+      "accountType": "BRL_ACCOUNT",
+      "paymentRails": ["PIX"],
       "pixKey": "12345678901",
       "pixKeyType": "CPF",
       "taxId": "12345678901",
@@ -104,6 +123,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
+- `paymentRails`: `PIX`
 - `pixKey`: The PIX key value
 - `pixKeyType`: One of `CPF`, `CNPJ`, `EMAIL`, `PHONE`, `RANDOM`
 - `taxId`: Tax ID of the account holder
@@ -116,16 +136,17 @@ PIX key formats:
 - Phone: +55 followed by number
 - Random: 32-character alphanumeric EVP key
 
-### Europe (IBAN)
+### Europe (EUR_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "EUR",
     "accountInfo": {
-      "accountType": "IBAN",
+      "accountType": "EUR_ACCOUNT",
+      "paymentRails": ["SEPA_INSTANT"],
       "iban": "DE89370400440532013000",
       "swiftBic": "COBADEFFXXX",
       "beneficiary": {
@@ -147,24 +168,54 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
+- `paymentRails`: `SEPA` or `SEPA_INSTANT`
 - `iban`: International Bank Account Number (15-34 characters)
-- `swiftBic`: SWIFT/BIC code (8 or 11 characters, pattern: `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`)
+- `swiftBic`: SWIFT/BIC code (8 or 11 characters, pattern: `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`) — optional
 
-IBAN format: Country code (2) + Check digits (2) + BBAN (up to 30)
+### Denmark (DKK_ACCOUNT)
 
-### United States (US_ACCOUNT)
+Same structure as EUR_ACCOUNT but with currency `DKK`:
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "DKK",
+    "accountInfo": {
+      "accountType": "DKK_ACCOUNT",
+      "paymentRails": ["SEPA"],
+      "iban": "DK5000400440116243",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "DK"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `SEPA` or `SEPA_INSTANT`
+- `iban`: IBAN number
+- `swiftBic`: optional
+
+### United States (USD_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "USD",
     "accountInfo": {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
+      "paymentRails": ["ACH"],
       "routingNumber": "123456789",
       "accountNumber": "12345678901",
-      "accountCategory": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Full Name",
@@ -185,20 +236,21 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
+- `paymentRails`: `ACH`, `WIRE`, `RTP`, or `FEDNOW`
 - `routingNumber`: 9-digit ABA routing number
 - `accountNumber`: Bank account number
-- `accountCategory`: CHECKING or SAVINGS
 
-### India (UPI)
+### India (INR_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "INR",
     "accountInfo": {
-      "accountType": "UPI",
+      "accountType": "INR_ACCOUNT",
+      "paymentRails": ["UPI"],
       "vpa": "user@okbank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -211,21 +263,51 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
-UPI ID format: `username@bankhandle` (e.g., `john@okaxis`, `jane@ybl`)
+UPI VPA format: `username@bankhandle` (e.g., `john@okaxis`, `jane@ybl`)
+
+### United Kingdom (GBP_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "GBP",
+    "accountInfo": {
+      "accountType": "GBP_ACCOUNT",
+      "paymentRails": ["FASTER_PAYMENTS"],
+      "sortCode": "12-34-56",
+      "accountNumber": "12345678",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "GB"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `FASTER_PAYMENTS`
+- `sortCode`: 6-digit sort code (pattern: `^[0-9]{2}-?[0-9]{2}-?[0-9]{2}$`)
+- `accountNumber`: 8-digit account number (pattern: `^[0-9]{8}$`)
 
 ### Nigeria (NGN_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "NGN",
     "accountInfo": {
       "accountType": "NGN_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
       "accountNumber": "1234567890",
       "bankName": "GTBank",
-      "purposeOfPayment": "GOODS_OR_SERVICES",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Full Name",
@@ -239,32 +321,25 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
-- `accountNumber`: 10-digit account number
+- `paymentRails`: `BANK_TRANSFER`
+- `accountNumber`: 10-digit account number (pattern: `^[0-9]{10}$`)
 - `bankName`: Bank name (e.g., "GTBank", "Zenith Bank", "Access Bank")
-- `purposeOfPayment`: Purpose code (e.g., `GOODS_OR_SERVICES`)
 - For individuals: `fullName`, `birthDate`, `nationality`
 - For businesses: `legalName`
 
 **IMPORTANT**: Use `bankName` (NOT `bankCode`). Use the bank's display name.
 
-Common Nigerian banks:
-
-- GTBank
-- Zenith Bank
-- United Bank for Africa
-- Access Bank
-- First Bank of Nigeria
-
 ### Canada (CAD_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "CAD",
     "accountInfo": {
       "accountType": "CAD_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
       "bankCode": "001",
       "branchCode": "00012",
       "accountNumber": "1234567",
@@ -281,48 +356,22 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
-- `bankCode`: 3-digit financial institution number
-- `branchCode`: 5-digit transit number
-- `accountNumber`: 7-12 digit account number
-
-### United Kingdom (GBP_ACCOUNT)
-
-```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
-  -X POST -H "Content-Type: application/json" \
-  -d '{
-    "customerId": "<customerId>",
-    "currency": "GBP",
-    "accountInfo": {
-      "accountType": "GBP_ACCOUNT",
-      "sortCode": "12-34-56",
-      "accountNumber": "12345678",
-      "beneficiary": {
-        "beneficiaryType": "INDIVIDUAL",
-        "fullName": "Full Name",
-        "birthDate": "1990-01-15",
-        "nationality": "GB"
-      }
-    }
-  }' \
-  "$GRID_BASE_URL/customers/external-accounts" | jq .
-```
-
-Required fields:
-
-- `sortCode`: 6-digit sort code (may include hyphens, e.g., `12-34-56`)
-- `accountNumber`: 8-digit account number
+- `paymentRails`: `BANK_TRANSFER`
+- `bankCode`: 3-digit financial institution number (pattern: `^[0-9]{3}$`)
+- `branchCode`: 5-digit transit number (pattern: `^[0-9]{5}$`)
+- `accountNumber`: 7-12 digit account number (pattern: `^[0-9]{7,12}$`)
 
 ### Philippines (PHP_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "PHP",
     "accountInfo": {
       "accountType": "PHP_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
       "bankName": "BDO Unibank",
       "accountNumber": "1234567890",
       "beneficiary": {
@@ -338,19 +387,21 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
+- `paymentRails`: `BANK_TRANSFER`
 - `bankName`: Name of the bank
 - `accountNumber`: Bank account number
 
 ### Singapore (SGD_ACCOUNT)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
     "currency": "SGD",
     "accountInfo": {
       "accountType": "SGD_ACCOUNT",
+      "paymentRails": ["FAST"],
       "bankName": "DBS Bank",
       "swiftCode": "DBSSSGSG",
       "accountNumber": "1234567890",
@@ -367,16 +418,285 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 Required fields:
 
+- `paymentRails`: `PAYNOW`, `FAST`, or `BANK_TRANSFER`
 - `bankName`: Name of the bank
 - `swiftCode`: SWIFT/BIC code (8 or 11 characters)
 - `accountNumber`: Bank account number
+
+### Hong Kong (HKD_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "HKD",
+    "accountInfo": {
+      "accountType": "HKD_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "HSBC",
+      "swiftCode": "HSBCHKHH",
+      "accountNumber": "123456789012",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "HK"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`: Name of the bank
+- `swiftCode`: SWIFT/BIC code (8 or 11 characters)
+- `accountNumber`: Bank account number
+
+### Indonesia (IDR_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "IDR",
+    "accountInfo": {
+      "accountType": "IDR_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "Bank Central Asia",
+      "swiftCode": "CENAIDJA",
+      "accountNumber": "1234567890",
+      "phoneNumber": "+628123456789",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "ID"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`: Name of the bank
+- `swiftCode`: SWIFT/BIC code
+- `accountNumber`: Bank account number
+- `phoneNumber`: Indonesian phone number (pattern: `^\+62[0-9]{9,12}$`)
+
+### Malaysia (MYR_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "MYR",
+    "accountInfo": {
+      "accountType": "MYR_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "Maybank",
+      "swiftCode": "MABORJMJXXX",
+      "accountNumber": "1234567890",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "MY"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`, `swiftCode`, `accountNumber`
+
+### Thailand (THB_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "THB",
+    "accountInfo": {
+      "accountType": "THB_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "Bangkok Bank",
+      "swiftCode": "BKKBTHBK",
+      "accountNumber": "1234567890",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "TH"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`, `swiftCode`, `accountNumber`
+
+### Vietnam (VND_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "VND",
+    "accountInfo": {
+      "accountType": "VND_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "Vietcombank",
+      "swiftCode": "BFTVVNVX",
+      "accountNumber": "1234567890",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "VN"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`, `swiftCode`, `accountNumber`
+
+### South Africa (ZAR_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "ZAR",
+    "accountInfo": {
+      "accountType": "ZAR_ACCOUNT",
+      "paymentRails": ["BANK_TRANSFER"],
+      "bankName": "Standard Bank",
+      "accountNumber": "1234567890",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "ZA"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Required fields:
+
+- `paymentRails`: `BANK_TRANSFER`
+- `bankName`: Name of the bank
+- `accountNumber`: 9-13 digit account number (pattern: `^[0-9]{9,13}$`)
+
+### Mobile Money Accounts (Africa)
+
+Several African countries use mobile money. They all share a similar structure with `phoneNumber` and `provider`.
+
+#### Kenya (KES_ACCOUNT)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "KES",
+    "accountInfo": {
+      "accountType": "KES_ACCOUNT",
+      "paymentRails": ["MOBILE_MONEY"],
+      "phoneNumber": "+254712345678",
+      "provider": "M-Pesa",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "KE"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+#### Rwanda (RWF_ACCOUNT)
+
+Phone pattern: `^\+250[0-9]{9}$`
+
+#### Tanzania (TZS_ACCOUNT)
+
+Phone pattern: `^\+255[0-9]{9}$`
+
+#### Uganda (UGX_ACCOUNT)
+
+Phone pattern: `^\+256[0-9]{9}$`
+
+#### Malawi (MWK_ACCOUNT)
+
+Phone pattern: `^\+265[0-9]{9}$`
+
+#### Zambia (ZMW_ACCOUNT)
+
+Phone pattern: `^\+260[0-9]{9}$`
+
+#### West Africa CFA (XOF_ACCOUNT)
+
+Supports Senegal (+221), Ivory Coast (+225), and Benin (+229):
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "XOF",
+    "accountInfo": {
+      "accountType": "XOF_ACCOUNT",
+      "paymentRails": ["MOBILE_MONEY"],
+      "countries": ["SN"],
+      "phoneNumber": "+221771234567",
+      "provider": "Orange Money",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Full Name",
+        "birthDate": "1990-01-15",
+        "nationality": "SN"
+      }
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Mobile money required fields:
+
+- `paymentRails`: `MOBILE_MONEY`
+- `phoneNumber`: Country-specific format (see patterns above)
+- `provider`: Mobile money provider name
+- `countries`: Required for XOF_ACCOUNT (enum: `SN`, `BJ`, `CI`), MWK_ACCOUNT (`MW`), UGX_ACCOUNT (`UG`)
 
 ### Crypto Wallets
 
 #### Spark Wallet (Bitcoin)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
@@ -389,10 +709,28 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
+#### Lightning (Bitcoin)
+
+```bash
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "<customerId>",
+    "currency": "BTC",
+    "accountInfo": {
+      "accountType": "LIGHTNING",
+      "lightningAddress": "user@domain.com"
+    }
+  }' \
+  "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Lightning supports one of: `invoice` (bolt11), `bolt12` (bolt12 offer), or `lightningAddress` (user@domain format).
+
 #### Solana Wallet (USDC)
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "<customerId>",
@@ -405,18 +743,26 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/external-accounts" | jq .
 ```
 
+#### Other Crypto Wallets
+
+- **TRON_WALLET**: USDT, requires `address`
+- **POLYGON_WALLET**: USDC, requires `address` (0x format)
+- **BASE_WALLET**: USDC, requires `address` (0x format)
+
+**Note:** Crypto wallets do NOT require beneficiary information.
+
 ## Beneficiary Information
 
-**CRITICAL**: All external accounts require beneficiary information. The required fields depend on the beneficiary type.
+**CRITICAL**: All fiat external accounts require beneficiary information. The required fields depend on the beneficiary type.
 
 ### For Individuals (beneficiaryType: "INDIVIDUAL")
 
-**All three fields are REQUIRED in the `beneficiary` object:**
+**`fullName` is REQUIRED in the `beneficiary` object. Other fields are optional but recommended:**
 
-- `fullName`: Full legal name
+- `fullName`: Full legal name (REQUIRED)
 - `birthDate`: Date of birth (YYYY-MM-DD format)
 - `nationality`: 2-letter ISO country code (e.g., NG, MX, IN, US)
-- `address`: Optional but recommended (object with `line1`, `city`, `state`, `postalCode`, `country`)
+- `address`: Object with `line1`, `city`, `state`, `postalCode`, `country`
 
 ### For Businesses (beneficiaryType: "BUSINESS")
 

--- a/.claude/skills/grid-api/references/endpoints.md
+++ b/.claude/skills/grid-api/references/endpoints.md
@@ -8,7 +8,7 @@ Production: `https://api.lightspark.com/grid/2025-10-13`
 
 ## Authentication
 
-HTTP Basic Auth: `Authorization: Basic base64(tokenId:clientSecret)`
+HTTP Basic Auth: `Authorization: Basic base64(clientId:clientSecret)`
 
 ## Platform Configuration
 
@@ -16,6 +16,21 @@ HTTP Basic Auth: `Authorization: Basic base64(tokenId:clientSecret)`
 |--------|----------|-------------|
 | GET | `/config` | Get platform configuration |
 | PATCH | `/config` | Update platform configuration |
+
+## Exchange Rates
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/exchange-rates` | Get cached FX rates for payment corridors |
+
+Query parameters: `sourceCurrency`, `destinationCurrency` (repeatable), `sendingAmount` (default 10000).
+Rates are cached ~5 minutes and include platform-specific fees.
+
+## Crypto
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/crypto/estimate-withdrawal-fee` | Estimate network + app fees for crypto withdrawal |
 
 ## Customers
 
@@ -26,7 +41,7 @@ HTTP Basic Auth: `Authorization: Basic base64(tokenId:clientSecret)`
 | GET | `/customers/{customerId}` | Get customer details |
 | PATCH | `/customers/{customerId}` | Update customer |
 | DELETE | `/customers/{customerId}` | Delete customer |
-| POST | `/customers/kyc-link` | Generate KYC link |
+| GET | `/customers/kyc-link` | Generate KYC link |
 | POST | `/customers/bulk/csv` | Bulk upload customers |
 | GET | `/customers/bulk/jobs/{jobId}` | Get bulk job status |
 
@@ -63,16 +78,45 @@ Internal accounts are auto-created when customers are created based on platform 
 | GET | `/quotes/{quoteId}` | Get quote details |
 | POST | `/quotes/{quoteId}/execute` | Execute a pending quote |
 
-### Quote Source Types
+### Quote Source Types (`sourceType` discriminator)
 
-- `source.accountId`: Internal account ID
-- `source.customerId` + `source.currency`: Customer-funded with payment instructions
+- `ACCOUNT`: Internal account funded. Fields: `accountId`
+- `REALTIME_FUNDING`: Just-in-time funded. Fields: `customerId`, `currency`
 
-### Quote Destination Types
+### Quote Destination Types (`destinationType` discriminator)
 
-- `destination.accountId`: External account ID
-- `destination.umaAddress` + `destination.currency`: UMA address
-- `destination.externalAccountDetails`: Inline account creation
+- `ACCOUNT`: External or internal account. Fields: `accountId`, `currency`
+- `UMA_ADDRESS`: UMA address. Fields: `umaAddress`, `currency`
+- `EXTERNAL_ACCOUNT_DETAILS`: Inline account creation (creates external account + quote in one step). Fields: `externalAccountDetails` (same shape as external account create request)
+
+### Quote Request Fields
+
+- `lookupId`: Lookup ID from receiver lookup (required for UMA destinations)
+- `lockedCurrencySide`: `SENDING` or `RECEIVING`
+- `lockedCurrencyAmount`: Amount in smallest currency unit
+- `immediatelyExecute`: Skip confirmation and execute immediately (default false)
+- `purposeOfPayment`: Required for certain geographies (e.g., India). Values: `GIFT`, `SELF`, `GOODS_OR_SERVICES`, `EDUCATION`, `HEALTH_OR_MEDICAL`, `REAL_ESTATE_PURCHASE`, `TAX_PAYMENT`, `LOAN_PAYMENT`, `UTILITY_BILL`, `DONATION`, `TRAVEL`, `OTHER`
+- `senderCustomerInfo`: Key-value pairs of sender info requested by destination (from receiver lookup `requiredPayerDataFields`)
+- `description`: Optional memo
+
+### Quote Response Fields
+
+- `totalSendingAmount` / `totalReceivingAmount`: Amounts in smallest currency units
+- `sendingCurrency` / `receivingCurrency`: Currency objects with code, decimals, name, symbol
+- `exchangeRate`: Units of sending currency per receiving currency unit
+- `feesIncluded`: Fees in smallest unit of sending currency
+- `paymentInstructions`: Funding options (for REALTIME_FUNDING sources)
+- `expiresAt`: Quote expiration timestamp
+- `transactionId`: Associated transaction ID
+- `rateDetails`: Detailed rate and fee breakdown
+
+### Quote Statuses
+
+- `PENDING`: Awaiting execution
+- `PROCESSING`: Being executed
+- `COMPLETED`: Successfully completed
+- `FAILED`: Execution failed
+- `EXPIRED`: Quote expired before execution
 
 ## Receiver Lookup
 
@@ -99,27 +143,30 @@ Returns: supported currencies, min/max amounts, required payer data fields.
 
 ### Transaction Statuses
 
-- `PENDING`: Awaiting processing
-- `PENDING_APPROVAL`: Needs approval (incoming)
-- `PROCESSING`: In progress
-- `COMPLETED`: Successfully completed
-- `FAILED`: Failed
-- `CANCELLED`: Cancelled
+- `CREATED`: Initial lookup has been created
+- `PENDING`: Quote has been created
+- `PROCESSING`: Funding received, payment initiated
+- `COMPLETED`: Payment sent to destination network
+- `REJECTED`: Receiving institution rejected payment, refunded
+- `FAILED`: An error occurred during payment
+- `REFUNDED`: Payment unable to complete, refunded
+- `EXPIRED`: Quote expired
 
 ## Webhooks
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/webhooks/test` | Send test webhook |
+| POST | `/sandbox/webhooks/test` | Send test webhook (sandbox only) |
 
 ### Webhook Events
 
 - `incoming-payment`: Payment received
 - `outgoing-payment`: Payment status update
-- `kyc-status`: KYC status change
-- `account-status`: Account status change
+- `customer-update`: Customer information or KYC status change
+- `internal-account-status`: Internal account status change
 - `bulk-upload`: Bulk job completion
 - `invitation-claimed`: Invitation claimed
+- `test-webhook`: Test event (sandbox only)
 
 ## Invitations
 

--- a/.claude/skills/grid-api/references/workflows.md
+++ b/.claude/skills/grid-api/references/workflows.md
@@ -13,20 +13,21 @@ Use this when the user wants to send money to a UMA address like `$alice@example
 1. **Look up the receiver**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/receiver/uma/%24alice%40example.com" | jq .
 ```
 
 This returns:
 
+- `id`: Lookup ID (use as `lookupId` when creating a quote — required for UMA destinations)
 - Supported currencies
 - Min/max amounts per currency
-- Required payer data fields
+- Required payer data fields (`requiredPayerDataFields`)
 
 2. **Check sender's balance**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/internal-accounts?customerId=<customerId>" | jq .
 ```
 
@@ -34,10 +35,13 @@ Identify the internal account with sufficient balance.
 
 3. **Create a quote**
 
+**Note:** `lookupId` from step 1 is required for UMA destinations.
+
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
+    "lookupId": "Lookup:xxx",
     "source": {
       "sourceType": "ACCOUNT",
       "accountId": "InternalAccount:xxx"
@@ -56,11 +60,13 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 The response includes:
 
-- `sendingAmount` and `sendingCurrency`
-- `receivingAmount` and `receivingCurrency`
+- `totalSendingAmount` and `sendingCurrency`
+- `totalReceivingAmount` and `receivingCurrency`
 - `exchangeRate`
-- `fees` array
+- `feesIncluded` (fees in smallest unit of sending currency)
 - `expiresAt` (quote validity)
+- `transactionId` (associated transaction)
+- `rateDetails` (detailed rate breakdown)
 
 4. **Show the user the exchange details and get confirmation**
 
@@ -69,7 +75,7 @@ Example: "You're sending $100.00 USD. The recipient will receive €92.15 EUR (r
 5. **Execute the quote**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   "$GRID_BASE_URL/quotes/Quote:xxx/execute" | jq .
 ```
@@ -77,9 +83,44 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 6. **Monitor the transaction**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions?status=PROCESSING" | jq .
 ```
+
+## Workflow 1b: Check FX Rate Before Setting Up a Payment
+
+Use this when an integrator wants to preview exchange rates for a payment corridor **before** creating a receiving account or quote. This is useful for showing indicative pricing in a UI or deciding which corridor to use.
+
+### Steps
+
+1. **Query exchange rates for the corridor**
+
+```bash
+# Check USD → INR rate for a $100 send
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  "$GRID_BASE_URL/exchange-rates?sourceCurrency=USD&destinationCurrency=INR&sendingAmount=10000" | jq .
+```
+
+The response returns an array of rate objects. Each includes:
+- `exchangeRate`, `receivingAmount`, `fees.fixed`
+- `minSendingAmount` / `maxSendingAmount` for the corridor
+- `destinationPaymentRail` (e.g., UPI, SEPA_INSTANT)
+
+2. **Show the user indicative pricing**
+
+Example: "USD → INR via UPI: Rate 82.50, you send $100.00 → recipient gets ₹8,250.00. Fixed fee: $1.00. Min $1.00, max $100,000.00."
+
+3. **If the user wants to proceed, continue with a normal payment workflow**
+
+- If sending to a UMA address → Workflow 1
+- If sending to a bank account → Workflow 2
+- The actual executed rate will be locked when the quote is created via `POST /quotes`
+
+**Key differences from quotes:**
+- Exchange rates are **indicative** (cached ~5 minutes), not locked
+- No account or customer setup required — useful for rate discovery
+- No quote expiration to worry about
+- Multiple corridors can be compared in a single request by omitting `destinationCurrency`
 
 ## Workflow 2: Send Payment to International Bank Account
 
@@ -93,12 +134,12 @@ Ask the user: "Which country is the bank account in?"
 
 Refer to `account-types.md` for:
 
-- Required account type (CLABE, PIX, IBAN, etc.)
-- Required fields
+- Required account type (MXN_ACCOUNT, BRL_ACCOUNT, EUR_ACCOUNT, etc.)
+- Required fields and payment rails
 
 2. **Collect account details interactively**
 
-For Mexico (CLABE):
+For Mexico (MXN_ACCOUNT):
 
 - Ask for 18-digit CLABE number
 - Ask for beneficiary name
@@ -108,13 +149,14 @@ For Mexico (CLABE):
 3. **Create the external account**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:xxx",
     "currency": "MXN",
     "accountInfo": {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
+      "paymentRails": ["SPEI"],
       "clabeNumber": "012345678901234567",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -130,14 +172,14 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 4. **Look up the account to get payment capabilities**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/receiver/external-account/ExternalAccount:xxx" | jq .
 ```
 
 5. **Create a quote**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -162,7 +204,7 @@ Note: `lockedCurrencySide: "RECEIVING"` means the recipient gets exactly this am
 7. **Execute the quote**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   "$GRID_BASE_URL/quotes/Quote:xxx/execute" | jq .
 ```
@@ -176,7 +218,7 @@ Use this when a customer wants to convert fiat to cryptocurrency.
 1. **Ensure customer has completed KYC**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/Customer:xxx" | jq .
 ```
 
@@ -187,14 +229,14 @@ Check `kycStatus` is `APPROVED`.
 Show customer the `paymentInstructions` from their internal account:
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/internal-accounts?customerId=Customer:xxx" | jq .
 ```
 
 3. **Create external account for crypto destination**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:xxx",
@@ -210,7 +252,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 4. **Create and execute quote for conversion**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -240,16 +282,16 @@ Use this when a customer wants to convert cryptocurrency to fiat.
 1. **Create fiat external account for payout**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:xxx",
     "currency": "USD",
     "accountInfo": {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
+      "paymentRails": ["ACH"],
       "routingNumber": "123456789",
       "accountNumber": "12345678901",
-      "accountCategory": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "John Doe",
@@ -268,7 +310,7 @@ Provide the deposit address from their BTC internal account.
 3. **Create and execute quote for conversion**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -295,14 +337,14 @@ Use this when your platform receives an incoming payment that needs approval.
 1. **List pending incoming transactions**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions?type=INCOMING&status=PENDING_APPROVAL" | jq .
 ```
 
 2. **Review transaction details**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions/Transaction:xxx" | jq .
 ```
 
@@ -310,12 +352,12 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 
 ```bash
 # Approve
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   "$GRID_BASE_URL/transactions/Transaction:xxx/approve" | jq .
 
 # Or reject
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{"reason": "Suspicious activity"}' \
   "$GRID_BASE_URL/transactions/Transaction:xxx/reject" | jq .
@@ -337,7 +379,7 @@ The API supports bulk customer creation via CSV upload.
 2. **Upload CSV**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST \
   -F "file=@customers.csv" \
   "$GRID_BASE_URL/customers/bulk/csv" | jq .
@@ -346,7 +388,7 @@ curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
 3. **Check job status**
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/customers/bulk/jobs/<jobId>" | jq .
 ```
 
@@ -364,7 +406,7 @@ If a quote expires before execution:
 Check transaction status for failure reason:
 
 ```bash
-curl -s -u "$GRID_API_TOKEN_ID:$GRID_API_CLIENT_SECRET" \
+curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   "$GRID_BASE_URL/transactions/Transaction:xxx" | jq .
 ```
 


### PR DESCRIPTION
### TL;DR

Updated Grid API skill documentation to reflect new API version with standardized account types, authentication credentials, and enhanced features like exchange rate checking and crypto withdrawal fee estimation.

### What changed?

- **Authentication**: Changed from `GRID_API_TOKEN_ID` to `GRID_CLIENT_ID` and `GRID_API_CLIENT_SECRET` to `GRID_CLIENT_SECRET` with backward compatibility
- **Account Types**: Standardized all fiat account types to use currency-specific naming (e.g., `CLABE` → `MXN_ACCOUNT`, `PIX` → `BRL_ACCOUNT`, `IBAN` → `EUR_ACCOUNT`) and added required `paymentRails` field
- **New Features**: Added exchange rates endpoint (`GET /exchange-rates`) for pre-quote FX rate checking and crypto withdrawal fee estimation endpoint (`POST /crypto/estimate-withdrawal-fee`)
- **Expanded Coverage**: Added support for 24 fiat account types across 28 countries including mobile money accounts for African markets
- **Enhanced Documentation**: Updated all curl examples, added new workflow for FX rate checking, and improved account type reference with validation patterns

### How to test?

1. Verify authentication works with both old and new credential formats
2. Test creating external accounts with new account types and `paymentRails` field
3. Query exchange rates endpoint for various currency corridors
4. Test crypto withdrawal fee estimation for supported networks
5. Validate account creation examples for all 24 fiat account types

### Why make this change?

The Grid API has evolved to support more payment corridors and provide better rate transparency. The standardized account types and payment rails make the API more consistent, while the new exchange rates endpoint allows integrators to show indicative pricing before committing to quotes. The expanded geographic coverage enables payments to more markets globally.