### PR TITLE
Add OAuth endpoint

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -186,6 +186,16 @@ resources:
           vnd_account_info: "#/components/schemas/VndAccountInfo"
           # base_external_account_info: "#/components/schemas/BaseExternalAccountInfo"
 
+  embedded_wallets:
+    subresources:
+      auth:
+        models:
+          embedded_wallet_oauth_provider: "#/components/schemas/EmbeddedWalletOAuthProvider"
+          embedded_wallet_auth_oauth_request: "#/components/schemas/EmbeddedWalletAuthOAuthRequest"
+          embedded_wallet_auth_oauth_response: "#/components/schemas/EmbeddedWalletAuthOAuthResponse"
+        methods:
+          oauth: post /embedded-wallets/{internalAccountId}/auth/oauth
+
   transfer_in:
     models:
       transaction: "#/components/schemas/TransactionOneOf"

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -26,6 +26,8 @@ tags:
     description: Endpoints for uploading and managing verification documents for customers and beneficial owners. Supports KYC and KYB document requirements.
   - name: Internal Accounts
     description: Internal account management endpoints for creating and managing internal accounts
+  - name: Embedded Wallets
+    description: Endpoints for starting and completing embedded wallet authentication flows.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -1181,6 +1183,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/{internalAccountId}/auth/oauth:
+    post:
+      summary: Authenticate an embedded wallet with OAuth
+      description: |
+        Authenticate the embedded wallet associated with the specified internal
+        account using an OAuth-issued OIDC token.
+
+        If the internal account is not yet linked to a Turnkey signer, Grid will
+        first provision the signer and supporting wallet records before completing
+        OAuth authentication.
+
+        Conditional validation:
+        - First-time setup requires `userName`, `provider`, `oidcToken`, and
+          `clientPublicKey`. `userEmail` is optional.
+        - Reauthentication requires `oidcToken` and `clientPublicKey`. `provider`
+          may still be supplied for validation or logging.
+      operationId: authenticateEmbeddedWalletWithOAuth
+      tags:
+        - Embedded Wallets
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: internalAccountId
+          in: path
+          description: Unique identifier of the EMBEDDED_WALLET internal account
+          required: true
+          schema:
+            type: string
+          example: InternalAccount:12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthOAuthRequest'
+      responses:
+        '200':
+          description: OAuth authentication completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOAuthResponse'
+        '400':
+          description: Bad request - Invalid OAuth authentication parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet internal account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal service error
           content:
@@ -9823,6 +9891,56 @@ components:
           example: ext_acc_123456
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    EmbeddedWalletOAuthProvider:
+      type: string
+      description: OAuth provider used for embedded wallet authentication
+      enum:
+        - GOOGLE
+        - APPLE
+      example: GOOGLE
+    EmbeddedWalletAuthOAuthRequest:
+      type: object
+      required:
+        - oidcToken
+        - clientPublicKey
+      description: |
+        Request to authenticate an embedded wallet with OAuth.
+
+        Conditional validation:
+        - If the internal account is not yet linked to a Turnkey signer, `userName`
+          and `provider` are required. `userEmail` is optional.
+        - If the internal account is already linked, only `oidcToken` and
+          `clientPublicKey` are required. `provider` may still be supplied for
+          validation or logging.
+      properties:
+        oidcToken:
+          type: string
+          description: OIDC token to exchange with Turnkey for OAuth authentication
+          example: eyJhbGciOiJSUzI1NiIsImtpZCI6Im9hdXRoLWtleS0xIn0.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature
+        clientPublicKey:
+          type: string
+          description: Public key that Turnkey should bind the resulting session to
+          example: 029a4f9d0e0bc2f2d8df91f0f2d1b09ff8f85f8b16f31c2fb45a3f6c4a79c2d8f1
+        provider:
+          $ref: '#/components/schemas/EmbeddedWalletOAuthProvider'
+        userName:
+          type: string
+          description: Full name to use when first provisioning the embedded wallet signer
+          example: Alice Example
+        userEmail:
+          type: string
+          format: email
+          description: Optional email address to attach when first provisioning the embedded wallet signer
+          example: alice@example.com
+    EmbeddedWalletAuthOAuthResponse:
+      type: object
+      required:
+        - session
+      properties:
+        session:
+          type: string
+          description: Opaque session string returned after successful OAuth authentication
+          example: session_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
     BeneficialOwnerCreateRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,6 +26,8 @@ tags:
     description: Endpoints for uploading and managing verification documents for customers and beneficial owners. Supports KYC and KYB document requirements.
   - name: Internal Accounts
     description: Internal account management endpoints for creating and managing internal accounts
