### PR TITLE
Add auth methods endpoints

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -207,6 +207,17 @@ resources:
           oauth: post /embedded-wallets/{internalAccountId}/auth/oauth
           init_passkey: post /embedded-wallets/{internalAccountId}/auth/passkey/init
           complete_passkey: post /embedded-wallets/{internalAccountId}/auth/passkey/complete
+      auth_methods:
+        models:
+          embedded_wallet_auth_method_type: "#/components/schemas/EmbeddedWalletAuthMethodType"
+          embedded_wallet_auth_method: "#/components/schemas/EmbeddedWalletAuthMethod"
+          embedded_wallet_auth_method_create_request: "#/components/schemas/EmbeddedWalletAuthMethodCreateRequest"
+          embedded_wallet_auth_method_update_request: "#/components/schemas/EmbeddedWalletAuthMethodUpdateRequest"
+          embedded_wallet_auth_operation_response: "#/components/schemas/EmbeddedWalletAuthOperationResponse"
+        methods:
+          create: post /embedded-wallets/auth/methods
+          update: patch /embedded-wallets/auth/methods/{authMethodId}
+          delete: delete /embedded-wallets/auth/methods/{authMethodId}
 
   transfer_in:
     models:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -27,7 +27,7 @@ tags:
   - name: Internal Accounts
     description: Internal account management endpoints for creating and managing internal accounts
   - name: Embedded Wallets
-    description: Endpoints for starting and completing embedded wallet authentication flows.
+    description: Endpoints for starting and completing embedded wallet authentication flows and managing embedded wallet authentication methods.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -1504,6 +1504,197 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/auth/methods:
+    post:
+      summary: Create an embedded wallet auth method
+      description: |
+        Create a new authentication method for the embedded wallet associated with
+        the supplied Turnkey stamp.
+
+        The request may create a passkey-based method immediately or return a
+        follow-up step for OTP or OAuth-based authentication methods.
+      operationId: createEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthMethodCreateRequest'
+      responses:
+        '201':
+          description: Embedded wallet auth method created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOperationResponse'
+        '400':
+          description: Bad request - Invalid auth method creation parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '409':
+          description: Conflict - Embedded wallet auth method already exists or cannot be created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/auth/methods/{authMethodId}:
+    patch:
+      summary: Update an embedded wallet auth method
+      description: |
+        Update the email address or phone number associated with an embedded wallet
+        auth method.
+
+        The auth method to update is identified by `authMethodId`, while the
+        request is authorized with a Turnkey stamp.
+      operationId: updateEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: authMethodId
+          in: path
+          description: Unique identifier of the embedded wallet auth method to update
+          required: true
+          schema:
+            type: string
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:direct:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthMethodUpdateRequest'
+      responses:
+        '200':
+          description: Embedded wallet auth method updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOperationResponse'
+        '400':
+          description: Bad request - Invalid auth method update parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet auth method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - Embedded wallet auth method cannot be updated in its current state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+    delete:
+      summary: Delete an embedded wallet auth method
+      description: |
+        Delete an embedded wallet auth method.
+
+        The request will be rejected when the specified auth method is the last
+        remaining authentication method for the embedded wallet.
+      operationId: deleteEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: authMethodId
+          in: path
+          description: Unique identifier of the embedded wallet auth method to delete
+          required: true
+          schema:
+            type: string
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      responses:
+        '204':
+          description: Embedded wallet auth method deleted successfully
+        '400':
+          description: Bad request - Invalid auth method deletion parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet auth method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - Embedded wallet auth method is the last remaining method or cannot be deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -10332,6 +10523,156 @@ components:
           type: string
           description: Opaque credential bundle returned after successful passkey authentication
           example: credential_bundle_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+    EmbeddedWalletAuthMethodType:
