### PR TITLE
Fix Mintlify sidebar chevrons and Ask AI input chrome

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1846,14 +1846,6 @@ html.dark #api-playground-2-operation-page .expandable {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide any Mintlify-added ::after chevrons on expandable summaries */
-#api-playground-2-operation-page details > summary::after,
-#api-playground-2-operation-page details.expandable > summary::after,
-#api-playground-2-operation-page [data-component-part="expandable-button"]::after {
-  content: none !important;
-  display: none !important;
-}
-
 /* Page description text - match body text size */
 #api-playground-2-operation-page header#header .text-lg,
 header#header .text-lg {
@@ -2712,16 +2704,9 @@ html.dark .accordion-group details > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
+/* Hide Mintlify's chevron SVG and icon wrapper */
 .accordion-group details > summary svg,
-.accordion-group details > summary div[data-component-part="accordion-icon"],
-.accordion-group details > summary span[data-icon],
-.accordion-group details > summary [data-slot="icon"] {
-  display: none !important;
-}
-
-.accordion-group details > summary::after {
-  content: none !important;
+.accordion-group details > summary div[data-component-part="accordion-icon"] {
   display: none !important;
 }
 
@@ -2857,26 +2842,13 @@ html.dark .prose:not(.accordion-group) > details.accordion > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
+/* Hide Mintlify's chevron SVG and icon wrapper */
 #content > details.accordion > summary svg,
 #content-area > details.accordion > summary svg,
 .prose:not(.accordion-group) > details.accordion > summary svg,
 #content > details.accordion > summary div[data-component-part="accordion-icon"],
 #content-area > details.accordion > summary div[data-component-part="accordion-icon"],
-.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"],
-#content > details.accordion > summary span[data-icon],
-#content-area > details.accordion > summary span[data-icon],
-.prose:not(.accordion-group) > details.accordion > summary span[data-icon],
-#content > details.accordion > summary [data-slot="icon"],
-#content-area > details.accordion > summary [data-slot="icon"],
-.prose:not(.accordion-group) > details.accordion > summary [data-slot="icon"] {
-  display: none !important;
-}
-
-#content > details.accordion > summary::after,
-#content-area > details.accordion > summary::after,
-.prose:not(.accordion-group) > details.accordion > summary::after {
-  content: none !important;
+.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"] {
   display: none !important;
 }
 

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1839,6 +1839,14 @@ html.dark #api-playground-2-operation-page .expandable {
   background-color: var(--ls-white-06) !important;
 }
 
+/* Hide any Mintlify-added ::after chevrons on expandable summaries */
+#api-playground-2-operation-page details > summary::after,
+#api-playground-2-operation-page details.expandable > summary::after,
+#api-playground-2-operation-page [data-component-part="expandable-button"]::after {
+  content: none !important;
+  display: none !important;
+}
+
 /* Page description text - match body text size */
 #api-playground-2-operation-page header#header .text-lg,
 header#header .text-lg {
@@ -2697,9 +2705,16 @@ html.dark .accordion-group details > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG and icon wrapper */
+/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
 .accordion-group details > summary svg,
-.accordion-group details > summary div[data-component-part="accordion-icon"] {
+.accordion-group details > summary div[data-component-part="accordion-icon"],
+.accordion-group details > summary span[data-icon],
+.accordion-group details > summary [data-slot="icon"] {
+  display: none !important;
+}
+
+.accordion-group details > summary::after {
+  content: none !important;
   display: none !important;
 }
 
@@ -2835,13 +2850,26 @@ html.dark .prose:not(.accordion-group) > details.accordion > summary:hover {
   background-color: var(--ls-white-06) !important;
 }
 
-/* Hide Mintlify's chevron SVG and icon wrapper */
+/* Hide Mintlify's chevron SVG, icon wrapper, and ::after pseudo-element */
 #content > details.accordion > summary svg,
 #content-area > details.accordion > summary svg,
 .prose:not(.accordion-group) > details.accordion > summary svg,
 #content > details.accordion > summary div[data-component-part="accordion-icon"],
 #content-area > details.accordion > summary div[data-component-part="accordion-icon"],
-.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"] {
+.prose:not(.accordion-group) > details.accordion > summary div[data-component-part="accordion-icon"],
+#content > details.accordion > summary span[data-icon],
+#content-area > details.accordion > summary span[data-icon],
+.prose:not(.accordion-group) > details.accordion > summary span[data-icon],
+#content > details.accordion > summary [data-slot="icon"],
+#content-area > details.accordion > summary [data-slot="icon"],
+.prose:not(.accordion-group) > details.accordion > summary [data-slot="icon"] {
+  display: none !important;
+}
+
+#content > details.accordion > summary::after,
+#content-area > details.accordion > summary::after,
+.prose:not(.accordion-group) > details.accordion > summary::after {
+  content: none !important;
   display: none !important;
 }
 

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -592,9 +592,12 @@ div:has(> .chat-assistant-floating-input) {
   background: transparent !important;
 }
 
+/* Mintlify currently renders the bottom bar glow on the input itself. */
+.chat-assistant-floating-input::before,
 div:has(> .chat-assistant-floating-input)::before,
 .chat-assistant-floating-input > div::before {
   background: transparent !important;
+  opacity: 0 !important;
 }
 
 /* Mobile assistant bar placeholder - make transparent so it doesn't cover content */
@@ -1150,11 +1153,15 @@ html.dark #navigation-items li[class*="space-y"] > button {
   color: var(--ls-gray-600) !important;
 }
 
-/* Hide the original SVG chevron */
-#sidebar-group > li > button > svg,
-ul#sidebar-group > li > button > svg,
-#navigation-items li.space-y-px > button > svg,
-#navigation-items li[class*="space-y"] > button > svg {
+/* Hide Mintlify's native chevron, including the new wrapped SVG variant. */
+#sidebar-group > li > button > div:has(> svg),
+ul#sidebar-group > li > button > div:has(> svg),
+#navigation-items li.space-y-px > button > div:has(> svg),
+#navigation-items li[class*="space-y"] > button > div:has(> svg),
+#sidebar-group > li > button svg,
+ul#sidebar-group > li > button svg,
+#navigation-items li.space-y-px > button svg,
+#navigation-items li[class*="space-y"] > button svg {
   display: none !important;
   visibility: hidden !important;
 }


### PR DESCRIPTION
## Summary
- supersede the closed `#324` with a fresh PR that keeps the existing accordion and expandable chevron guards
- hide Mintlify's newly wrapped API Reference sidebar chevron markup so it no longer renders beside our custom chevron styling
- make the floating Ask AI input's bottom bar pseudo-element fully transparent

## Test plan
- [x] Run `make lint`
- [ ] Verify the API Reference sidebar shows a single chevron in the Mintlify preview
- [ ] Verify the Ask AI input bottom bar is transparent in the Mintlify preview


Made with [Cursor](https://cursor.com)