### PR TITLE
feat: change cryptoNetwork from string to enum

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2783,7 +2783,7 @@ paths:
                 value:
                   internalAccountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
                   currency: USDC
-                  cryptoNetwork: SOLANA_MAINNET
+                  cryptoNetwork: SOLANA
                   amount: 1000000
                   destinationAddress: 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
       responses:
@@ -7640,6 +7640,28 @@ components:
           type: string
           description: The verified full name of the account holder as returned by the payment rail
           example: John Doe
+    CryptoNetwork:
+      type: string
+      description: |
+        The blockchain network identifier. The environment (mainnet vs testnet) is determined
+        automatically based on whether the request is made against the production or sandbox API.
+
+        | Value | Production | Sandbox |
+        |-------|------------|---------|
+        | BITCOIN | Bitcoin mainnet | Bitcoin testnet |
+        | ETHEREUM | Ethereum mainnet | Ethereum Sepolia |
+        | SOLANA | Solana mainnet | Solana devnet |
+        | BASE | Base mainnet | Base Sepolia |
+        | SPARK | Spark mainnet | Spark testnet |
+        | LIGHTNING | Lightning mainnet | Lightning regtest |
+      enum:
+        - BITCOIN
+        - ETHEREUM
+        - SOLANA
+        - BASE
+        - SPARK
+        - LIGHTNING
+      example: SOLANA
     ExternalAccountType:
       type: string
       enum:
@@ -9748,9 +9770,7 @@ components:
               $ref: '#/components/schemas/BeneficiaryVerifiedData'
               description: Verified beneficiary data returned by the payment rail, if available
             cryptoNetwork:
-              type: string
-              description: 'The blockchain network for this external account, if applicable. Present when the account is a cryptocurrency wallet. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-              example: SOLANA_MAINNET
+              $ref: '#/components/schemas/CryptoNetwork'
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:
@@ -9777,9 +9797,7 @@ components:
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
               default: false
             cryptoNetwork:
