### PR TITLE
add Embedded Wallet OAUTH credential create

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -344,6 +344,8 @@ resources:
           email_otp_credential_verify_request_fields: '#/components/schemas/EmailOtpCredentialVerifyRequestFields'
           email_otp_credential_additional_challenge: '#/components/schemas/EmailOtpCredentialAdditionalChallenge'
           email_otp_credential_additional_challenge_fields: '#/components/schemas/EmailOtpCredentialAdditionalChallengeFields'
+          oauth_credential_create_request: '#/components/schemas/OauthCredentialCreateRequest'
+          oauth_credential_create_request_fields: '#/components/schemas/OauthCredentialCreateRequestFields'
   exchange_rates:
     methods:
       list:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3617,7 +3617,7 @@ paths:
 
         **First credential on an internal account**
 
-        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests.
+        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`.
 
         **Adding an additional credential**
 
@@ -3654,6 +3654,12 @@ paths:
                 value:
                   type: EMAIL_OTP
                   accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+              oauth:
+                summary: Register an OAuth credential
+                value:
+                  type: OAUTH
+                  accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
       responses:
         '201':
           description: Authentication credential created successfully
@@ -13100,13 +13106,35 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialCreateRequest'
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequestFields'
+    OauthCredentialCreateRequestFields:
+      type: object
+      required:
+        - type
+        - oidcToken
+      properties:
+        type:
+          type: string
+          enum:
+            - OAUTH
+          description: Discriminator value identifying this as an OAuth credential.
+        oidcToken:
+          type: string
+          description: OIDC ID token issued by the identity provider (e.g. Google, Apple). Grid fetches the issuer's signing key from the `iss` claim's `.well-known` OpenID configuration and verifies the token signature. The token's `iat` claim must be less than 60 seconds before the request timestamp.
+          example: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
+    OauthCredentialCreateRequest:
+      title: OAuth Credential Create Request
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialCreateRequest'
+        - $ref: '#/components/schemas/OauthCredentialCreateRequestFields'
     AuthCredentialCreateRequestOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequest'
+        - $ref: '#/components/schemas/OauthCredentialCreateRequest'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialCreateRequest'
+          OAUTH: '#/components/schemas/OauthCredentialCreateRequest'
     AuthMethod:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3617,7 +3617,7 @@ paths:
 
         **First credential on an internal account**
 
-        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests.
+        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`.
 
         **Adding an additional credential**
 
@@ -3654,6 +3654,12 @@ paths:
                 value:
                   type: EMAIL_OTP
                   accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+              oauth:
+                summary: Register an OAuth credential
+                value:
+                  type: OAUTH
+                  accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
       responses:
         '201':
           description: Authentication credential created successfully
@@ -13100,13 +13106,35 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialCreateRequest'
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequestFields'
+    OauthCredentialCreateRequestFields:
+      type: object
+      required:
+        - type
+        - oidcToken
+      properties:
+        type:
+          type: string
+          enum:
+            - OAUTH
+          description: Discriminator value identifying this as an OAuth credential.
+        oidcToken:
+          type: string
+          description: OIDC ID token issued by the identity provider (e.g. Google, Apple). Grid fetches the issuer's signing key from the `iss` claim's `.well-known` OpenID configuration and verifies the token signature. The token's `iat` claim must be less than 60 seconds before the request timestamp.
+          example: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
+    OauthCredentialCreateRequest:
+      title: OAuth Credential Create Request
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialCreateRequest'
+        - $ref: '#/components/schemas/OauthCredentialCreateRequestFields'
     AuthCredentialCreateRequestOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequest'
+        - $ref: '#/components/schemas/OauthCredentialCreateRequest'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialCreateRequest'
+          OAUTH: '#/components/schemas/OauthCredentialCreateRequest'
     AuthMethod:
       type: object
       required:

--- a/openapi/components/schemas/auth/AuthCredentialCreateRequestOneOf.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialCreateRequestOneOf.yaml
@@ -1,6 +1,8 @@
 oneOf:
   - $ref: ./EmailOtpCredentialCreateRequest.yaml
+  - $ref: ./OauthCredentialCreateRequest.yaml
 discriminator:
   propertyName: type
   mapping:
     EMAIL_OTP: ./EmailOtpCredentialCreateRequest.yaml
+    OAUTH: ./OauthCredentialCreateRequest.yaml

--- a/openapi/components/schemas/auth/OauthCredentialCreateRequest.yaml
+++ b/openapi/components/schemas/auth/OauthCredentialCreateRequest.yaml
@@ -1,0 +1,4 @@
+title: OAuth Credential Create Request
+allOf:
+  - $ref: ./AuthCredentialCreateRequest.yaml
+  - $ref: ./OauthCredentialCreateRequestFields.yaml

--- a/openapi/components/schemas/auth/OauthCredentialCreateRequestFields.yaml
+++ b/openapi/components/schemas/auth/OauthCredentialCreateRequestFields.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - type
+  - oidcToken
+properties:
+  type:
+    type: string
+    enum:
+      - OAUTH
+    description: Discriminator value identifying this as an OAuth credential.
+  oidcToken:
+    type: string
+    description: >-
+      OIDC ID token issued by the identity provider (e.g. Google, Apple).
+      Grid fetches the issuer's signing key from the `iss` claim's
+      `.well-known` OpenID configuration and verifies the token signature.
+      The token's `iat` claim must be less than 60 seconds before the
+      request timestamp.
+    example: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature

--- a/openapi/paths/auth/auth_credentials.yaml
+++ b/openapi/paths/auth/auth_credentials.yaml
@@ -13,7 +13,11 @@ post:
     credentials, this call also triggers a one-time password email to the
     address on the customer record tied to the internal account; the
     credential must be activated via `POST /auth/credentials/{id}/verify`
-    before it can sign requests.
+    before it can sign requests. For `OAUTH` credentials, the supplied
+    `oidcToken` is validated inline against the issuer's `.well-known`
+    OpenID configuration (the token's `iat` must be less than 60 seconds
+    before the request); activation still happens via
+    `POST /auth/credentials/{id}/verify`.
 
 
     **Adding an additional credential**
@@ -74,6 +78,12 @@ post:
             value:
               type: EMAIL_OTP
               accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+          oauth:
+            summary: Register an OAuth credential
+            value:
+              type: OAUTH
+              accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+              oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
   responses:
     '201':
       description: Authentication credential created successfully


### PR DESCRIPTION
Adds the OAUTH branch to `AuthCredentialCreateRequestOneOf`, letting platforms register an OIDC-backed authentication credential on an Embedded Wallet internal account.

**Request shape**

- `POST /auth/credentials` body: `{ type: "OAUTH", accountId, oidcToken }` → 201 `AuthMethod`.

**Schemas added**

- `OauthCredentialCreateRequestFields` — `{ type: "OAUTH", oidcToken }` (variant single-value enum on `type`).
- `OauthCredentialCreateRequest` — `allOf(AuthCredentialCreateRequest, OauthCredentialCreateRequestFields)`; wire body is `{ type, accountId, oidcToken }` (accountId inherited from the base).
- `AuthCredentialCreateRequestOneOf.yaml` discriminator map extended with `OAUTH → OauthCredentialCreateRequest`.

**Notes**

- Multiple OAuth credentials are allowed per internal account (no analogue to `EMAIL_OTP_CREDENTIAL_ALREADY_EXISTS`).
- This PR only wires the create flow; `POST /auth/credentials/{id}/verify` gets its own OAUTH branch in the next PR in the stack.
- Bundled `openapi.yaml` and `mintlify/openapi.yaml` regenerated via `make build`.