### PR TITLE
feat: adding paymentRail to quote account destination

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8297,6 +8297,10 @@ components:
               type: string
               description: Destination account identifier
               example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+            paymentRail:
+              type: string
+              description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
+              example: ACH
           description: Destination account details
     UmaAddressDestination:
       title: UMA Address

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8297,6 +8297,10 @@ components:
               type: string
               description: Destination account identifier
               example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+            paymentRail:
+              type: string
+              description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
+              example: ACH
           description: Destination account details
     UmaAddressDestination:
       title: UMA Address

--- a/openapi/components/schemas/quotes/AccountDestination.yaml
+++ b/openapi/components/schemas/quotes/AccountDestination.yaml
@@ -14,4 +14,11 @@ allOf:
         type: string
         description: Destination account identifier
         example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+      paymentRail:
+        type: string
+        description: >-
+          The payment rail to use for the transfer. Must be one of the rails
+          supported by the destination account. If not specified, the system
+          will select a default rail.
+        example: ACH
     description: Destination account details


### PR DESCRIPTION
### TL;DR

Added optional `paymentRail` field to the `AccountDestination` schema to allow specifying the payment rail for transfers.

### What changed?

Added a new optional `paymentRail` field to the `AccountDestination` schema with:
- Type: string
- Description explaining it must be one of the rails supported by the destination account
- Default behavior where the system selects a rail if not specified
- Example value of "ACH"

### How to test?

Test API requests that include the `AccountDestination` object by:
1. Sending requests with the `paymentRail` field specified (e.g., "ACH")
2. Sending requests without the `paymentRail` field to verify default behavior
3. Validating that only supported payment rails are accepted for each destination account

### Why make this change?

This change provides users with explicit control over which payment rail to use for transfers, while maintaining backward compatibility by making the field optional and preserving existing default rail selection behavior.