-              type: string
-              description: 'The blockchain network for this external account. Required when the account is a cryptocurrency wallet. Specifies which network the wallet is on. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-              example: SOLANA_MAINNET
+              $ref: '#/components/schemas/CryptoNetwork'
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlatformExternalAccountCreateRequest:
@@ -10851,9 +10869,9 @@ components:
               description: Currency code for the funding source. See [Supported Currencies](https://grid.lightspark.com/platform-overview/core-concepts/currencies-and-rails) for the full list of supported fiat and crypto currencies.
               example: USD
             cryptoNetwork:
-              type: string
-              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`, `ETHEREUM_TESTNET`, `BASE_MAINNET`, `BASE_TESTNET`, `SPARK_MAINNET`, `SPARK_TESTNET`, `LIGHTNING_MAINNET`, `LIGHTNING_REGTEST`.'
-              example: SOLANA_MAINNET
+              allOf:
+                - $ref: '#/components/schemas/CryptoNetwork'
+                - description: The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated.
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:
       oneOf:
@@ -11137,9 +11155,7 @@ components:
           description: The currency code of the asset to withdraw (e.g. USDC).
           example: USDC
         cryptoNetwork:
-          type: string
-          description: 'The blockchain network for the withdrawal. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-          example: SOLANA_MAINNET
+          $ref: '#/components/schemas/CryptoNetwork'
         amount:
           type: integer
           description: The amount to withdraw in the smallest unit of the currency.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2783,7 +2783,7 @@ paths:
                 value:
                   internalAccountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
                   currency: USDC
-                  cryptoNetwork: SOLANA_MAINNET
+                  cryptoNetwork: SOLANA
                   amount: 1000000
                   destinationAddress: 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
       responses:
@@ -7640,6 +7640,28 @@ components:
           type: string
           description: The verified full name of the account holder as returned by the payment rail
           example: John Doe
+    CryptoNetwork:
+      type: string
+      description: |
+        The blockchain network identifier. The environment (mainnet vs testnet) is determined
+        automatically based on whether the request is made against the production or sandbox API.
+
+        | Value | Production | Sandbox |
+        |-------|------------|---------|
+        | BITCOIN | Bitcoin mainnet | Bitcoin testnet |
+        | ETHEREUM | Ethereum mainnet | Ethereum Sepolia |
+        | SOLANA | Solana mainnet | Solana devnet |
+        | BASE | Base mainnet | Base Sepolia |
+        | SPARK | Spark mainnet | Spark testnet |
+        | LIGHTNING | Lightning mainnet | Lightning regtest |
+      enum:
+        - BITCOIN
+        - ETHEREUM
+        - SOLANA
+        - BASE
+        - SPARK
+        - LIGHTNING
+      example: SOLANA
     ExternalAccountType:
       type: string
       enum:
@@ -9748,9 +9770,7 @@ components:
               $ref: '#/components/schemas/BeneficiaryVerifiedData'
               description: Verified beneficiary data returned by the payment rail, if available
             cryptoNetwork:
-              type: string
-              description: 'The blockchain network for this external account, if applicable. Present when the account is a cryptocurrency wallet. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-              example: SOLANA_MAINNET
+              $ref: '#/components/schemas/CryptoNetwork'
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     ExternalAccountCreateRequest:
@@ -9777,9 +9797,7 @@ components:
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
               default: false
             cryptoNetwork:
-              type: string
-              description: 'The blockchain network for this external account. Required when the account is a cryptocurrency wallet. Specifies which network the wallet is on. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-              example: SOLANA_MAINNET
+              $ref: '#/components/schemas/CryptoNetwork'
             accountInfo:
               $ref: '#/components/schemas/ExternalAccountInfoOneOf'
     PlatformExternalAccountCreateRequest:
@@ -10851,9 +10869,9 @@ components:
               description: Currency code for the funding source. See [Supported Currencies](https://grid.lightspark.com/platform-overview/core-concepts/currencies-and-rails) for the full list of supported fiat and crypto currencies.
               example: USD
             cryptoNetwork:
-              type: string
-              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`, `ETHEREUM_TESTNET`, `BASE_MAINNET`, `BASE_TESTNET`, `SPARK_MAINNET`, `SPARK_TESTNET`, `LIGHTNING_MAINNET`, `LIGHTNING_REGTEST`.'
-              example: SOLANA_MAINNET
+              allOf:
+                - $ref: '#/components/schemas/CryptoNetwork'
+                - description: The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated.
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:
       oneOf:
@@ -11137,9 +11155,7 @@ components:
           description: The currency code of the asset to withdraw (e.g. USDC).
           example: USDC
         cryptoNetwork:
-          type: string
-          description: 'The blockchain network for the withdrawal. Example values: SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.'
-          example: SOLANA_MAINNET
+          $ref: '#/components/schemas/CryptoNetwork'
         amount:
           type: integer
           description: The amount to withdraw in the smallest unit of the currency.

--- a/openapi/components/schemas/crypto/CryptoNetwork.yaml
+++ b/openapi/components/schemas/crypto/CryptoNetwork.yaml
@@ -1,0 +1,21 @@
+type: string
+description: |
+  The blockchain network identifier. The environment (mainnet vs testnet) is determined
+  automatically based on whether the request is made against the production or sandbox API.
+
+  | Value | Production | Sandbox |
+  |-------|------------|---------|
+  | BITCOIN | Bitcoin mainnet | Bitcoin testnet |
+  | ETHEREUM | Ethereum mainnet | Ethereum Sepolia |
+  | SOLANA | Solana mainnet | Solana devnet |
+  | BASE | Base mainnet | Base Sepolia |
+  | SPARK | Spark mainnet | Spark testnet |
+  | LIGHTNING | Lightning mainnet | Lightning regtest |
+enum:
+  - BITCOIN
+  - ETHEREUM
+  - SOLANA
+  - BASE
+  - SPARK
+  - LIGHTNING
+example: SOLANA

--- a/openapi/components/schemas/crypto/EstimateCryptoWithdrawalFeeRequest.yaml
+++ b/openapi/components/schemas/crypto/EstimateCryptoWithdrawalFeeRequest.yaml
@@ -15,13 +15,7 @@ properties:
     description: The currency code of the asset to withdraw (e.g. USDC).
     example: USDC
   cryptoNetwork:
-    type: string
-    description: >-
-      The blockchain network for the withdrawal. Example values: SOLANA_MAINNET,
-      SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET,
-      BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET,
-      LIGHTNING_REGTEST.
-    example: SOLANA_MAINNET
+    $ref: ./CryptoNetwork.yaml
   amount:
     type: integer
     description: The amount to withdraw in the smallest unit of the currency.

--- a/openapi/components/schemas/external_accounts/ExternalAccount.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccount.yaml
@@ -41,12 +41,6 @@ allOf:
         $ref: ./BeneficiaryVerifiedData.yaml
         description: Verified beneficiary data returned by the payment rail, if available
       cryptoNetwork:
-        type: string
-        description: >-
-          The blockchain network for this external account, if applicable. Present when the account
-          is a cryptocurrency wallet. Example values: SOLANA_MAINNET, SOLANA_DEVNET,
-          ETHEREUM_MAINNET, ETHEREUM_TESTNET, BASE_MAINNET, BASE_TESTNET,
-          SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET, LIGHTNING_REGTEST.
-        example: SOLANA_MAINNET
+        $ref: ../crypto/CryptoNetwork.yaml
       accountInfo:
         $ref: ./ExternalAccountInfoOneOf.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
@@ -29,13 +29,6 @@ allOf:
           incoming UMA payments will be deposited into the primary internal account for the customer.
         default: false
       cryptoNetwork:
-        type: string
-        description: >-
-          The blockchain network for this external account. Required when the account is a
-          cryptocurrency wallet. Specifies which network the wallet is on. Example values:
-          SOLANA_MAINNET, SOLANA_DEVNET, ETHEREUM_MAINNET, ETHEREUM_TESTNET,
-          BASE_MAINNET, BASE_TESTNET, SPARK_MAINNET, SPARK_TESTNET, LIGHTNING_MAINNET,
-          LIGHTNING_REGTEST.
-        example: SOLANA_MAINNET
+        $ref: ../crypto/CryptoNetwork.yaml
       accountInfo:
         $ref: ./ExternalAccountInfoOneOf.yaml

--- a/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
+++ b/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
@@ -24,15 +24,12 @@ allOf:
           for the full list of supported fiat and crypto currencies.
         example: USD
       cryptoNetwork:
-        type: string
-        description: >-
-          The crypto network to use for the funding source. Required when `currency` is a
-          stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit
-          on, so the correct deposit address can be generated. Example values:
-          `SOLANA_MAINNET`, `SOLANA_DEVNET`, `ETHEREUM_MAINNET`, `ETHEREUM_TESTNET`,
-          `BASE_MAINNET`, `BASE_TESTNET`, `SPARK_MAINNET`, `SPARK_TESTNET`,
-          `LIGHTNING_MAINNET`, `LIGHTNING_REGTEST`.
-        example: SOLANA_MAINNET
+        allOf:
+          - $ref: ../crypto/CryptoNetwork.yaml
+          - description: >-
+              The crypto network to use for the funding source. Required when `currency` is a
+              stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit
+              on, so the correct deposit address can be generated.
     description: >-
       Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
       This will require manual just-in-time funding using `paymentInstructions` in the response.

--- a/openapi/paths/crypto/crypto_estimate-withdrawal-fee.yaml
+++ b/openapi/paths/crypto/crypto_estimate-withdrawal-fee.yaml
@@ -21,7 +21,7 @@ post:
             value:
               internalAccountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
               currency: USDC
-              cryptoNetwork: SOLANA_MAINNET
+              cryptoNetwork: SOLANA
               amount: 1000000
               destinationAddress: 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
   responses:


### PR DESCRIPTION
## Summary
- Creates a shared `CryptoNetwork` enum schema with values: `BITCOIN`, `ETHEREUM`, `SOLANA`, `BASE`, `SPARK`, `LIGHTNING`
- Environment (mainnet/testnet/devnet) is now determined automatically by the API environment, removing `_MAINNET`/`_TESTNET`/`_DEVNET`/`_REGTEST` suffixes
- Updates all 4 schemas that reference `cryptoNetwork` to use the shared enum (`EstimateCryptoWithdrawalFeeRequest`, `ExternalAccount`, `ExternalAccountCreateRequest`, `RealtimeFundingQuoteSource`)
- Full list of networks sourced from webdev's `sparklib/money/crypto_network.py`

## Test plan
- [x] `make build` — OpenAPI bundle succeeds
- [x] `make lint-openapi` — validation passes
- [ ] Verify API reference renders the enum dropdown correctly on affected endpoints
- [ ] Confirm server-side mapping from truncated values to environment-specific values works

🤖 Generated with [Claude Code](https://claude.com/claude-code)