+      type: string
+      description: |
+        Type of authentication method associated with an embedded wallet.
+
+        | Value | Description |
+        |-------|-------------|
+        | PASSKEY | WebAuthn passkey-based authentication |
+        | OTP | One-time password delivered to an email address or phone number |
+        | OAUTH | Third-party OAuth-based authentication |
+      enum:
+        - PASSKEY
+        - OTP
+        - OAUTH
+      example: OTP
+    EmbeddedWalletAuthMethodCreateRequest:
+      type: object
+      required:
+        - methodType
+      properties:
+        methodType:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethodType'
+        email:
+          type: string
+          format: email
+          description: Email address to associate with the auth method, when applicable
+          example: alice@example.com
+        phoneNumber:
+          type: string
+          description: Phone number to associate with the auth method, when applicable
+          example: '+14155550123'
+        oauthProvider:
+          type: string
+          description: OAuth provider to use when `methodType` is `OAUTH`
+          example: GOOGLE
+        redirectUri:
+          type: string
+          format: uri
+          description: Redirect URI for OAuth-based auth method creation, when applicable
+          example: https://partner.example.com/embedded-wallet/callback
+        authenticatorName:
+          type: string
+          description: Friendly name for a passkey authenticator, when applicable
+          example: Alice MacBook Pro
+    EmbeddedWalletAuthMethod:
+      type: object
+      required:
+        - id
+        - methodType
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the embedded wallet auth method
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        methodType:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethodType'
+        label:
+          type: string
+          description: Human-readable label or masked identifier for the auth method
+          example: al***@example.com
+        oauthProvider:
+          type: string
+          description: OAuth provider associated with the auth method, when applicable
+          example: GOOGLE
+        verifiedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the auth method was verified and became active
+          example: '2026-04-08T15:32:28Z'
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: '2026-04-08T15:30:01Z'
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last update timestamp
+          example: '2026-04-08T15:32:28Z'
+    EmbeddedWalletAuthOperationResponse:
+      type: object
+      required:
+        - status
+        - nextStep
+      properties:
+        embeddedWalletId:
+          type: string
+          description: Unique identifier of the embedded wallet associated with the operation
+          example: EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000001
+        authSessionId:
+          type: string
+          description: Unique identifier of the embedded wallet auth session, when applicable
+          example: EmbeddedWalletAuthSession:019542f5-b3e7-1d02-0000-000000000002
+        pendingActionId:
+          type: string
+          description: Unique identifier of the pending embedded wallet action
+          example: EmbeddedWalletPendingAction:019542f5-b3e7-1d02-0000-000000000003
+        otpChallengeId:
+          type: string
+          description: Unique identifier of the OTP challenge, when an OTP step is active
+          example: EmbeddedWalletOtpChallenge:019542f5-b3e7-1d02-0000-000000000004
+        turnkeySubOrgId:
+          type: string
+          description: Turnkey sub-organization identifier associated with the embedded wallet
+          example: suborg_01JABCDEF23456789GHIJKL
+        status:
+          type: string
+          description: Current status of the embedded wallet auth-related operation
+          example: PENDING
+        nextStep:
+          type: string
+          description: Next action the integrator or end user must complete
+          example: COMPLETE_OTP_VERIFICATION
+        maskedDestination:
+          type: string
+          description: Masked email address or phone number used for OTP delivery
+          example: al***@example.com
+        oauthConsentUrl:
+          type: string
+          format: uri
+          description: OAuth consent URL the integrator should redirect the end user to, when applicable
+          example: https://accounts.google.com/o/oauth2/v2/auth?client_id=example-client-id
+        expiresAt:
+          type: string
+          format: date-time
+          description: Expiration timestamp for the current step of the auth flow
+          example: '2026-04-08T15:40:00Z'
+        authMethod:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethod'
+    EmbeddedWalletAuthMethodUpdateRequest:
+      type: object
+      description: |
+        Fields to update for an embedded wallet auth method. Provide only the fields relevant to the auth method being updated.
+      minProperties: 1
+      properties:
+        email:
+          type: string
+          format: email
+          description: New email address for the embedded wallet auth method
+          example: alice.updated@example.com
+        phoneNumber:
+          type: string
+          description: New phone number for the embedded wallet auth method
+          example: '+14155550124'
+        label:
+          type: string
+          description: Updated user-facing label for the auth method
+          example: Primary recovery email
     BeneficialOwnerCreateRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,7 +27,7 @@ tags:
   - name: Internal Accounts
     description: Internal account management endpoints for creating and managing internal accounts
   - name: Embedded Wallets
