### PR TITLE
add Embedded Wallet OAUTH credential to additional credential flow

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -348,6 +348,8 @@ resources:
           oauth_credential_create_request_fields: '#/components/schemas/OauthCredentialCreateRequestFields'
           oauth_credential_verify_request: '#/components/schemas/OauthCredentialVerifyRequest'
           oauth_credential_verify_request_fields: '#/components/schemas/OauthCredentialVerifyRequestFields'
+          oauth_credential_additional_challenge: '#/components/schemas/OauthCredentialAdditionalChallenge'
+          oauth_credential_additional_challenge_fields: '#/components/schemas/OauthCredentialAdditionalChallengeFields'
   exchange_rates:
     methods:
       list:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3682,6 +3682,13 @@ paths:
                     payloadToSign: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
                     requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
                     expiresAt: '2026-04-08T15:35:00Z'
+                oauth:
+                  summary: Additional OAuth credential challenge
+                  value:
+                    type: OAUTH
+                    payloadToSign: Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==
+                    requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                    expiresAt: '2026-04-08T15:35:00Z'
         '400':
           description: Bad request. Returned with `EMAIL_OTP_CREDENTIAL_ALREADY_EXISTS` when registering an `EMAIL_OTP` credential on an internal account that already has one — only one email OTP credential is supported per internal account at this time.
           content:
@@ -13221,13 +13228,30 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialAdditionalChallenge'
         - $ref: '#/components/schemas/EmailOtpCredentialAdditionalChallengeFields'
+    OauthCredentialAdditionalChallengeFields:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - OAUTH
+          description: Discriminator value identifying this as an additional-credential challenge for an OAuth credential.
+    OauthCredentialAdditionalChallenge:
+      title: OAuth Credential Additional Challenge
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialAdditionalChallenge'
+        - $ref: '#/components/schemas/OauthCredentialAdditionalChallengeFields'
     AuthCredentialAdditionalChallengeOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialAdditionalChallenge'
+        - $ref: '#/components/schemas/OauthCredentialAdditionalChallenge'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialAdditionalChallenge'
+          OAUTH: '#/components/schemas/OauthCredentialAdditionalChallenge'
     AuthCredentialVerifyRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3682,6 +3682,13 @@ paths:
                     payloadToSign: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
                     requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
                     expiresAt: '2026-04-08T15:35:00Z'
+                oauth:
+                  summary: Additional OAuth credential challenge
+                  value:
+                    type: OAUTH
+                    payloadToSign: Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==
+                    requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                    expiresAt: '2026-04-08T15:35:00Z'
         '400':
           description: Bad request. Returned with `EMAIL_OTP_CREDENTIAL_ALREADY_EXISTS` when registering an `EMAIL_OTP` credential on an internal account that already has one — only one email OTP credential is supported per internal account at this time.
           content:
@@ -13221,13 +13228,30 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialAdditionalChallenge'
         - $ref: '#/components/schemas/EmailOtpCredentialAdditionalChallengeFields'
+    OauthCredentialAdditionalChallengeFields:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - OAUTH
+          description: Discriminator value identifying this as an additional-credential challenge for an OAuth credential.
+    OauthCredentialAdditionalChallenge:
+      title: OAuth Credential Additional Challenge
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialAdditionalChallenge'
+        - $ref: '#/components/schemas/OauthCredentialAdditionalChallengeFields'
     AuthCredentialAdditionalChallengeOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialAdditionalChallenge'
+        - $ref: '#/components/schemas/OauthCredentialAdditionalChallenge'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialAdditionalChallenge'
+          OAUTH: '#/components/schemas/OauthCredentialAdditionalChallenge'
     AuthCredentialVerifyRequest:
       type: object
       required:

--- a/openapi/components/schemas/auth/AuthCredentialAdditionalChallengeOneOf.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialAdditionalChallengeOneOf.yaml
@@ -1,6 +1,8 @@
 oneOf:
   - $ref: ./EmailOtpCredentialAdditionalChallenge.yaml
+  - $ref: ./OauthCredentialAdditionalChallenge.yaml
 discriminator:
   propertyName: type
   mapping:
     EMAIL_OTP: ./EmailOtpCredentialAdditionalChallenge.yaml
+    OAUTH: ./OauthCredentialAdditionalChallenge.yaml

--- a/openapi/components/schemas/auth/OauthCredentialAdditionalChallenge.yaml
+++ b/openapi/components/schemas/auth/OauthCredentialAdditionalChallenge.yaml
@@ -1,0 +1,4 @@
+title: OAuth Credential Additional Challenge
+allOf:
+  - $ref: ./AuthCredentialAdditionalChallenge.yaml
+  - $ref: ./OauthCredentialAdditionalChallengeFields.yaml

--- a/openapi/components/schemas/auth/OauthCredentialAdditionalChallengeFields.yaml
+++ b/openapi/components/schemas/auth/OauthCredentialAdditionalChallengeFields.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - type
+properties:
+  type:
+    type: string
+    enum:
+      - OAUTH
+    description: >-
+      Discriminator value identifying this as an additional-credential
+      challenge for an OAuth credential.

--- a/openapi/paths/auth/auth_credentials.yaml
+++ b/openapi/paths/auth/auth_credentials.yaml
@@ -114,6 +114,13 @@ post:
                 payloadToSign: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
                 requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
                 expiresAt: '2026-04-08T15:35:00Z'
+            oauth:
+              summary: Additional OAuth credential challenge
+              value:
+                type: OAUTH
+                payloadToSign: Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==
+                requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                expiresAt: '2026-04-08T15:35:00Z'
     '400':
       description: >-
         Bad request. Returned with `EMAIL_OTP_CREDENTIAL_ALREADY_EXISTS` when


### PR DESCRIPTION
Adds the OAUTH branch to `AuthCredentialAdditionalChallengeOneOf`, letting platforms register a second (or third, etc.) OAuth credential on an internal account that already has one. Completes the "add another credential" challenge/retry pattern for OAuth, matching the EMAIL_OTP flow already in the stack.

**Flow**

1. `POST /auth/credentials` with `{ type: "OAUTH", accountId, oidcToken }` on an account that already has a credential.
2. Response is 202 with `{ type: "OAUTH", payloadToSign, requestId, expiresAt }`.
3. Client signs `payloadToSign` with the session private key of an existing verified credential on the same internal account and retries the request with `Grid-Wallet-Signature` + `Request-Id` headers.
4. Signed retry returns 201 with the created `AuthMethod`.

**Schemas added**

- `OauthCredentialAdditionalChallengeFields` — `{ type: "OAUTH" }` (variant single-value enum on `type`; no analogue to the `email` field on the EMAIL_OTP variant — providers are not distinguished at the challenge level).
- `OauthCredentialAdditionalChallenge` — `allOf(AuthCredentialAdditionalChallenge, OauthCredentialAdditionalChallengeFields)`; wire shape is `{ type, payloadToSign, requestId, expiresAt }` (signing fields inherited from the base).
- `AuthCredentialAdditionalChallengeOneOf.yaml` discriminator map extended with `OAUTH → OauthCredentialAdditionalChallenge`.