### PR TITLE
Add bankAccountType to USD, bankName/documentType/documentNumber to COP, and COMPANY_LEGAL_NAME field name

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4304,6 +4304,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -944,7 +944,7 @@ paths:
                     accountType: USD_ACCOUNT
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
-                    accountCategory: CHECKING
+                    bankAccountType: CHECKING
                     bankName: Chase Bank
                     platformAccountId: ext_acc_123456
                     beneficiary:
@@ -1064,7 +1064,7 @@ paths:
                     accountType: USD_ACCOUNT
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
-                    accountCategory: CHECKING
+                    bankAccountType: CHECKING
                     bankName: Chase Bank
                     platformAccountId: ext_acc_123456
                     beneficiary:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5564,6 +5564,12 @@ components:
           minLength: 9
           maxLength: 9
           pattern: ^[0-9]{9}$
+        bankAccountType:
+          type: string
+          description: The bank account type. Required for certain corridors (e.g., El Salvador).
+          enum:
+            - CHECKING
+            - SAVINGS
     UsdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
@@ -9328,6 +9334,7 @@ components:
         - accountType
         - accountNumber
         - bankAccountType
+        - bankName
         - phoneNumber
       properties:
         accountType:
@@ -9345,6 +9352,9 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
         phoneNumber:
           type: string
           description: The phone number in international format
@@ -9396,6 +9406,12 @@ components:
         countryOfResidence:
           type: string
           description: The country of residence of the beneficiary
+        documentType:
+          type: string
+          description: The type of identity document (e.g., national ID, passport)
+        documentNumber:
+          type: string
+          description: The identity document number
         address:
           $ref: '#/components/schemas/Address'
     CopExternalAccountInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4304,6 +4304,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -944,7 +944,7 @@ paths:
                     accountType: USD_ACCOUNT
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
-                    accountCategory: CHECKING
+                    bankAccountType: CHECKING
                     bankName: Chase Bank
                     platformAccountId: ext_acc_123456
                     beneficiary:
@@ -1064,7 +1064,7 @@ paths:
                     accountType: USD_ACCOUNT
                     accountNumber: '12345678901'
                     routingNumber: '123456789'
-                    accountCategory: CHECKING
+                    bankAccountType: CHECKING
                     bankName: Chase Bank
                     platformAccountId: ext_acc_123456
                     beneficiary:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5564,6 +5564,12 @@ components:
           minLength: 9
           maxLength: 9
           pattern: ^[0-9]{9}$
+        bankAccountType:
+          type: string
+          description: The bank account type. Required for certain corridors (e.g., El Salvador).
+          enum:
+            - CHECKING
+            - SAVINGS
     UsdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
@@ -9328,6 +9334,7 @@ components:
         - accountType
         - accountNumber
         - bankAccountType
+        - bankName
         - phoneNumber
       properties:
         accountType:
@@ -9345,6 +9352,9 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
         phoneNumber:
           type: string
           description: The phone number in international format
@@ -9396,6 +9406,12 @@ components:
         countryOfResidence:
           type: string
           description: The country of residence of the beneficiary
+        documentType:
+          type: string
+          description: The type of identity document (e.g., national ID, passport)
+        documentNumber:
+          type: string
+          description: The identity document number
         address:
           $ref: '#/components/schemas/Address'
     CopExternalAccountInfo:

--- a/openapi/components/schemas/common/CopAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/CopAccountInfoBase.yaml
@@ -3,6 +3,7 @@ required:
 - accountType
 - accountNumber
 - bankAccountType
+- bankName
 - phoneNumber
 properties:
   accountType:
@@ -20,6 +21,9 @@ properties:
     enum:
     - CHECKING
     - SAVINGS
+  bankName:
+    type: string
+    description: The name of the bank
   phoneNumber:
     type: string
     description: The phone number in international format

--- a/openapi/components/schemas/common/CopBeneficiary.yaml
+++ b/openapi/components/schemas/common/CopBeneficiary.yaml
@@ -27,5 +27,11 @@ properties:
   countryOfResidence:
     type: string
     description: The country of residence of the beneficiary
+  documentType:
+    type: string
+    description: The type of identity document (e.g., national ID, passport)
+  documentNumber:
+    type: string
+    description: The identity document number
   address:
     $ref: ./Address.yaml

--- a/openapi/components/schemas/common/UsdAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/UsdAccountInfoBase.yaml
@@ -20,3 +20,9 @@ properties:
     minLength: 9
     maxLength: 9
     pattern: ^[0-9]{9}$
+  bankAccountType:
+    type: string
+    description: The bank account type. Required for certain corridors (e.g., El Salvador).
+    enum:
+    - CHECKING
+    - SAVINGS

--- a/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
+++ b/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
@@ -17,6 +17,7 @@ enum:
   - ULTIMATE_INSTITUTION_COUNTRY
   - IDENTIFIER
   - BUSINESS_TYPE
+  - COMPANY_LEGAL_NAME
 description: >-
   Name of a type of field containing info about a platform's customer or
   counterparty customer.

--- a/openapi/paths/customers/customers_external_accounts.yaml
+++ b/openapi/paths/customers/customers_external_accounts.yaml
@@ -90,7 +90,7 @@ post:
                 accountType: USD_ACCOUNT
                 accountNumber: "12345678901"
                 routingNumber: "123456789"
-                accountCategory: CHECKING
+                bankAccountType: CHECKING
                 bankName: Chase Bank
                 platformAccountId: ext_acc_123456
                 beneficiary:

--- a/openapi/paths/platform/platform_external_accounts.yaml
+++ b/openapi/paths/platform/platform_external_accounts.yaml
@@ -66,7 +66,7 @@ post:
                 accountType: USD_ACCOUNT
                 accountNumber: "12345678901"
                 routingNumber: "123456789"
-                accountCategory: CHECKING
+                bankAccountType: CHECKING
                 bankName: Chase Bank
                 platformAccountId: ext_acc_123456
                 beneficiary:


### PR DESCRIPTION
### TL;DR

Expanded the OpenAPI schema with new fields for COP accounts, USD account info, and customer field definitions.

### What changed?

- Added `bankName` as a required field to `CopAccountInfoBase`, capturing the name of the bank for COP accounts.
- Added `documentType` and `documentNumber` fields to `CopBeneficiary`, allowing identity document information (e.g., national ID, passport) to be associated with a beneficiary.
- Added `bankAccountType` (`CHECKING` or `SAVINGS`) to `UsdAccountInfoBase`, required for certain corridors such as El Salvador.
- Added `COMPANY_LEGAL_NAME` as a valid enum value to `CustomerInfoFieldName`, enabling platforms to capture a company's legal name as a customer info field.

### How to test?

- Validate that COP account creation requests require `bankName` and that the field is correctly documented in the API reference.
- Confirm that `documentType` and `documentNumber` can be submitted as part of a COP beneficiary payload.
- Test USD account creation for El Salvador corridors to verify that `bankAccountType` is accepted and enforced where required.
- Verify that `COMPANY_LEGAL_NAME` is accepted as a valid `CustomerInfoFieldName` value in relevant customer info requests.

### Why make this change?

These additions support expanded corridor requirements and compliance needs. Certain payment corridors (e.g., El Salvador) require bank account type information for USD transfers, COP beneficiaries may need identity document details for regulatory purposes, and `COMPANY_LEGAL_NAME` is needed to capture legal entity information for business customers.