### PR TITLE
Add SDKs & CLI documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ sequenceDiagram
     else Asynchronous Processing (within 5 seconds)
         Client-->>Grid: HTTP 202 Accepted
         Client->>Grid: /transactions/{transactionId}/approve or /reject
-        opt Approved
+        alt Approved
           Grid->>Bank: Execute payment to user's bank account
           Grid->>Client: Webhook: INCOMING_PAYMENT (COMPLETED)
           Client-->>Grid: HTTP 200 OK (acknowledge completion)

--- a/mintlify/api-reference/sdks.mdx
+++ b/mintlify/api-reference/sdks.mdx
@@ -1,0 +1,15 @@
+---
+title: 'SDKs & CLI'
+icon: "/images/icons/code.svg"
+description: 'Official client libraries and command-line interface for the Grid API'
+"og:image": "/images/og/og-api-reference-generic.png"
+---
+
+import Sdks from '/snippets/sdks.mdx';
+import Cli from '/snippets/cli.mdx';
+
+<Sdks />
+
+## CLI
+
+<Cli />

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -266,7 +266,8 @@
               "api-reference/terminology",
               "api-reference/authentication",
               "api-reference/webhooks",
-              "api-reference/sandbox-testing"
+              "api-reference/sandbox-testing",
+              "api-reference/sdks"
             ]
           },
           {

--- a/mintlify/images/icons/kotlin.svg
+++ b/mintlify/images/icons/kotlin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 4H20L12 12L20 20H4V4Z"/>
+</svg>

--- a/mintlify/snippets/cli.mdx
+++ b/mintlify/snippets/cli.mdx
@@ -52,6 +52,7 @@ export GRID_API_CLIENT_SECRET="your-client-secret"
 | `grid transfers in` | Transfer funds in (external to internal) |
 | `grid transfers out` | Transfer funds out (internal to external) |
 | `grid transactions list` | List transactions |
+| `grid transactions get` | Get transaction details |
 | `grid receiver lookup-uma` | Look up a UMA address |
 | `grid sandbox fund` | Fund a sandbox account |
 | `grid sandbox send` | Simulate sending funds to a JIT quote |
@@ -61,8 +62,9 @@ Short aliases are available: `cust` for `customers`, `tx` for `transactions`, `a
 
 ### Example: Send USDC to a Mexico Bank Account
 
+<Steps>
+<Step title="Create a customer">
 ```bash
-# 1. Create a customer
 grid customers create \
   --platform-id "your-id" \
   --type INDIVIDUAL \
@@ -73,8 +75,10 @@ grid customers create \
   --address-state "CDMX" \
   --address-postal "06600" \
   --address-country "MX"
-
-# 2. Create an external CLABE account for the customer
+```
+</Step>
+<Step title="Create an external CLABE account for the customer">
+```bash
 grid accounts external create \
   --customer-id <customerId> \
   --currency MXN \
@@ -84,8 +88,10 @@ grid accounts external create \
   --beneficiary-name "Carlos Garcia" \
   --beneficiary-birth-date "1988-03-20" \
   --beneficiary-nationality MX
-
-# 3. Create a quote (returns payment instructions)
+```
+</Step>
+<Step title="Create a quote">
+```bash
 grid quotes create \
   --source-customer <customerId> \
   --source-currency USDC \
@@ -93,13 +99,19 @@ grid quotes create \
   --dest-currency MXN \
   --amount 100000 \
   --lock-side RECEIVING
-
-# 4. In sandbox, simulate the USDC deposit
+```
+</Step>
+<Step title="In sandbox, simulate the USDC deposit">
+```bash
 grid sandbox send --quote-id <quoteId> --currency USDC
-
-# 5. Check transaction status
+```
+</Step>
+<Step title="Check transaction status">
+```bash
 grid transactions get <transactionId>
 ```
+</Step>
+</Steps>
 
 <Note>
 All amounts are in the **smallest currency unit** (e.g., cents for USD, satoshis for BTC). Quotes expire in 1–5 minutes.

--- a/mintlify/snippets/cli.mdx
+++ b/mintlify/snippets/cli.mdx
@@ -1,0 +1,103 @@
+The Grid CLI lets you interact with the Grid API directly from your terminal — manage customers, send payments, create quotes, and test in sandbox without writing any code.
+
+<Card
+  title="Grid CLI"
+  icon="square-terminal"
+  href="https://github.com/lightsparkdev/grid-api/tree/main/cli"
+>
+  Open-source CLI built with Node.js and TypeScript.
+</Card>
+
+### Installation
+
+```bash
+cd cli
+npm install
+npm run build
+npm link        # makes `grid` available globally
+```
+
+### Configuration
+
+Configure your credentials interactively:
+
+```bash
+grid configure
+```
+
+This prompts for your API Token ID and Client Secret, validates them, and saves to `~/.grid-credentials`.
+
+Alternatively, set environment variables:
+
+```bash
+export GRID_API_TOKEN_ID="your-token-id"
+export GRID_API_CLIENT_SECRET="your-client-secret"
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `grid configure` | Set up API credentials |
+| `grid config get` | View platform configuration |
+| `grid customers list` | List customers |
+| `grid customers create` | Create a customer |
+| `grid accounts internal list` | List internal accounts |
+| `grid accounts external create` | Create an external bank account or wallet |
+| `grid quotes create` | Create a payment quote |
+| `grid quotes execute` | Execute a pending quote |
+| `grid transfers in` | Transfer funds in (external to internal) |
+| `grid transfers out` | Transfer funds out (internal to external) |
+| `grid transactions list` | List transactions |
+| `grid receiver lookup-uma` | Look up a UMA address |
+| `grid sandbox fund` | Fund a sandbox account |
+| `grid sandbox send` | Simulate sending funds to a JIT quote |
+| `grid sandbox receive` | Simulate receiving a UMA payment |
+
+Short aliases are available: `cust` for `customers`, `tx` for `transactions`, `acct` for `accounts`.
+
+### Example: Send USDC to a Mexico Bank Account
+
+```bash
+# 1. Create a customer
+grid customers create \
+  --platform-id "your-id" \
+  --type INDIVIDUAL \
+  --full-name "Carlos Garcia" \
+  --birth-date "1988-03-20" \
+  --address-line1 "Av Reforma 222" \
+  --address-city "Mexico City" \
+  --address-state "CDMX" \
+  --address-postal "06600" \
+  --address-country "MX"
+
+# 2. Create an external CLABE account for the customer
+grid accounts external create \
+  --customer-id <customerId> \
+  --currency MXN \
+  --account-type CLABE \
+  --clabe "012345678901234567" \
+  --beneficiary-type INDIVIDUAL \
+  --beneficiary-name "Carlos Garcia" \
+  --beneficiary-birth-date "1988-03-20" \
+  --beneficiary-nationality MX
+
+# 3. Create a quote (returns payment instructions)
+grid quotes create \
+  --source-customer <customerId> \
+  --source-currency USDC \
+  --dest-account <externalAccountId> \
+  --dest-currency MXN \
+  --amount 100000 \
+  --lock-side RECEIVING
+
+# 4. In sandbox, simulate the USDC deposit
+grid sandbox send --quote-id <quoteId> --currency USDC
+
+# 5. Check transaction status
+grid transactions get <transactionId>
+```
+
+<Note>
+All amounts are in the **smallest currency unit** (e.g., cents for USD, satoshis for BTC). Quotes expire in 1–5 minutes.
+</Note>

--- a/mintlify/snippets/cli.mdx
+++ b/mintlify/snippets/cli.mdx
@@ -10,8 +10,11 @@ The Grid CLI lets you interact with the Grid API directly from your terminal —
 
 ### Installation
 
+**Prerequisites:** Node.js v20 or v22 is required.
+
 ```bash
-cd cli
+git clone https://github.com/lightsparkdev/grid-api.git
+cd grid-api/cli
 npm install
 npm run build
 npm link        # makes `grid` available globally

--- a/mintlify/snippets/sdks.mdx
+++ b/mintlify/snippets/sdks.mdx
@@ -10,7 +10,7 @@ Grid provides official SDKs to help you integrate faster. These libraries wrap t
   </Card>
   <Card
     title="Kotlin"
-    icon="java"
+    icon="kotlin"
     href="https://github.com/lightsparkdev/grid-kotlin-sdk"
   >
     For JVM and Android applications. Available on Maven Central.

--- a/mintlify/snippets/sdks.mdx
+++ b/mintlify/snippets/sdks.mdx
@@ -10,7 +10,7 @@ Grid provides official SDKs to help you integrate faster. These libraries wrap t
   </Card>
   <Card
     title="Kotlin"
-    icon="kotlin"
+    icon="/images/icons/kotlin.svg"
     href="https://github.com/lightsparkdev/grid-kotlin-sdk"
   >
     For JVM and Android applications. Available on Maven Central.

--- a/mintlify/snippets/sdks.mdx
+++ b/mintlify/snippets/sdks.mdx
@@ -1,0 +1,18 @@
+Grid provides official SDKs to help you integrate faster. These libraries wrap the Grid API with idiomatic interfaces, type safety, and built-in error handling.
+
+<CardGroup cols={2}>
+  <Card
+    title="JavaScript / TypeScript"
+    icon="js"
+    href="https://github.com/lightsparkdev/grid-js-sdk"
+  >
+    Install via npm and start building with full TypeScript support.
+  </Card>
+  <Card
+    title="Kotlin"
+    icon="java"
+    href="https://github.com/lightsparkdev/grid-kotlin-sdk"
+  >
+    For JVM and Android applications. Available on Maven Central.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Adds an **SDKs & CLI** page to the API Reference tab linking to the [Kotlin SDK](https://github.com/lightsparkdev/grid-kotlin-sdk) and [JS/TS SDK](https://github.com/lightsparkdev/grid-js-sdk), plus CLI documentation with command reference and an end-to-end example
- Creates reusable snippets (`snippets/sdks.mdx`, `snippets/cli.mdx`) so the content can be included on any page
- Fixes a mermaid diagram parse error in README.md (`opt` → `alt` to support `else`)

## Test plan
- [ ] Run `make lint` and confirm no new warnings
- [ ] Run `mint dev` and verify the SDKs & CLI page renders under API Reference
- [ ] Confirm SDK cards link to the correct GitHub repos
- [ ] Confirm CLI example code blocks render correctly (no blank boxes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)