-    description: Endpoints for starting and completing embedded wallet authentication flows.
+    description: Endpoints for starting and completing embedded wallet authentication flows and managing embedded wallet authentication methods.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -1504,6 +1504,197 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/auth/methods:
+    post:
+      summary: Create an embedded wallet auth method
+      description: |
+        Create a new authentication method for the embedded wallet associated with
+        the supplied Turnkey stamp.
+
+        The request may create a passkey-based method immediately or return a
+        follow-up step for OTP or OAuth-based authentication methods.
+      operationId: createEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthMethodCreateRequest'
+      responses:
+        '201':
+          description: Embedded wallet auth method created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOperationResponse'
+        '400':
+          description: Bad request - Invalid auth method creation parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '409':
+          description: Conflict - Embedded wallet auth method already exists or cannot be created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/auth/methods/{authMethodId}:
+    patch:
+      summary: Update an embedded wallet auth method
+      description: |
+        Update the email address or phone number associated with an embedded wallet
+        auth method.
+
+        The auth method to update is identified by `authMethodId`, while the
+        request is authorized with a Turnkey stamp.
+      operationId: updateEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: authMethodId
+          in: path
+          description: Unique identifier of the embedded wallet auth method to update
+          required: true
+          schema:
+            type: string
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:direct:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthMethodUpdateRequest'
+      responses:
+        '200':
+          description: Embedded wallet auth method updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOperationResponse'
+        '400':
+          description: Bad request - Invalid auth method update parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet auth method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - Embedded wallet auth method cannot be updated in its current state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+    delete:
+      summary: Delete an embedded wallet auth method
+      description: |
+        Delete an embedded wallet auth method.
+
+        The request will be rejected when the specified auth method is the last
+        remaining authentication method for the embedded wallet.
+      operationId: deleteEmbeddedWalletAuthMethod
+      tags:
+        - Embedded Wallets
+      security: []
+      parameters:
+        - name: authMethodId
+          in: path
+          description: Unique identifier of the embedded wallet auth method to delete
+          required: true
+          schema:
+            type: string
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        - name: X-Turnkey-Stamp
+          in: header
+          description: |
+            Turnkey stamp authorizing the request. The stamp may represent either a session stamp or a direct stamp.
+          required: true
+          schema:
+            type: string
+          example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+      responses:
+        '204':
+          description: Embedded wallet auth method deleted successfully
+        '400':
+          description: Bad request - Invalid auth method deletion parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized - Turnkey stamp is invalid or expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet auth method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - Embedded wallet auth method is the last remaining method or cannot be deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -10332,6 +10523,156 @@ components:
           type: string
           description: Opaque credential bundle returned after successful passkey authentication
           example: credential_bundle_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+    EmbeddedWalletAuthMethodType:
