### PR TITLE
Add discoveries api endpoint. This GET endpoint returns payment railes available by currency and country

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -44,6 +44,8 @@ tags:
     description: Endpoints to programmatically manage API tokens
   - name: Exchange Rates
     description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
+  - name: Discoveries
+    description: Endpoints for discovering available payment rails, banks, and providers for a given country and currency corridor.
 paths:
   /config:
     get:
@@ -239,6 +241,99 @@ paths:
                         fees:
                           fixed: 10
                         updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /discoveries:
+    get:
+      summary: List available receiving institution names
+      description: |
+        Retrieve available payment institution names for a given country and currency. Use this endpoint
+        to look up supported banks and payment providers for a specific corridor.
+        If no country and currency parameter are provided, all payment institutions will be returned
+
+        The `bankName` field in each result is the value to pass as `bankName` when
+        creating an external account via `POST /customers/external-accounts`.
+      operationId: getDiscoveries
+      tags:
+        - Discoveries
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: country
+          in: query
+          description: ISO 3166-1 alpha-2 country code (e.g. PH)
+          required: false
+          schema:
+            type: string
+          example: PH
+        - name: currency
+          in: query
+          description: ISO 4217 currency code (e.g. PHP)
+          required: false
+          schema:
+            type: string
+          example: PHP
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    description: List of payment rails matching the filter criteria
+                    items:
+                      type: object
+                      required:
+                        - bankName
+                        - displayName
+                        - country
+                        - currency
+                      properties:
+                        bankName:
+                          type: string
+                          description: |
+                            Canonical name for this payment rail. Pass this value as `bankName` when creating an external account.
+                        displayName:
+                          type: string
+                          description: Human-friendly display name for this payment rail.
+                        country:
+                          type: string
+                          description: ISO 3166-1 alpha-2 country code.
+                        currency:
+                          type: string
+                          description: ISO 4217 currency code.
+              examples:
+                philippinesBanks:
+                  summary: Payment rails for Philippines (PHP)
+                  value:
+                    data:
+                      - bankName: BDO Unibank
+                        displayName: BDO Unibank
+                        country: PH
+                        currency: PHP
+                      - bankName: BPI
+                        displayName: Bank of the Philippine Islands
+                        country: PH
+                        currency: PHP
         '400':
           description: Bad request - Invalid parameters
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,6 +44,8 @@ tags:
     description: Endpoints to programmatically manage API tokens
   - name: Exchange Rates
     description: Endpoints for retrieving cached foreign exchange rates. Rates are cached for approximately 5 minutes and include platform-specific fees.
+  - name: Discoveries
+    description: Endpoints for discovering available payment rails, banks, and providers for a given country and currency corridor.
 paths:
   /config:
     get:
@@ -239,6 +241,99 @@ paths:
                         fees:
                           fixed: 10
                         updatedAt: '2025-02-05T12:00:00Z'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /discoveries:
+    get:
+      summary: List available receiving institution names
+      description: |
+        Retrieve available payment institution names for a given country and currency. Use this endpoint
+        to look up supported banks and payment providers for a specific corridor.
+        If no country and currency parameter are provided, all payment institutions will be returned
+
+        The `bankName` field in each result is the value to pass as `bankName` when
+        creating an external account via `POST /customers/external-accounts`.
+      operationId: getDiscoveries
+      tags:
+        - Discoveries
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: country
+          in: query
+          description: ISO 3166-1 alpha-2 country code (e.g. PH)
+          required: false
+          schema:
+            type: string
+          example: PH
+        - name: currency
+          in: query
+          description: ISO 4217 currency code (e.g. PHP)
+          required: false
+          schema:
+            type: string
+          example: PHP
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    description: List of payment rails matching the filter criteria
+                    items:
+                      type: object
+                      required:
+                        - bankName
+                        - displayName
+                        - country
+                        - currency
+                      properties:
+                        bankName:
+                          type: string
+                          description: |
+                            Canonical name for this payment rail. Pass this value as `bankName` when creating an external account.
+                        displayName:
+                          type: string
+                          description: Human-friendly display name for this payment rail.
+                        country:
+                          type: string
+                          description: ISO 3166-1 alpha-2 country code.
+                        currency:
+                          type: string
+                          description: ISO 4217 currency code.
+              examples:
+                philippinesBanks:
+                  summary: Payment rails for Philippines (PHP)
+                  value:
+                    data:
+                      - bankName: BDO Unibank
+                        displayName: BDO Unibank
+                        country: PH
+                        currency: PHP
+                      - bankName: BPI
+                        displayName: Bank of the Philippine Islands
+                        country: PH
+                        currency: PHP
         '400':
           description: Bad request - Invalid parameters
           content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -48,6 +48,10 @@ tags:
     description: >-
       Endpoints for retrieving cached foreign exchange rates. Rates are cached
       for approximately 5 minutes and include platform-specific fees.
