### PR TITLE
Fix double chevron issue caused by Mintlify update

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1839,6 +1839,14 @@ html.dark #api-playground-2-operation-page .expandable {
   background-color: var(--ls-white-06) !important;
 }
 
+/* Hide any Mintlify-added ::after chevrons on expandable summaries */
+#api-playground-2-operation-page details > summary::after,
+#api-playground-2-operation-page details.expandable > summary::after,
+#api-playground-2-operation-page [data-component-part="expandable-button"]::after {
+  content: none !important;
+  display: none !important;
+}
+
 /* Page description text - match body text size */
 #api-playground-2-operation-page header#header .text-lg,
 header#header .text-lg {
@@ -2697,9 +2705,16 @@ html.dark .accordion-group details > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG and icon wrapper */
+/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
 .accordion-group details > summary svg,
-.accordion-group details > summary div[data-component-part="accordion-icon"] {
+.accordion-group details > summary div[data-component-part="accordion-icon"],
+.accordion-group details > summary span[data-icon],
+.accordion-group details > summary [data-slot="icon"] {
+  display: none !important;
+}
+
+.accordion-group details > summary::after {
+  content: none !important;
   display: none !important;
 }
 
@@ -2835,13 +2850,26 @@ html.dark .prose:not(.accordion-group) > details.accordion > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG and icon wrapper */
+/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
 #content > details.accordion > summary svg,
 #content-area > details.accordion > summary svg,
 .prose:not(.accordion-group) > details.accordion > summary svg,
 #content > details.accordion > summary div[data-component-part="accordion-icon"],
 #content-area > details.accordion > summary div[data-component-part="accordion-icon"],
-.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"] {
+.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"],
+#content > details.accordion > summary span[data-icon],
+#content-area > details.accordion > summary span[data-icon],
+.prose:not(.accordion-group) > details.accordion > summary span[data-icon],
+#content > details.accordion > summary [data-slot="icon"],
+#content-area > details.accordion > summary [data-slot="icon"],
+.prose:not(.accordion-group) > details.accordion > summary [data-slot="icon"] {
+  display: none !important;
+}
+
+#content > details.accordion > summary::after,
+#content-area > details.accordion > summary::after,
+.prose:not(.accordion-group) > details.accordion > summary::after {
+  content: none !important;
   display: none !important;
 }
 

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -592,9 +592,12 @@ div:has(> .chat-assistant-floating-input) {
   background: transparent !important;
 }
 
+/* Mintlify currently renders the bottom bar glow on the input itself. */
+.chat-assistant-floating-input::before,
 div:has(> .chat-assistant-floating-input)::before,
 .chat-assistant-floating-input > div::before {
   background: transparent !important;
+  opacity: 0 !important;
 }
 
 /* Mobile assistant bar placeholder - make transparent so it doesn't cover content */
@@ -1150,11 +1153,15 @@ html.dark #navigation-items li[class*="space-y"] > button {
   color: var(--ls-gray-600) !important;
 }
 
-/* Hide the original SVG chevron */
-#sidebar-group > li > button > svg,
-ul#sidebar-group > li > button > svg,
-#navigation-items li.space-y-px > button > svg,
-#navigation-items li[class*="space-y"] > button > svg {
+/* Hide Mintlify's native chevron, including the new wrapped SVG variant. */
+#sidebar-group > li > button > div:has(> svg),
+ul#sidebar-group > li > button > div:has(> svg),
+#navigation-items li.space-y-px > button > div:has(> svg),
+#navigation-items li[class*="space-y"] > button > div:has(> svg),
+#sidebar-group > li > button svg,
+ul#sidebar-group > li > button svg,
+#navigation-items li.space-y-px > button svg,
+#navigation-items li[class*="space-y"] > button svg {
   display: none !important;
   visibility: hidden !important;
 }


### PR DESCRIPTION
Hide ::after pseudo-elements that Mintlify may have added to accordion and expandable summaries, which were causing duplicate chevrons alongside our custom ::before chevrons.

- Added ::after hiding rules for accordion-group summaries
- Added ::after hiding rules for standalone accordion summaries
- Added ::after hiding rules for API reference expandable sections
- Added additional icon element selectors (span[data-icon], [data-slot="icon"])

https://claude.ai/code/session_01Csh9eQughWs7SqfyMfFVw4