### PR TITLE
docs: Standardize curl env vars to GRID_CLIENT_ID and GRID_CLIENT_SECRET

### DIFF
--- a/mintlify/api-reference/sandbox-testing.mdx
+++ b/mintlify/api-reference/sandbox-testing.mdx
@@ -37,7 +37,7 @@ Instantly add funds to any internal account using `/sandbox/internal-accounts/{a
 
 ```bash
 curl -X POST https://api.lightspark.com/grid/2025-10-13/sandbox/internal-accounts/{accountId}/fund \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{ "amount": 100000 }'
 ```
@@ -54,14 +54,14 @@ After creating a quote, you need to fund it to trigger execution. There are two 
 
 ```bash
 curl -X POST https://api.lightspark.com/grid/2025-10-13/quotes/{quoteId}/execute \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Real-time funding via sandbox send** — If your quote uses real-time funding, the quote response includes payment instructions for you to transfer funds to. Use `/sandbox/send` to simulate this payment:
 
 ```bash
 curl -X POST https://api.lightspark.com/grid/2025-10-13/sandbox/send \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
@@ -83,7 +83,7 @@ Use the sandbox receive endpoint to simulate an incoming UMA payment to one of y
 
 ```bash
 curl -X POST https://api.lightspark.com/grid/2025-10-13/sandbox/uma/receive \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "senderUmaAddress": "$success.usd@sandbox.uma.money",

--- a/mintlify/global-p2p/getting-started/platform-configuration.mdx
+++ b/mintlify/global-p2p/getting-started/platform-configuration.mdx
@@ -88,7 +88,7 @@ You can retrieve your current platform configuration to see what settings are al
 
 ```bash
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/config" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Response example:
@@ -132,7 +132,7 @@ To update your platform configuration, call the PATCH endpoint with the fields y
 
 ```bash
 curl -sS -X PATCH "https://api.lightspark.com/grid/2025-10-13/config" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "umaDomain": "mycompany.com",