+  - name: Embedded Wallets
+    description: Endpoints for starting and completing embedded wallet authentication flows.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -1181,6 +1183,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /embedded-wallets/{internalAccountId}/auth/oauth:
+    post:
+      summary: Authenticate an embedded wallet with OAuth
+      description: |
+        Authenticate the embedded wallet associated with the specified internal
+        account using an OAuth-issued OIDC token.
+
+        If the internal account is not yet linked to a Turnkey signer, Grid will
+        first provision the signer and supporting wallet records before completing
+        OAuth authentication.
+
+        Conditional validation:
+        - First-time setup requires `userName`, `provider`, `oidcToken`, and
+          `clientPublicKey`. `userEmail` is optional.
+        - Reauthentication requires `oidcToken` and `clientPublicKey`. `provider`
+          may still be supplied for validation or logging.
+      operationId: authenticateEmbeddedWalletWithOAuth
+      tags:
+        - Embedded Wallets
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: internalAccountId
+          in: path
+          description: Unique identifier of the EMBEDDED_WALLET internal account
+          required: true
+          schema:
+            type: string
+          example: InternalAccount:12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddedWalletAuthOAuthRequest'
+      responses:
+        '200':
+          description: OAuth authentication completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedWalletAuthOAuthResponse'
+        '400':
+          description: Bad request - Invalid OAuth authentication parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Embedded wallet internal account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal service error
           content:
@@ -9823,6 +9891,56 @@ components:
           example: ext_acc_123456
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountInfoOneOf'
+    EmbeddedWalletOAuthProvider:
+      type: string
+      description: OAuth provider used for embedded wallet authentication
+      enum:
+        - GOOGLE
+        - APPLE
+      example: GOOGLE
+    EmbeddedWalletAuthOAuthRequest:
+      type: object
+      required:
+        - oidcToken
+        - clientPublicKey
+      description: |
+        Request to authenticate an embedded wallet with OAuth.
+
+        Conditional validation:
+        - If the internal account is not yet linked to a Turnkey signer, `userName`
+          and `provider` are required. `userEmail` is optional.
+        - If the internal account is already linked, only `oidcToken` and
+          `clientPublicKey` are required. `provider` may still be supplied for
+          validation or logging.
+      properties:
+        oidcToken:
+          type: string
+          description: OIDC token to exchange with Turnkey for OAuth authentication
+          example: eyJhbGciOiJSUzI1NiIsImtpZCI6Im9hdXRoLWtleS0xIn0.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature
+        clientPublicKey:
+          type: string
+          description: Public key that Turnkey should bind the resulting session to
+          example: 029a4f9d0e0bc2f2d8df91f0f2d1b09ff8f85f8b16f31c2fb45a3f6c4a79c2d8f1
+        provider:
+          $ref: '#/components/schemas/EmbeddedWalletOAuthProvider'
+        userName:
+          type: string
+          description: Full name to use when first provisioning the embedded wallet signer
+          example: Alice Example
+        userEmail:
+          type: string
+          format: email
+          description: Optional email address to attach when first provisioning the embedded wallet signer
+          example: alice@example.com
+    EmbeddedWalletAuthOAuthResponse:
+      type: object
+      required:
+        - session
+      properties:
+        session:
+          type: string
+          description: Opaque session string returned after successful OAuth authentication
+          example: session_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9
     BeneficialOwnerCreateRequest:
       type: object
       required:

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthRequest.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthRequest.yaml
@@ -1,0 +1,33 @@
+type: object
+required:
+  - oidcToken
+  - clientPublicKey
+description: |
+  Request to authenticate an embedded wallet with OAuth.
+
+  Conditional validation:
+  - If the internal account is not yet linked to a Turnkey signer, `userName`
+    and `provider` are required. `userEmail` is optional.
+  - If the internal account is already linked, only `oidcToken` and
+    `clientPublicKey` are required. `provider` may still be supplied for
+    validation or logging.
+properties:
+  oidcToken:
+    type: string
+    description: OIDC token to exchange with Turnkey for OAuth authentication
+    example: eyJhbGciOiJSUzI1NiIsImtpZCI6Im9hdXRoLWtleS0xIn0.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature
+  clientPublicKey:
+    type: string
+    description: Public key that Turnkey should bind the resulting session to
+    example: 029a4f9d0e0bc2f2d8df91f0f2d1b09ff8f85f8b16f31c2fb45a3f6c4a79c2d8f1
+  provider:
+    $ref: ./EmbeddedWalletOAuthProvider.yaml
+  userName:
+    type: string
+    description: Full name to use when first provisioning the embedded wallet signer
+    example: Alice Example
+  userEmail:
+    type: string
+    format: email
+    description: Optional email address to attach when first provisioning the embedded wallet signer
+    example: alice@example.com

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthResponse.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - session
+properties:
+  session:
+    type: string
+    description: Opaque session string returned after successful OAuth authentication
+    example: session_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9