+  - name: Discoveries
+    description: >-
+      Endpoints for discovering available payment rails, banks, and providers
+      for a given country and currency corridor.
 servers:
   - url: https://api.lightspark.com/grid/2025-10-13
     description: Production server
@@ -85,6 +89,8 @@ paths:
     $ref: paths/platform/config.yaml
   /exchange-rates:
     $ref: paths/exchange-rates/exchange_rates.yaml
+  /discoveries:
+    $ref: paths/discoveries/discoveries.yaml
   /customers:
     $ref: paths/customers/customers.yaml
   /customers/{customerId}:

--- a/openapi/paths/discoveries/discoveries.yaml
+++ b/openapi/paths/discoveries/discoveries.yaml
@@ -1,0 +1,93 @@
+get:
+  summary: List available receiving institution names
+  description: |
+    Retrieve available payment institution names for a given country and currency. Use this endpoint
+    to look up supported banks and payment providers for a specific corridor.
+    If no country and currency parameter are provided, all payment institutions will be returned
+
+    The `bankName` field in each result is the value to pass as `bankName` when
+    creating an external account via `POST /customers/external-accounts`.
+  operationId: getDiscoveries
+  tags:
+    - Discoveries
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: country
+      in: query
+      description: ISO 3166-1 alpha-2 country code (e.g. PH)
+      required: false
+      schema:
+        type: string
+      example: PH
+    - name: currency
+      in: query
+      description: ISO 4217 currency code (e.g. PHP)
+      required: false
+      schema:
+        type: string
+      example: PHP
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                description: List of payment rails matching the filter criteria
+                items:
+                  type: object
+                  required:
+                    - bankName
+                    - displayName
+                    - country
+                    - currency
+                  properties:
+                    bankName:
+                      type: string
+                      description: >
+                        Canonical name for this payment rail. Pass this value as
+                        `bankName` when creating an external account.
+                    displayName:
+                      type: string
+                      description: Human-friendly display name for this payment rail.
+                    country:
+                      type: string
+                      description: ISO 3166-1 alpha-2 country code.
+                    currency:
+                      type: string
+                      description: ISO 4217 currency code.
+          examples:
+            philippinesBanks:
+              summary: Payment rails for Philippines (PHP)
+              value:
+                data:
+                  - bankName: BDO Unibank
+                    displayName: BDO Unibank
+                    country: PH
+                    currency: PHP
+                  - bankName: BPI
+                    displayName: Bank of the Philippine Islands
+                    country: PH
+                    currency: PHP
+    "400":
+      description: Bad request - Invalid parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    "500":
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
### TL;DR

Added a new `/discoveries` endpoint to retrieve available payment rails for specific country and currency combinations.

### What changed?

- Added a new "Discoveries" tag and endpoint group for payment rail discovery functionality
- Implemented `GET /discoveries` endpoint that accepts `country` (ISO 3166-1 alpha-2) and `currency` (ISO 4217) query parameters
- The endpoint returns a list of payment rails with stable identifiers, names, display names, country, and currency information
- Each payment rail's `id` field serves as the stable identifier to use when creating external accounts
- Included comprehensive error handling for 400, 401, and 500 status codes
- Added example response showing Philippine banks (BDO Unibank and Bank of the Philippine Islands)

### How to test?

1. Make a GET request to `/discoveries?country=PH&currency=PHP` with proper authentication
2. Verify the response contains a `payment_rails` array with bank information
3. Test error cases by omitting required parameters or using invalid country/currency codes
4. Confirm the returned `id` values can be used as `bankName` when creating external accounts via `POST /customers/{id}/external-accounts`

### Why make this change?

This endpoint enables developers to programmatically discover which payment rails, banks, and providers are available for specific country-currency corridors supported by Grid's partners, eliminating the need to hardcode bank names and providing a dynamic way to populate payment options in applications.