--- a/mintlify/global-p2p/onboarding-customers/configuring-customers.mdx
+++ b/mintlify/global-p2p/onboarding-customers/configuring-customers.mdx
@@ -70,7 +70,7 @@ To register a new customer directly, use the `POST /customers` endpoint (regulat
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "platformCustomerId": "9f84e0c2a72c4fa",
@@ -123,7 +123,7 @@ The Grid API validates these requirements and will return an error if they are n
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "umaAddress": "$acme.corp@mycompany.com",
@@ -153,7 +153,7 @@ Unregulated institutions should initiate a hosted KYC/KYB flow. Generate a link 
 
 ```bash
 curl -sS -G "https://api.lightspark.com/grid/2025-10-13/customers/kyc-link" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   --data-urlencode "platformCustomerId=9f84e0c2a72c4fa" \
   --data-urlencode "redirectUri=https://app.example.com/onboarding/completed"
 ```
@@ -183,14 +183,14 @@ You can retrieve customer information using either the Grid-assigned customer ID
 
 ```bash
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 or list customers with a filter:
 
 ```bash
 curl -sS -G "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   --data-urlencode "umaAddress={umaAddress}" \
   --data-urlencode "platformCustomerId={platformCustomerId}" \
   --data-urlencode "customerType={customerType}" \
@@ -224,7 +224,7 @@ For large-scale customer imports, you can upload a CSV file containing customer 
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers/bulk/csv" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -F "file=@customers.csv"
 ```
 
@@ -253,7 +253,7 @@ You can track the job status through:
 
 ```bash
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/customers/bulk/jobs/{jobId}" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Example job status response:

--- a/mintlify/global-p2p/quickstart.mdx
+++ b/mintlify/global-p2p/quickstart.mdx
@@ -41,14 +41,14 @@ In this guide, the entities map as follows:
   ```
 
   <Tip>
-  Use Basic Auth in cURL with `-u "$GRID_CLIENT_ID:$GRID_API_SECRET"`.
+  Use Basic Auth in cURL with `-u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"`.
   </Tip>
 ## Create a customer
   Register a customer who will send the payment. You can provide your own UMA handle or let the system generate one.
 
   ```bash
   curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-    -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+    -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d '{
       "platformCustomerId": "cust_7b3c5a89d2f1e0",
@@ -79,7 +79,7 @@ In this guide, the entities map as follows:
 
   ```bash
   curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-    -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+    -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d '{
       "currency": "MXN",
@@ -139,7 +139,7 @@ In this guide, the entities map as follows:
 
   ```bash
   curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-    -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+    -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d '{
       "source": {
@@ -187,7 +187,7 @@ In this guide, the entities map as follows:
 
   ```bash
   curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/send" \
-    -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+    -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d '{
       "reference": "UMA-Q12345-REF",

--- a/mintlify/payouts-and-b2b/quickstart.mdx
+++ b/mintlify/payouts-and-b2b/quickstart.mdx
@@ -44,7 +44,7 @@ export GRID_CLIENT_SECRET="YOUR_SANDBOX_CLIENT_SECRET"
 ```
 
 <Tip>
-Use Basic Auth in cURL with `-u "$GRID_CLIENT_ID:$GRID_API_SECRET"`.
+Use Basic Auth in cURL with `-u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"`.
 </Tip>
 
 ## Onboard a Customer

--- a/mintlify/ramps/onboarding/configuring-customers.mdx
+++ b/mintlify/ramps/onboarding/configuring-customers.mdx
@@ -42,7 +42,7 @@ For personal conversions and consumer wallets.
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "platformCustomerId": "user_12345",
@@ -63,7 +63,7 @@ For corporate conversions and business accounts.
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "platformCustomerId": "biz_67890",

--- a/mintlify/ramps/onboarding/platform-configuration.mdx
+++ b/mintlify/ramps/onboarding/platform-configuration.mdx
@@ -23,7 +23,7 @@ Create API credentials in the Grid dashboard. Credentials are scoped to an envir
 ```bash
 # Using cURL's Basic Auth shorthand (-u):
 curl -sS -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Base API path
@@ -97,7 +97,7 @@ Use the webhook test endpoint to verify your endpoint configuration:
 
 ```bash
 curl -sS -X POST 'https://api.lightspark.com/grid/2025-10-13/webhooks/test' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Example test webhook payload:**
@@ -130,7 +130,7 @@ You can retrieve your current platform configuration programmatically:
 
 ```bash
 curl -sS -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Response example:**
@@ -164,7 +164,7 @@ Update your platform configuration using the PATCH endpoint:
 
 ```bash
 curl -sS -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "webhookEndpoint": "https://api.mycompany.com/webhooks/grid",

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -46,7 +46,7 @@ Set up a webhook endpoint for sandbox notifications:
 
 ```bash
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "webhookEndpoint": "https://api.yourapp.dev/webhooks/grid"
@@ -66,7 +66,7 @@ Simulate the complete on-ramp flow in sandbox:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "platformCustomerId": "test_user_001",
@@ -90,7 +90,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -121,7 +121,7 @@ Use the sandbox endpoint to simulate receiving the fiat payment:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/sandbox/send' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "reference": "RAMP-ABC123",
@@ -169,7 +169,7 @@ Simulate a Bitcoin deposit to the customer's internal account using the sandbox 
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/sandbox/internal-accounts/InternalAccount:btc001/fund' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "amount": 10000000
@@ -186,7 +186,7 @@ Replace `InternalAccount:btc001` with your actual BTC internal account ID.
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:sandbox001",
@@ -223,7 +223,7 @@ In sandbox, you can use special account number patterns to test different scenar
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -243,7 +243,7 @@ Then execute the quote:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes/{quoteId}/execute' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Info>
@@ -289,7 +289,7 @@ Test error scenarios systematically using the magic account patterns:
 ```bash
 # Create account with insufficient funds pattern
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:sandbox001",
@@ -308,7 +308,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 # Attempt off-ramp to this account - will fail immediately
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes/{quoteId}/execute' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 # Response: 400 Bad Request with insufficient funds error
 ```
 
@@ -327,7 +327,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 ```bash
 # Create quote from empty internal account
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -349,7 +349,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
 ```bash
 # Attempt quote with invalid Spark address
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -u "$SANDBOX_CLIENT_ID:$SANDBOX_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "destination": {

--- a/mintlify/ramps/platform-tools/webhooks.mdx
+++ b/mintlify/ramps/platform-tools/webhooks.mdx
@@ -98,7 +98,7 @@ Configure your webhook endpoint in the Grid dashboard or via API:
 
 ```bash
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "webhookEndpoint": "https://api.yourapp.com/webhooks/grid"
@@ -369,7 +369,7 @@ Test webhook handling using the test endpoint:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/webhooks/test' \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 This sends a test webhook to your configured endpoint:

--- a/mintlify/snippets/creating-customers/customers.mdx
+++ b/mintlify/snippets/creating-customers/customers.mdx
@@ -58,7 +58,7 @@ To register a new customer directly, use the `POST /customers` endpoint (regulat
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{{
     "platformCustomerId": "9f84e0c2a72c4fa",
@@ -111,7 +111,7 @@ The Grid API validates these requirements and will return an error if they are n
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{{
     "umaAddress": "$acme.corp@mycompany.com",
@@ -141,7 +141,7 @@ Unregulated institutions should initiate a hosted KYC/KYB flow. Generate a link 
 
 ```bash
 curl -sS -G "https://api.lightspark.com/grid/2025-10-13/customers/kyc-link" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   --data-urlencode "platformCustomerId=9f84e0c2a72c4fa" \
   --data-urlencode "redirectUri=https://app.example.com/onboarding/completed"
 ```
@@ -183,14 +183,14 @@ You can retrieve customer information using either the Grid-assigned customer ID
 
 ```bash
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 or list customers with a filter:
 
 ```bash
 curl -sS -G "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   --data-urlencode "umaAddress={umaAddress}" \
   --data-urlencode "platformCustomerId={platformCustomerId}" \
   --data-urlencode "customerType={customerType}" \
@@ -208,7 +208,7 @@ Use PATCH to update customer information:
 
 ```bash
 curl -sS -X PATCH "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{{
     "umaAddress": "$john.doe@uma.domain.com",
@@ -243,7 +243,7 @@ For large-scale customer imports, you can upload a CSV file containing customer 
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers/bulk/csv" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -F "file=@customers.csv"
 ```
 
@@ -272,7 +272,7 @@ You can track the job status through:
 
 ```bash
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/customers/bulk/jobs/{jobId}" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Example job status response:

--- a/mintlify/snippets/platform-config-currency-api-webhooks.mdx
+++ b/mintlify/snippets/platform-config-currency-api-webhooks.mdx
@@ -16,7 +16,7 @@ Never share or expose your API secret. Rotate credentials periodically and restr
 ```bash
 # Using cURL's Basic Auth shorthand (-u):
 curl -sS -X GET "https://api.lightspark.com/grid/2025-10-13/config" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 ```
 
@@ -40,7 +40,7 @@ Use the webhook test endpoint to send a synthetic event to your configured endpo
 
 ```bash
 curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/webhooks/test" \
-  -u "$GRID_CLIENT_ID:$GRID_API_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Example test webhook payload:

--- a/mintlify/snippets/platform-configuration-non-uma.mdx
+++ b/mintlify/snippets/platform-configuration-non-uma.mdx
@@ -8,7 +8,7 @@ You can retrieve your current platform configuration to see what settings are al
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET'
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
 ```
 
 ```json Success
@@ -39,7 +39,7 @@ To update your platform configuration for payouts payments, use the PATCH endpoi
 
 ```bash cURL
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET' \
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET \
   -H 'Content-Type: application/json' \
   -d '{
     "webhookEndpoint": "https://api.mycompany.com/webhooks/grid",
@@ -107,7 +107,7 @@ After updating your configuration, it's recommended to verify that the changes w
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET'
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
 ```
 
 <Warning>

--- a/mintlify/snippets/platform-configuration-non-uma.mdx
+++ b/mintlify/snippets/platform-configuration-non-uma.mdx
@@ -8,7 +8,7 @@ You can retrieve your current platform configuration to see what settings are al
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ```json Success
@@ -39,7 +39,7 @@ To update your platform configuration for payouts payments, use the PATCH endpoi
 
 ```bash cURL
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "webhookEndpoint": "https://api.mycompany.com/webhooks/grid",
@@ -107,7 +107,7 @@ After updating your configuration, it's recommended to verify that the changes w
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Warning>

--- a/mintlify/snippets/platform-configuration-uma.mdx
+++ b/mintlify/snippets/platform-configuration-uma.mdx
@@ -9,7 +9,7 @@ You can retrieve your current platform configuration to see what settings are al
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET'
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
 ```
 
 ```json Success
@@ -53,7 +53,7 @@ To update your platform configuration for UMA payments, use the PATCH endpoint:
 
 ```bash cURL
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET' \
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET \
   -H 'Content-Type: application/json' \
   -d '{
     "umaDomain": "mycompany.com",
@@ -187,7 +187,7 @@ After updating your configuration, it's recommended to verify that the changes w
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET'
+  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
 ```
 
 <Warning>

--- a/mintlify/snippets/platform-configuration-uma.mdx
+++ b/mintlify/snippets/platform-configuration-uma.mdx
@@ -9,7 +9,7 @@ You can retrieve your current platform configuration to see what settings are al
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ```json Success
@@ -53,7 +53,7 @@ To update your platform configuration for UMA payments, use the PATCH endpoint:
 
 ```bash cURL
 curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "umaDomain": "mycompany.com",
@@ -187,7 +187,7 @@ After updating your configuration, it's recommended to verify that the changes w
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
-  -u $GRID_CLIENT_ID:$GRID_CLIENT_SECRET
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Warning>


### PR DESCRIPTION
Fixes inconsistent environment variable names across curl examples:
- SANDBOX_CLIENT_ID:SANDBOX_API_SECRET → GRID_CLIENT_ID:GRID_CLIENT_SECRET
- GRID_API_SECRET → GRID_CLIENT_SECRET
- YOUR_CLIENT_ID:YOUR_CLIENT_SECRET → $GRID_CLIENT_ID:$GRID_CLIENT_SECRET

https://claude.ai/code/session_01DDmEbZhoeCbMT5n5RJeqhJ