--- a/openapi/components/schemas/embedded_wallets/EmbeddedWalletOAuthProvider.yaml
+++ b/openapi/components/schemas/embedded_wallets/EmbeddedWalletOAuthProvider.yaml
@@ -1,0 +1,6 @@
+type: string
+description: OAuth provider used for embedded wallet authentication
+enum:
+  - GOOGLE
+  - APPLE
+example: GOOGLE

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -28,6 +28,10 @@ tags:
       and beneficial owners. Supports KYC and KYB document requirements.
   - name: Internal Accounts
     description: Internal account management endpoints for creating and managing internal accounts
+  - name: Embedded Wallets
+    description: >-
+      Endpoints for starting and completing embedded wallet authentication
+      flows.
   - name: External Accounts
     description: External account management endpoints for creating and managing external bank accounts
   - name: Same-Currency Transfers
@@ -105,6 +109,8 @@ paths:
     $ref: paths/customers/customers_external_accounts.yaml
   /platform/external-accounts:
     $ref: paths/platform/platform_external_accounts.yaml
+  /embedded-wallets/{internalAccountId}/auth/oauth:
+    $ref: paths/embedded-wallets/embedded_wallets_{internalAccountId}_auth_oauth.yaml
   /beneficial-owners:
     $ref: paths/beneficial-owners/beneficial_owners.yaml
   /beneficial-owners/{beneficialOwnerId}:

--- a/openapi/paths/embedded-wallets/embedded_wallets_{internalAccountId}_auth_oauth.yaml
+++ b/openapi/paths/embedded-wallets/embedded_wallets_{internalAccountId}_auth_oauth.yaml
@@ -1,0 +1,65 @@
+post:
+  summary: Authenticate an embedded wallet with OAuth
+  description: |
+    Authenticate the embedded wallet associated with the specified internal
+    account using an OAuth-issued OIDC token.
+
+    If the internal account is not yet linked to a Turnkey signer, Grid will
+    first provision the signer and supporting wallet records before completing
+    OAuth authentication.
+
+    Conditional validation:
+    - First-time setup requires `userName`, `provider`, `oidcToken`, and
+      `clientPublicKey`. `userEmail` is optional.
+    - Reauthentication requires `oidcToken` and `clientPublicKey`. `provider`
+      may still be supplied for validation or logging.
+  operationId: authenticateEmbeddedWalletWithOAuth
+  tags:
+    - Embedded Wallets
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: internalAccountId
+      in: path
+      description: Unique identifier of the EMBEDDED_WALLET internal account
+      required: true
+      schema:
+        type: string
+      example: InternalAccount:12dcbd6-dced-4ec4-b756-3c3a9ea3d123
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthRequest.yaml
+  responses:
+    '200':
+      description: OAuth authentication completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/embedded_wallets/EmbeddedWalletAuthOAuthResponse.yaml
+    '400':
+      description: Bad request - Invalid OAuth authentication parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Embedded wallet internal account not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
- Added the endpoint `/embedded-wallets/{internalAccountId}/auth/oauth` which is a one step endpoint for OAuth authentication
- Client sends oidc token + pubkey, Grid creates sub org/session
- This endpoint does not require separate init + complete endpoints (unlike OAuth + Passkeys)