+      type: string
+      description: |
+        Type of authentication method associated with an embedded wallet.
+
+        | Value | Description |
+        |-------|-------------|
+        | PASSKEY | WebAuthn passkey-based authentication |
+        | OTP | One-time password delivered to an email address or phone number |
+        | OAUTH | Third-party OAuth-based authentication |
+      enum:
+        - PASSKEY
+        - OTP
+        - OAUTH
+      example: OTP
+    EmbeddedWalletAuthMethodCreateRequest:
+      type: object
+      required:
+        - methodType
+      properties:
+        methodType:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethodType'
+        email:
+          type: string
+          format: email
+          description: Email address to associate with the auth method, when applicable
+          example: alice@example.com
+        phoneNumber:
+          type: string
+          description: Phone number to associate with the auth method, when applicable
+          example: '+14155550123'
+        oauthProvider:
+          type: string
+          description: OAuth provider to use when `methodType` is `OAUTH`
+          example: GOOGLE
+        redirectUri:
+          type: string
+          format: uri
+          description: Redirect URI for OAuth-based auth method creation, when applicable
+          example: https://partner.example.com/embedded-wallet/callback
+        authenticatorName:
+          type: string
+          description: Friendly name for a passkey authenticator, when applicable
+          example: Alice MacBook Pro
+    EmbeddedWalletAuthMethod:
+      type: object
+      required:
+        - id
+        - methodType
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the embedded wallet auth method
+          example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+        methodType:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethodType'
+        label:
+          type: string
+          description: Human-readable label or masked identifier for the auth method
+          example: al***@example.com
+        oauthProvider:
+          type: string
+          description: OAuth provider associated with the auth method, when applicable
+          example: GOOGLE
+        verifiedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the auth method was verified and became active
+          example: '2026-04-08T15:32:28Z'
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: '2026-04-08T15:30:01Z'
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last update timestamp
+          example: '2026-04-08T15:32:28Z'
+    EmbeddedWalletAuthOperationResponse:
+      type: object
+      required:
+        - status
+        - nextStep
+      properties:
+        embeddedWalletId:
+          type: string
+          description: Unique identifier of the embedded wallet associated with the operation
+          example: EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000001
+        authSessionId:
+          type: string
+          description: Unique identifier of the embedded wallet auth session, when applicable
+          example: EmbeddedWalletAuthSession:019542f5-b3e7-1d02-0000-000000000002
+        pendingActionId:
+          type: string
+          description: Unique identifier of the pending embedded wallet action
+          example: EmbeddedWalletPendingAction:019542f5-b3e7-1d02-0000-000000000003
+        otpChallengeId:
+          type: string
+          description: Unique identifier of the OTP challenge, when an OTP step is active
+          example: EmbeddedWalletOtpChallenge:019542f5-b3e7-1d02-0000-000000000004
+        turnkeySubOrgId:
+          type: string
+          description: Turnkey sub-organization identifier associated with the embedded wallet
+          example: suborg_01JABCDEF23456789GHIJKL
+        status:
+          type: string
+          description: Current status of the embedded wallet auth-related operation
+          example: PENDING
+        nextStep:
+          type: string
+          description: Next action the integrator or end user must complete
+          example: COMPLETE_OTP_VERIFICATION
+        maskedDestination:
+          type: string
+          description: Masked email address or phone number used for OTP delivery
+          example: al***@example.com
+        oauthConsentUrl:
+          type: string
+          format: uri
+          description: OAuth consent URL the integrator should redirect the end user to, when applicable
+          example: https://accounts.google.com/o/oauth2/v2/auth?client_id=example-client-id
+        expiresAt:
+          type: string
+          format: date-time
+          description: Expiration timestamp for the current step of the auth flow
+          example: '2026-04-08T15:40:00Z'
+        authMethod:
+          $ref: '#/components/schemas/EmbeddedWalletAuthMethod'
+    EmbeddedWalletAuthMethodUpdateRequest:
+      type: object
+      description: |
+        Fields to update for an embedded wallet auth method. Provide only the fields relevant to the auth method being updated.
+      minProperties: 1
+      properties:
+        email:
+          type: string
+          format: email
+          description: New email address for the embedded wallet auth method
+          example: alice.updated@example.com
+        phoneNumber:
+          type: string
+          description: New phone number for the embedded wallet auth method
+          example: '+14155550124'
+        label:
+          type: string
+          description: Updated user-facing label for the auth method
+          example: Primary recovery email
     BeneficialOwnerCreateRequest:
       type: object
       required:

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethod.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethod.yaml
@@ -1,0 +1,36 @@
+type: object
+required:
+  - id
+  - methodType
+  - createdAt
+  - updatedAt
+properties:
+  id:
+    type: string
+    description: Unique identifier of the embedded wallet auth method
+    example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+  methodType:
+    $ref: ./EmbeddedWalletAuthMethodType.yaml
+  label:
+    type: string
+    description: Human-readable label or masked identifier for the auth method
+    example: al***@example.com
+  oauthProvider:
+    type: string
+    description: OAuth provider associated with the auth method, when applicable
+    example: GOOGLE
+  verifiedAt:
+    type: string
+    format: date-time
+    description: Timestamp when the auth method was verified and became active
+    example: '2026-04-08T15:32:28Z'
+  createdAt:
+    type: string
+    format: date-time
+    description: Creation timestamp
+    example: '2026-04-08T15:30:01Z'
+  updatedAt:
+    type: string
+    format: date-time
+    description: Last update timestamp
+    example: '2026-04-08T15:32:28Z'

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodCreateRequest.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodCreateRequest.yaml
@@ -1,0 +1,28 @@
+type: object
+required:
+  - methodType
+properties:
+  methodType:
+    $ref: ./EmbeddedWalletAuthMethodType.yaml
+  email:
+    type: string
+    format: email
+    description: Email address to associate with the auth method, when applicable
+    example: alice@example.com
+  phoneNumber:
+    type: string
+    description: Phone number to associate with the auth method, when applicable
+    example: '+14155550123'
+  oauthProvider:
+    type: string
+    description: OAuth provider to use when `methodType` is `OAUTH`
+    example: GOOGLE
+  redirectUri:
+    type: string
+    format: uri
+    description: Redirect URI for OAuth-based auth method creation, when applicable
+    example: https://partner.example.com/embedded-wallet/callback
+  authenticatorName:
+    type: string
+    description: Friendly name for a passkey authenticator, when applicable
+    example: Alice MacBook Pro

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodType.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodType.yaml
@@ -1,0 +1,14 @@
+type: string
+description: |
+  Type of authentication method associated with an embedded wallet.
+
+  | Value | Description |
+  |-------|-------------|
+  | PASSKEY | WebAuthn passkey-based authentication |
+  | OTP | One-time password delivered to an email address or phone number |
+  | OAUTH | Third-party OAuth-based authentication |
+enum:
+  - PASSKEY
+  - OTP
+  - OAUTH
+example: OTP

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodUpdateRequest.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthMethodUpdateRequest.yaml
@@ -1,0 +1,19 @@
+type: object
+description: >
+  Fields to update for an embedded wallet auth method. Provide only the fields
+  relevant to the auth method being updated.
+minProperties: 1
+properties:
+  email:
+    type: string
+    format: email
+    description: New email address for the embedded wallet auth method
+    example: alice.updated@example.com
+  phoneNumber:
+    type: string
+    description: New phone number for the embedded wallet auth method
+    example: '+14155550124'
+  label:
+    type: string
+    description: Updated user-facing label for the auth method
+    example: Primary recovery email

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOperationResponse.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOperationResponse.yaml
@@ -1,0 +1,49 @@
+type: object
+required:
+  - status
+  - nextStep
+properties:
+  embeddedWalletId:
+    type: string
+    description: Unique identifier of the embedded wallet associated with the operation
+    example: EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000001
+  authSessionId:
+    type: string
+    description: Unique identifier of the embedded wallet auth session, when applicable
+    example: EmbeddedWalletAuthSession:019542f5-b3e7-1d02-0000-000000000002
+  pendingActionId:
+    type: string
+    description: Unique identifier of the pending embedded wallet action
+    example: EmbeddedWalletPendingAction:019542f5-b3e7-1d02-0000-000000000003
+  otpChallengeId:
+    type: string
+    description: Unique identifier of the OTP challenge, when an OTP step is active
+    example: EmbeddedWalletOtpChallenge:019542f5-b3e7-1d02-0000-000000000004
+  turnkeySubOrgId:
+    type: string
+    description: Turnkey sub-organization identifier associated with the embedded wallet
+    example: suborg_01JABCDEF23456789GHIJKL
+  status:
+    type: string
+    description: Current status of the embedded wallet auth-related operation
+    example: PENDING
+  nextStep:
+    type: string
+    description: Next action the integrator or end user must complete
+    example: COMPLETE_OTP_VERIFICATION
+  maskedDestination:
+    type: string
+    description: Masked email address or phone number used for OTP delivery
+    example: al***@example.com
+  oauthConsentUrl:
+    type: string
+    format: uri
+    description: OAuth consent URL the integrator should redirect the end user to, when applicable
+    example: https://accounts.google.com/o/oauth2/v2/auth?client_id=example-client-id
+  expiresAt:
+    type: string
+    format: date-time
+    description: Expiration timestamp for the current step of the auth flow
+    example: '2026-04-08T15:40:00Z'
+  authMethod:
+    $ref: ./EmbeddedWalletAuthMethod.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -31,7 +31,7 @@ tags:
   - name: Embedded Wallets
     description: >-
       Endpoints for starting and completing embedded wallet authentication
