### PR TITLE
Add PaymentRail enum for external accounts

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4645,6 +4645,25 @@ components:
           description: Number of decimal places for the currency
           minimum: 0
           example: 2
+    PaymentRail:
+      type: string
+      enum:
+        - ACH
+        - BANK_TRANSFER
+        - FAST
+        - FASTER_PAYMENTS
+        - FEDNOW
+        - MOBILE_MONEY
+        - PAYNOW
+        - PIX
+        - RTP
+        - SEPA
+        - SEPA_INSTANT
+        - SPEI
+        - UPI
+        - WIRE
+      description: The payment rail used for the transfer. Payment rails represent the underlying payment network or system used to move funds between accounts.
+      example: ACH
     ExchangeRateFees:
       type: object
       description: Fees associated with an exchange rate
@@ -4693,9 +4712,7 @@ components:
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:
-          type: string
-          description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
-          example: UPI
+          $ref: '#/components/schemas/PaymentRail'
         receivingAmount:
           type: integer
           format: int64
@@ -11889,9 +11906,9 @@ components:
               description: Destination account identifier
               example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
             paymentRail:
-              type: string
-              description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
-              example: ACH
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
+                - description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           description: Destination account details
     UmaAddressDestination:
       title: UMA Address

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4712,7 +4712,10 @@ components:
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:
-          $ref: '#/components/schemas/PaymentRail'
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
+            - description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+              example: UPI
         receivingAmount:
           type: integer
           format: int64

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4645,6 +4645,25 @@ components:
           description: Number of decimal places for the currency
           minimum: 0
           example: 2
+    PaymentRail:
+      type: string
+      enum:
+        - ACH
+        - BANK_TRANSFER
+        - FAST
+        - FASTER_PAYMENTS
+        - FEDNOW
+        - MOBILE_MONEY
+        - PAYNOW
+        - PIX
+        - RTP
+        - SEPA
+        - SEPA_INSTANT
+        - SPEI
+        - UPI
+        - WIRE
+      description: The payment rail used for the transfer. Payment rails represent the underlying payment network or system used to move funds between accounts.
+      example: ACH
     ExchangeRateFees:
       type: object
       description: Fees associated with an exchange rate
@@ -4693,9 +4712,7 @@ components:
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:
-          type: string
-          description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
-          example: UPI
+          $ref: '#/components/schemas/PaymentRail'
         receivingAmount:
           type: integer
           format: int64
@@ -11889,9 +11906,9 @@ components:
               description: Destination account identifier
               example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
             paymentRail:
-              type: string
-              description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
-              example: ACH
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
+                - description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           description: Destination account details
     UmaAddressDestination:
       title: UMA Address

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4712,7 +4712,10 @@ components:
         destinationCurrency:
           $ref: '#/components/schemas/Currency'
         destinationPaymentRail:
-          $ref: '#/components/schemas/PaymentRail'
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
+            - description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+              example: UPI
         receivingAmount:
           type: integer
           format: int64

--- a/openapi/components/schemas/common/PaymentRail.yaml
+++ b/openapi/components/schemas/common/PaymentRail.yaml
@@ -1,0 +1,20 @@
+type: string
+enum:
+  - ACH
+  - BANK_TRANSFER
+  - FAST
+  - FASTER_PAYMENTS
+  - FEDNOW
+  - MOBILE_MONEY
+  - PAYNOW
+  - PIX
+  - RTP
+  - SEPA
+  - SEPA_INSTANT
+  - SPEI
+  - UPI
+  - WIRE
+description: >-
+  The payment rail used for the transfer. Payment rails represent the underlying
+  payment network or system used to move funds between accounts.
+example: ACH

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -35,7 +35,10 @@ properties:
   destinationCurrency:
     $ref: ../common/Currency.yaml
   destinationPaymentRail:
-    $ref: ../common/PaymentRail.yaml
+    allOf:
+      - $ref: ../common/PaymentRail.yaml
+      - description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
+        example: UPI
   receivingAmount:
     type: integer
     format: int64

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -35,9 +35,7 @@ properties:
   destinationCurrency:
     $ref: ../common/Currency.yaml
   destinationPaymentRail:
-    type: string
-    description: The payment rail used for the destination (e.g., UPI, SEPA_INSTANT, MOBILE_MONEY, FASTER_PAYMENTS)
-    example: UPI
+    $ref: ../common/PaymentRail.yaml
   receivingAmount:
     type: integer
     format: int64

--- a/openapi/components/schemas/quotes/AccountDestination.yaml
+++ b/openapi/components/schemas/quotes/AccountDestination.yaml
@@ -15,10 +15,10 @@ allOf:
         description: Destination account identifier
         example: ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
       paymentRail:
-        type: string
-        description: >-
-          The payment rail to use for the transfer. Must be one of the rails
-          supported by the destination account. If not specified, the system
-          will select a default rail.
-        example: ACH
+        allOf:
+          - $ref: ../common/PaymentRail.yaml
+          - description: >-
+              The payment rail to use for the transfer. Must be one of the rails
+              supported by the destination account. If not specified, the system
+              will select a default rail.
     description: Destination account details


### PR DESCRIPTION
## Summary
- Introduces a new `PaymentRail` enum in `openapi/components/schemas/common/PaymentRail.yaml` containing all 14 payment rails used across external accounts: ACH, BANK_TRANSFER, FAST, FASTER_PAYMENTS, FEDNOW, MOBILE_MONEY, PAYNOW, PIX, RTP, SEPA, SEPA_INSTANT, SPEI, UPI, WIRE
- Wires the enum into `AccountDestination.paymentRail` (quotes) and `ExchangeRate.destinationPaymentRail` (exchange rates) which previously used untyped strings
- Individual per-currency `AccountInfo` schemas retain their currency-specific subset enums for stricter validation

## Test plan
- [x] `make build` succeeds — OpenAPI spec bundles correctly
- [x] `npx @redocly/cli lint openapi.yaml` passes validation (16 pre-existing warnings, 0 errors)
- [ ] Verify generated SDK clients pick up the new enum type
- [ ] Verify Mintlify docs render the enum values on API reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)