### PR TITLE
docs: update sandbox access to self-serve via dashboard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,9 @@ jobs:
           node-version: '24'
           cache: 'npm'
       
+      - name: Install libsecret
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Install dependencies
         run: npm ci
 

--- a/mintlify/api-reference/environments.mdx
+++ b/mintlify/api-reference/environments.mdx
@@ -14,7 +14,7 @@ import { topLevelProductName } from '/snippets/variables.mdx'
 Sandbox enables you to test your integration without making real payments.  In sandbox, we expose sandbox specific APIs to trigger specific test cases like incoming payments.  Additionally you'll find test UMA addresses to simulate different sending scenarios.  For more information, see [Sandbox Testing](sandbox-testing).
 
 ## Production
-Production moves real money.  To get access to a production environment, please reach out to your Lightspark contact.
+Production moves real money.  To get access to a production environment, go to [app.lightspark.com](https://app.lightspark.com) and enable production from the dashboard.
 
 ## Service IPs
 

--- a/mintlify/api-reference/environments.mdx
+++ b/mintlify/api-reference/environments.mdx
@@ -14,7 +14,7 @@ import { topLevelProductName } from '/snippets/variables.mdx'
 Sandbox enables you to test your integration without making real payments.  In sandbox, we expose sandbox specific APIs to trigger specific test cases like incoming payments.  Additionally you'll find test UMA addresses to simulate different sending scenarios.  For more information, see [Sandbox Testing](sandbox-testing).
 
 ## Production
-Production moves real money.  To get access to a production environment, go to [app.lightspark.com](https://app.lightspark.com) and enable production from the dashboard.
+Production moves real money.  To get access to a production environment, please reach out to your Lightspark contact.
 
 ## Service IPs
 

--- a/mintlify/global-p2p/getting-started/implementation-overview.mdx
+++ b/mintlify/global-p2p/getting-started/implementation-overview.mdx
@@ -70,10 +70,10 @@ When you’re ready to go live:
 - Complete corridor and provider onboarding as needed for your regions
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, retries, and idempotency keys
-- Run final UAT in Sandbox, then request Production access from our team
+- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
 
 <Check>
-Contact our team to enable Production and finalize corridor activations.
+Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and finalize corridor activations.
 </Check>
 
 ## Support

--- a/mintlify/global-p2p/getting-started/implementation-overview.mdx
+++ b/mintlify/global-p2p/getting-started/implementation-overview.mdx
@@ -70,10 +70,10 @@ When you’re ready to go live:
 - Complete corridor and provider onboarding as needed for your regions
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, retries, and idempotency keys
-- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
+- Run final UAT in Sandbox, then request Production access from your Lightspark contact
 
 <Check>
-Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and finalize corridor activations.
+Contact your Lightspark representative to enable Production and finalize corridor activations.
 </Check>
 
 ## Support

--- a/mintlify/global-p2p/quickstart.mdx
+++ b/mintlify/global-p2p/quickstart.mdx
@@ -32,7 +32,7 @@ In this guide, the entities map as follows:
 **Flow**: Alice (customer) funds a transfer from her external account → to Carlos (also a customer) → who receives funds in his external bank account. Alternatively, Alice could send directly to Carlos's UMA address if he has one.
 
 ## Get API credentials
-  Create a Sandbox API credentialsin the dashboard, then set environment variables for local use.
+  Create Sandbox API credentials in the [dashboard](https://app.lightspark.com), then set environment variables for local use.
 
   ```bash
   export GRID_BASE_URL="https://api.lightspark.com/grid/2025-10-13"

--- a/mintlify/payouts-and-b2b/onboarding/implementation-overview.mdx
+++ b/mintlify/payouts-and-b2b/onboarding/implementation-overview.mdx
@@ -70,9 +70,9 @@ When you’re ready to go live:
 - Complete corridor and provider onboarding as needed for your regions
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, retries, and idempotency keys
-- Run final UAT in Sandbox, then request Production access from our team
+- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
 
 <Check>
-Contact our team to enable Production and finalize corridor activations.
+Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and finalize corridor activations.
 </Check>
 

--- a/mintlify/payouts-and-b2b/onboarding/implementation-overview.mdx
+++ b/mintlify/payouts-and-b2b/onboarding/implementation-overview.mdx
@@ -70,9 +70,9 @@ When you’re ready to go live:
 - Complete corridor and provider onboarding as needed for your regions
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, retries, and idempotency keys
-- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
+- Run final UAT in Sandbox, then request Production access from your Lightspark contact
 
 <Check>
-Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and finalize corridor activations.
+Contact your Lightspark representative to enable Production and finalize corridor activations.
 </Check>
 

--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -20,7 +20,7 @@ The Grid sandbox environment allows you to test your payouts integration without
 
 To use the sandbox environment:
 
-1. Contact Lightspark to get your inital sandbox credentials configured. Email [support@lightspark.com](mailto:support@lightspark.com) to get started.
+1. Go to [app.lightspark.com](https://app.lightspark.com), create an account, and generate your sandbox API keys from the dashboard.
 2. Add your sandbox API token and secret to your environment variables.
 3. Use the normal production base URL: `https://api.lightspark.com/grid/2025-10-13`
 4. Authenticate using your sandbox token with HTTP Basic Auth

--- a/mintlify/platform-overview/core-concepts/entities.mdx
+++ b/mintlify/platform-overview/core-concepts/entities.mdx
@@ -18,7 +18,7 @@ Your **platform configuration** defines global settings for your Grid integratio
 - **UMA domain** (optional): Your domain for UMA addresses (e.g., `yourplatform.com`)
 - **Required counterparty fields** (UMA only): Information required from senders for compliance
 
-Platform configuration is managed via the dashboard or by contacting Lightspark support.
+Platform configuration is managed via the [dashboard](https://app.lightspark.com).
 
 ## ID Format
 

--- a/mintlify/platform-overview/introduction/faq.mdx
+++ b/mintlify/platform-overview/introduction/faq.mdx
@@ -29,7 +29,7 @@ mode: "wide"
       </Step>
 
       <Step title="Go to Production">
-        Once testing is complete, enable production from the dashboard to launch with real transactions.
+        Once testing is complete, reach out to your Lightspark contact to receive production credentials and launch with real transactions.
       </Step>
     </Steps>
   </Accordion>

--- a/mintlify/platform-overview/introduction/faq.mdx
+++ b/mintlify/platform-overview/introduction/faq.mdx
@@ -21,15 +21,15 @@ mode: "wide"
 
   <Accordion title="How do I get started with Grid?">
     <Steps>
-      <Step title="Contact Sales">
-        Reach out to [sales@lightspark.com](mailto:sales@lightspark.com) to discuss your use case and get custom pricing.
+      <Step title="Create an Account">
+        Go to [app.lightspark.com](https://app.lightspark.com) to create your account and access the Grid dashboard.
       </Step>
-      <Step title="Get Sandbox Credentials">
-        You'll receive sandbox API credentials to start building and testing your integration.
+      <Step title="Generate Sandbox API Keys">
+        Generate your sandbox API keys from the dashboard and start building and testing your integration.
       </Step>
-      
+
       <Step title="Go to Production">
-        Once testing is complete, you'll receive production credentials to launch with real transactions.
+        Once testing is complete, enable production from the dashboard to launch with real transactions.
       </Step>
     </Steps>
   </Accordion>

--- a/mintlify/ramps/onboarding/implementation-overview.mdx
+++ b/mintlify/ramps/onboarding/implementation-overview.mdx
@@ -146,10 +146,10 @@ When you're ready to go live:
 - Confirm webhook security, monitoring, and alerting are configured
 - Review rate limits, error handling, and idempotency
 - Test conversion flows thoroughly in Sandbox
-- Run final UAT in Sandbox, then request Production access from our team
+- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
 
 <Check>
-  Contact our team to enable Production and begin processing real conversions.
+  Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and begin processing real conversions.
 </Check>
 
 ## Support

--- a/mintlify/ramps/onboarding/implementation-overview.mdx
+++ b/mintlify/ramps/onboarding/implementation-overview.mdx
@@ -146,10 +146,10 @@ When you're ready to go live:
 - Confirm webhook security, monitoring, and alerting are configured
 - Review rate limits, error handling, and idempotency
 - Test conversion flows thoroughly in Sandbox
-- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
+- Run final UAT in Sandbox, then request Production access from your Lightspark contact
 
 <Check>
-  Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and begin processing real conversions.
+  Contact your Lightspark representative to enable Production and begin processing real conversions.
 </Check>
 
 ## Support

--- a/mintlify/rewards/developer-guides/implementation-overview.mdx
+++ b/mintlify/rewards/developer-guides/implementation-overview.mdx
@@ -87,8 +87,8 @@ When you're ready to go live:
 - Ensure adequate funding in your production platform account
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, and idempotency
-- Run final UAT in Sandbox, then request Production access from our team
+- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
 
 <Check>
-Contact our team to enable Production and begin distributing Bitcoin rewards.
+Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and begin distributing Bitcoin rewards.
 </Check>

--- a/mintlify/rewards/developer-guides/implementation-overview.mdx
+++ b/mintlify/rewards/developer-guides/implementation-overview.mdx
@@ -87,8 +87,8 @@ When you're ready to go live:
 - Ensure adequate funding in your production platform account
 - Confirm webhook security, monitoring, and alerting are in place
 - Review rate limits, error handling, and idempotency
-- Run final UAT in Sandbox, then enable Production from the [dashboard](https://app.lightspark.com)
+- Run final UAT in Sandbox, then request Production access from your Lightspark contact
 
 <Check>
-Go to [app.lightspark.com](https://app.lightspark.com) to enable Production and begin distributing Bitcoin rewards.
+Contact your Lightspark representative to enable Production and begin distributing Bitcoin rewards.
 </Check>

--- a/mintlify/rewards/platform-tools/sandbox-testing.mdx
+++ b/mintlify/rewards/platform-tools/sandbox-testing.mdx
@@ -15,7 +15,7 @@ The Grid sandbox environment allows you to test your rewards integration without
 
 To use the sandbox environment:
 
-1. Contact Lightspark to get your inital sandbox credentials configured. Email [support@lightspark.com](mailto:support@lightspark.com) to get started.
+1. Go to [app.lightspark.com](https://app.lightspark.com), create an account, and generate your sandbox API keys from the dashboard.
 2. Add your sandbox API token and secret to your environment variables.
 3. Use the normal production base URL: `https://api.lightspark.com/grid/2025-10-13`
 4. Authenticate using your sandbox token with HTTP Basic Auth

--- a/mintlify/snippets/webhooks.mdx
+++ b/mintlify/snippets/webhooks.mdx
@@ -3,7 +3,7 @@ All webhooks sent by the Grid API include a signature in the `X-Grid-Signature` 
 ## Signature Verification Process
 
 1. **Obtain your Grid public key**
-   - This is provided to you during the integration process. Reach out to us at [support@lightspark.com](mailto:support@lightspark.com) or over Slack to get the public key.
+   - This is available in your [dashboard](https://app.lightspark.com) under API settings.
    - The key is in PEM format and can be used with standard cryptographic libraries
 
 2. **Verify incoming webhooks**


### PR DESCRIPTION
Grid Sandbox is now self-serve. Replace references to contacting
sales/support for sandbox credentials with directions to create an
account and generate API keys at app.lightspark.com.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>