### PR TITLE
add Embedded Wallet Auth endpoint for Email OTP challenge

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -327,6 +327,7 @@ resources:
         methods:
           create: post /auth/credentials
           verify: post /auth/credentials/{id}/verify
+          challenge: post /auth/credentials/{id}/challenge
         models:
           auth_method_type: '#/components/schemas/AuthMethodType'
           auth_method: '#/components/schemas/AuthMethod'

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3878,6 +3878,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /auth/credentials/{id}/challenge:
+    post:
+      summary: Resend an authentication credential challenge
+      description: |
+        Re-issue the challenge for an existing authentication credential.
+
+        For `EMAIL_OTP` credentials, this triggers a new one-time password email to the address on file. After the user receives the new OTP, call `POST /auth/credentials/{id}/verify` to complete verification and issue a session.
+      operationId: challengeAuthCredential
+      tags:
+        - Embedded Wallet Auth
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The id of the authentication credential to re-challenge (the `id` field of the `AuthMethod` returned from `POST /auth/credentials`).
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Challenge re-issued for the authentication credential
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthMethod'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Authentication credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '429':
+          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the OTP rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
+          headers:
+            Retry-After:
+              description: Number of seconds to wait before retrying the request.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 webhooks:
   incoming-payment:
     post:
@@ -13327,6 +13388,33 @@ components:
               format: date-time
               description: Timestamp after which the session signing key is no longer valid.
               example: '2026-04-08T15:35:00Z'
+    Error429:
+      type: object
+      required:
+        - message
+        - status
+        - code
+      properties:
+        status:
+          type: integer
+          enum:
+            - 429
+          description: HTTP status code
+        code:
+          type: string
+          description: |
+            | Error Code | Description |
+            |------------|-------------|
+            | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+          enum:
+            - RATE_LIMITED
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+          additionalProperties: true
     WebhookType:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3878,6 +3878,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /auth/credentials/{id}/challenge:
+    post:
+      summary: Resend an authentication credential challenge
+      description: |
+        Re-issue the challenge for an existing authentication credential.
+
+        For `EMAIL_OTP` credentials, this triggers a new one-time password email to the address on file. After the user receives the new OTP, call `POST /auth/credentials/{id}/verify` to complete verification and issue a session.
+      operationId: challengeAuthCredential
+      tags:
+        - Embedded Wallet Auth
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The id of the authentication credential to re-challenge (the `id` field of the `AuthMethod` returned from `POST /auth/credentials`).
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Challenge re-issued for the authentication credential
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthMethod'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Authentication credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '429':
+          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the OTP rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
+          headers:
+            Retry-After:
+              description: Number of seconds to wait before retrying the request.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 webhooks:
   incoming-payment:
     post:
@@ -13327,6 +13388,33 @@ components:
               format: date-time
               description: Timestamp after which the session signing key is no longer valid.
               example: '2026-04-08T15:35:00Z'
+    Error429:
+      type: object
+      required:
+        - message
+        - status
+        - code
+      properties:
+        status:
+          type: integer
+          enum:
+            - 429
+          description: HTTP status code
+        code:
+          type: string
+          description: |
+            | Error Code | Description |
+            |------------|-------------|
+            | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+          enum:
+            - RATE_LIMITED
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+          additionalProperties: true
     WebhookType:
       type: string
       enum:

--- a/openapi/components/schemas/errors/Error429.yaml
+++ b/openapi/components/schemas/errors/Error429.yaml
@@ -1,0 +1,26 @@
+type: object
+required:
+  - message
+  - status
+  - code
+properties:
+  status:
+    type: integer
+    enum:
+      - 429
+    description: HTTP status code
+  code:
+    type: string
+    description: |
+      | Error Code | Description |
+      |------------|-------------|
+      | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+    enum:
+      - RATE_LIMITED
+  message:
+    type: string
+    description: Error message
+  details:
+    type: object
+    description: Additional error details
+    additionalProperties: true

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -180,6 +180,8 @@ paths:
     $ref: paths/auth/auth_credentials.yaml
   /auth/credentials/{id}/verify:
     $ref: paths/auth/auth_credentials_{id}_verify.yaml
+  /auth/credentials/{id}/challenge:
+    $ref: paths/auth/auth_credentials_{id}_challenge.yaml
 webhooks:
   incoming-payment:
     $ref: webhooks/incoming-payment.yaml

--- a/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
+++ b/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
@@ -1,0 +1,70 @@
+post:
+  summary: Resend an authentication credential challenge
+  description: >
+    Re-issue the challenge for an existing authentication credential.
+
+
+    For `EMAIL_OTP` credentials, this triggers a new one-time password email to
+    the address on file. After the user receives the new OTP, call
+    `POST /auth/credentials/{id}/verify` to complete verification and issue a
+    session.
+  operationId: challengeAuthCredential
+  tags:
+    - Embedded Wallet Auth
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: id
+      in: path
+      description: >-
+        The id of the authentication credential to re-challenge (the `id` field
+        of the `AuthMethod` returned from `POST /auth/credentials`).
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Challenge re-issued for the authentication credential
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/auth/AuthMethod.yaml
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Authentication credential not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '429':
+      description: >-
+        Too many requests. Returned with `RATE_LIMITED` when challenge
+        re-issues are requested more frequently than the OTP rate limit
+        allows. Clients should back off and retry after the interval
+        indicated by the `Retry-After` response header.
+      headers:
+        Retry-After:
+          description: Number of seconds to wait before retrying the request.
+          schema:
+            type: integer
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error429.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
## Endpoint

- `POST /auth/credentials/{id}/challenge` — re-issue the challenge for an existing credential without rebuilding it. For `EMAIL_OTP`, triggers a new OTP email so the user can call `/verify` again after a missed or expired code.

## Request / response

```
POST /auth/credentials/{id}/challenge
(no body)

→ 200 AuthMethod   // { id, accountId, type, nickname, createdAt, updatedAt }
```

## Resources

No new schemas. Reuses `AuthMethod` from the parent PR (#349). Stainless config adds `challenge` to the `auth.credentials` resource methods.