-      flows.
+      flows and managing embedded wallet authentication methods.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -119,6 +119,10 @@ paths:
     $ref: paths/embedded-wallets/embedded_wallets_{internalAccountId}_auth_passkey_init.yaml
   /embedded-wallets/{internalAccountId}/auth/passkey/complete:
     $ref: paths/embedded-wallets/embedded_wallets_{internalAccountId}_auth_passkey_complete.yaml
+  /embedded-wallets/auth/methods:
+    $ref: paths/embedded-wallets/embedded_wallets_auth_methods.yaml
+  /embedded-wallets/auth/methods/{authMethodId}:
+    $ref: paths/embedded-wallets/embedded_wallets_auth_methods_{authMethodId}.yaml
   /beneficial-owners:
     $ref: paths/beneficial-owners/beneficial_owners.yaml
   /beneficial-owners/{beneficialOwnerId}:

--- a/openapi/paths/embedded-wallets/embedded_wallets_auth_methods.yaml
+++ b/openapi/paths/embedded-wallets/embedded_wallets_auth_methods.yaml
@@ -1,0 +1,59 @@
+post:
+  summary: Create an embedded wallet auth method
+  description: |
+    Create a new authentication method for the embedded wallet associated with
+    the supplied Turnkey stamp.
+
+    The request may create a passkey-based method immediately or return a
+    follow-up step for OTP or OAuth-based authentication methods.
+  operationId: createEmbeddedWalletAuthMethod
+  tags:
+    - Embedded Wallets
+  security: []
+  parameters:
+    - name: X-Turnkey-Stamp
+      in: header
+      description: >
+        Turnkey stamp authorizing the request. The stamp may represent either a
+        session stamp or a direct stamp.
+      required: true
+      schema:
+        type: string
+      example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthMethodCreateRequest.yaml
+  responses:
+    '201':
+      description: Embedded wallet auth method created successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthOperationResponse.yaml
+    '400':
+      description: Bad request - Invalid auth method creation parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized - Turnkey stamp is invalid or expired
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '409':
+      description: Conflict - Embedded wallet auth method already exists or cannot be created
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/embedded-wallets/embedded_wallets_auth_methods_{authMethodId}.yaml
+++ b/openapi/paths/embedded-wallets/embedded_wallets_auth_methods_{authMethodId}.yaml
@@ -1,0 +1,134 @@
+patch:
+  summary: Update an embedded wallet auth method
+  description: |
+    Update the email address or phone number associated with an embedded wallet
+    auth method.
+
+    The auth method to update is identified by `authMethodId`, while the
+    request is authorized with a Turnkey stamp.
+  operationId: updateEmbeddedWalletAuthMethod
+  tags:
+    - Embedded Wallets
+  security: []
+  parameters:
+    - name: authMethodId
+      in: path
+      description: Unique identifier of the embedded wallet auth method to update
+      required: true
+      schema:
+        type: string
+      example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+    - name: X-Turnkey-Stamp
+      in: header
+      description: >
+        Turnkey stamp authorizing the request. The stamp may represent either a
+        session stamp or a direct stamp.
+      required: true
+      schema:
+        type: string
+      example: stamp:direct:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthMethodUpdateRequest.yaml
+  responses:
+    '200':
+      description: Embedded wallet auth method updated successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthOperationResponse.yaml
+    '400':
+      description: Bad request - Invalid auth method update parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized - Turnkey stamp is invalid or expired
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Embedded wallet auth method not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: Conflict - Embedded wallet auth method cannot be updated in its current state
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
+
+delete:
+  summary: Delete an embedded wallet auth method
+  description: |
+    Delete an embedded wallet auth method.
+
+    The request will be rejected when the specified auth method is the last
+    remaining authentication method for the embedded wallet.
+  operationId: deleteEmbeddedWalletAuthMethod
+  tags:
+    - Embedded Wallets
+  security: []
+  parameters:
+    - name: authMethodId
+      in: path
+      description: Unique identifier of the embedded wallet auth method to delete
+      required: true
+      schema:
+        type: string
+      example: EmbeddedWalletAuthMethod:019542f5-b3e7-1d02-0000-000000000001
+    - name: X-Turnkey-Stamp
+      in: header
+      description: >
+        Turnkey stamp authorizing the request. The stamp may represent either a
+        session stamp or a direct stamp.
+      required: true
+      schema:
+        type: string
+      example: stamp:session:eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
+  responses:
+    '204':
+      description: Embedded wallet auth method deleted successfully
+    '400':
+      description: Bad request - Invalid auth method deletion parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized - Turnkey stamp is invalid or expired
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Embedded wallet auth method not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: Conflict - Embedded wallet auth method is the last remaining method or cannot be deleted
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
Add auth endpoints for embedded wallets.

Original list of endpoints and their modified new endpoint:
https://www.notion.so/lightspark/Gridsparknkey-321b3339000681669411e1d96cf95647?source=copy_link#ae4a254443814f01b587119a70ce117b


 | Original | Implemented | Notes |
  |---|---|---|
  | POST /embedded-wallets/auth/init | POST /embedded-wallets/auth/init | Same path/method |
  | POST /embedded-wallets/auth/otp/init | POST /embedded-wallets/auth/otp/init | Same path/method |
  | POST /embedded-wallets/auth/otp/verify | POST /embedded-wallets/auth/otp/verify | Same path/method |
  | POST /embedded-wallets/auth/add | POST /embedded-wallets/auth/methods | Renamed to a resource-style create endpoint |
  | POST /embedded-wallets/auth/remove | DELETE /embedded-wallets/auth/methods/{authMethodId} | Converted to RESTful delete; now requires authMethodId |
  | POST /embedded-wallets/auth/update | PATCH /embedded-wallets/auth/methods/{authMethodId} | Converted to RESTful update; now requires authMethodId |
  | POST /embedded-wallets/auth/callback | POST /embedded-wallets/auth/callback | Same path/method |
