### PR TITLE
add Embedded Wallet PASSKEY auth credential create

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -350,6 +350,12 @@ resources:
           oauth_credential_verify_request_fields: '#/components/schemas/OauthCredentialVerifyRequestFields'
           oauth_credential_additional_challenge: '#/components/schemas/OauthCredentialAdditionalChallenge'
           oauth_credential_additional_challenge_fields: '#/components/schemas/OauthCredentialAdditionalChallengeFields'
+          passkey_attestation: '#/components/schemas/PasskeyAttestation'
+          passkey_credential_create_request: '#/components/schemas/PasskeyCredentialCreateRequest'
+          passkey_credential_create_request_fields: '#/components/schemas/PasskeyCredentialCreateRequestFields'
+          passkey_auth_challenge: '#/components/schemas/PasskeyAuthChallenge'
+          auth_method_response: '#/components/schemas/AuthMethodResponse'
+          auth_credential_response_one_of: '#/components/schemas/AuthCredentialResponseOneOf'
   exchange_rates:
     methods:
       list:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3623,7 +3623,7 @@ paths:
 
         **First credential on an internal account**
 
-        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`.
+        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`. For `PASSKEY` credentials, the client completes a WebAuthn registration (`navigator.credentials.create()`) using a `challenge` issued by the platform backend and submits the resulting `attestation` here; the credential must still be activated via `POST /auth/credentials/{id}/verify` by completing a WebAuthn assertion. Unlike the registration `challenge` (platform-issued), the challenge for the first authentication is issued by Grid and returned inline on the `201` response alongside the `AuthMethod` fields, plus a `requestId` and challenge `expiresAt` (see `PasskeyAuthChallenge`). The client uses that Grid-issued `challenge` to produce the assertion and submits it with `Request-Id: <requestId>` to `POST /auth/credentials/{id}/verify`. On every subsequent reauthentication the challenge is re-issued via `POST /auth/credentials/{id}/challenge`. Only one `PASSKEY` credential is supported per internal account in v1.
 
         **Adding an additional credential**
 
@@ -3666,13 +3666,58 @@ paths:
                   type: OAUTH
                   accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                   oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
+              passkey:
+                summary: Register a passkey credential
+                value:
+                  type: PASSKEY
+                  accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  nickname: iPhone Face-ID
+                  challenge: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+                  attestation:
+                    credentialId: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+                    clientDataJson: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+                    attestationObject: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+                    transports:
+                      - internal
+                      - hybrid
       responses:
         '201':
-          description: Authentication credential created successfully
+          description: Authentication credential created successfully. For `EMAIL_OTP` and `OAUTH`, the body is a plain `AuthMethod`. For `PASSKEY`, the body is a `PasskeyAuthChallenge` — an `AuthMethod` with the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the first authentication assertion.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthMethod'
+                $ref: '#/components/schemas/AuthCredentialResponseOneOf'
+              examples:
+                emailOtp:
+                  summary: Email OTP credential created
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: EMAIL_OTP
+                    nickname: example@lightspark.com
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                oauth:
+                  summary: OAuth credential created
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: OAUTH
+                    nickname: example@lightspark.com
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                passkey:
+                  summary: Passkey credential created with first-authentication challenge
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: PASSKEY
+                    nickname: iPhone Face-ID
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                    challenge: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+                    requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                    expiresAt: '2026-04-08T15:35:00Z'
         '202':
           description: An existing authentication credential is already registered on the internal account. The response contains a `payloadToSign` that must be signed with the session private key of an existing verified credential on the same internal account, along with a `requestId` that must be echoed back on the retry. The signature is passed as the `Grid-Wallet-Signature` header and the `requestId` as the `Request-Id` header on a retry of this request to complete registration.
           content:
@@ -13147,15 +13192,79 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialCreateRequest'
         - $ref: '#/components/schemas/OauthCredentialCreateRequestFields'
+    PasskeyAttestation:
+      title: Passkey Attestation
+      type: object
+      required:
+        - credentialId
+        - clientDataJson
+        - attestationObject
+      properties:
+        credentialId:
+          type: string
+          description: Base64url-encoded credential identifier produced by the authenticator at registration time. Typically the base64url of `PublicKeyCredential.rawId`.
+          example: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+        clientDataJson:
+          type: string
+          description: 'Base64url-encoded JSON client data collected by the browser during the WebAuthn `navigator.credentials.create()` call. Corresponds to `AuthenticatorAttestationResponse.clientDataJSON` from the WebAuthn spec — Grid''s field name is intentionally camelCased as `clientDataJson` (lowercase JSON) for consistency with the rest of the API; the value is the same bytes the browser returns. Contains the challenge, origin, and `type: "webauthn.create"`.'
+          example: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+        attestationObject:
+          type: string
+          description: Base64url-encoded CBOR attestation object produced by the authenticator during registration. Corresponds to `AuthenticatorAttestationResponse.attestationObject`.
+          example: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+        transports:
+          type: array
+          items:
+            type: string
+            enum:
+              - usb
+              - nfc
+              - ble
+              - internal
+              - hybrid
+          description: Optional. WebAuthn transports as returned by `AuthenticatorAttestationResponse.getTransports()`. Values follow the W3C `AuthenticatorTransport` enum — pass the raw values through to Grid; provider-specific translation is handled server-side. Some authenticators return an empty array; omit the field or send `[]` in that case.
+          example:
+            - internal
+            - hybrid
+    PasskeyCredentialCreateRequestFields:
+      type: object
+      required:
+        - type
+        - nickname
+        - challenge
+        - attestation
+      properties:
+        type:
+          type: string
+          enum:
+            - PASSKEY
+          description: Discriminator value identifying this as a passkey credential.
+        nickname:
+          type: string
+          description: Human-readable identifier for the passkey, chosen by the user at registration time (e.g. "iPhone Face-ID", "YubiKey 5C"). Shown back on `AuthMethod` responses and in credential listings.
+          example: iPhone Face-ID
+        challenge:
+          type: string
+          description: Base64url-encoded WebAuthn challenge issued by the platform backend and passed to the client before `navigator.credentials.create()`. Grid verifies it matches the challenge embedded in the attestation's `clientDataJson`, binding the attestation to this registration. Must be single-use.
+          example: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+        attestation:
+          $ref: '#/components/schemas/PasskeyAttestation'
+    PasskeyCredentialCreateRequest:
+      title: Passkey Credential Create Request
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialCreateRequest'
+        - $ref: '#/components/schemas/PasskeyCredentialCreateRequestFields'
     AuthCredentialCreateRequestOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequest'
         - $ref: '#/components/schemas/OauthCredentialCreateRequest'
+        - $ref: '#/components/schemas/PasskeyCredentialCreateRequest'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialCreateRequest'
           OAUTH: '#/components/schemas/OauthCredentialCreateRequest'
+          PASSKEY: '#/components/schemas/PasskeyCredentialCreateRequest'
     AuthMethod:
       type: object
       required:
@@ -13190,6 +13299,48 @@ components:
           format: date-time
           description: Last update timestamp.
           example: '2026-04-08T15:35:00Z'
+    AuthMethodResponse:
+      title: Auth Method Response
+      description: 'Strict wrapper around `AuthMethod` used inside `AuthCredentialResponseOneOf` for the `EMAIL_OTP` and `OAUTH` branches. The only difference from `AuthMethod` is `unevaluatedProperties: false`, which disambiguates the oneOf against `PasskeyAuthChallenge` — without the strictness, an `AuthMethod` with extra fields would ambiguously match both branches.'
+      allOf:
+        - $ref: '#/components/schemas/AuthMethod'
+      unevaluatedProperties: false
+    PasskeyAuthChallenge:
+      title: Passkey Auth Challenge
+      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials` (first-authentication case) and `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a Grid-issued `challenge`, the corresponding `requestId`, and the challenge's `expiresAt` to the base `AuthMethod` fields. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
+      allOf:
+        - $ref: '#/components/schemas/AuthMethod'
+        - type: object
+          required:
+            - challenge
+            - requestId
+            - expiresAt
+          properties:
+            challenge:
+              type: string
+              description: Base64url-encoded challenge issued by Grid for the pending passkey authentication. The client passes it into `navigator.credentials.get()` as the WebAuthn challenge; the resulting assertion is submitted to `POST /auth/credentials/{id}/verify`. Single-use; a new challenge is issued on the next call to `POST /auth/credentials/{id}/challenge`.
+              example: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+            requestId:
+              type: string
+              description: Unique identifier for this pending passkey authentication request. Must be echoed as the `Request-Id` header on the subsequent `POST /auth/credentials/{id}/verify` call so Grid can correlate the assertion with the issued challenge.
+              example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+            expiresAt:
+              type: string
+              format: date-time
+              description: Timestamp after which the issued challenge is no longer valid. The assertion must reach `POST /auth/credentials/{id}/verify` before this time; otherwise the client must request a fresh challenge via `POST /auth/credentials/{id}/challenge`.
+              example: '2026-04-08T15:35:00Z'
+    AuthCredentialResponseOneOf:
+      title: Auth Credential Response
+      description: Discriminated response shape returned from `POST /auth/credentials` (on successful registration) and `POST /auth/credentials/{id}/challenge` (on challenge re-issue). For `EMAIL_OTP` and `OAUTH` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion.
+      oneOf:
+        - $ref: '#/components/schemas/AuthMethodResponse'
+        - $ref: '#/components/schemas/PasskeyAuthChallenge'
+      discriminator:
+        propertyName: type
+        mapping:
+          EMAIL_OTP: '#/components/schemas/AuthMethodResponse'
+          OAUTH: '#/components/schemas/AuthMethodResponse'
+          PASSKEY: '#/components/schemas/PasskeyAuthChallenge'
     AuthCredentialAdditionalChallenge:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3623,7 +3623,7 @@ paths:
 
         **First credential on an internal account**
 
-        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`.
+        If the target internal account does not yet have any authentication credential registered, call this endpoint with the credential details. The response is `201` with the created `AuthMethod`. For `EMAIL_OTP` credentials, this call also triggers a one-time password email to the address on the customer record tied to the internal account; the credential must be activated via `POST /auth/credentials/{id}/verify` before it can sign requests. For `OAUTH` credentials, the supplied `oidcToken` is validated inline against the issuer's `.well-known` OpenID configuration (the token's `iat` must be less than 60 seconds before the request); activation still happens via `POST /auth/credentials/{id}/verify`. For `PASSKEY` credentials, the client completes a WebAuthn registration (`navigator.credentials.create()`) using a `challenge` issued by the platform backend and submits the resulting `attestation` here; the credential must still be activated via `POST /auth/credentials/{id}/verify` by completing a WebAuthn assertion. Unlike the registration `challenge` (platform-issued), the challenge for the first authentication is issued by Grid and returned inline on the `201` response alongside the `AuthMethod` fields, plus a `requestId` and challenge `expiresAt` (see `PasskeyAuthChallenge`). The client uses that Grid-issued `challenge` to produce the assertion and submits it with `Request-Id: <requestId>` to `POST /auth/credentials/{id}/verify`. On every subsequent reauthentication the challenge is re-issued via `POST /auth/credentials/{id}/challenge`. Only one `PASSKEY` credential is supported per internal account in v1.
 
         **Adding an additional credential**
 
@@ -3666,13 +3666,58 @@ paths:
                   type: OAUTH
                   accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                   oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
+              passkey:
+                summary: Register a passkey credential
+                value:
+                  type: PASSKEY
+                  accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  nickname: iPhone Face-ID
+                  challenge: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+                  attestation:
+                    credentialId: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+                    clientDataJson: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+                    attestationObject: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+                    transports:
+                      - internal
+                      - hybrid
       responses:
         '201':
-          description: Authentication credential created successfully
+          description: Authentication credential created successfully. For `EMAIL_OTP` and `OAUTH`, the body is a plain `AuthMethod`. For `PASSKEY`, the body is a `PasskeyAuthChallenge` — an `AuthMethod` with the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the first authentication assertion.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthMethod'
+                $ref: '#/components/schemas/AuthCredentialResponseOneOf'
+              examples:
+                emailOtp:
+                  summary: Email OTP credential created
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: EMAIL_OTP
+                    nickname: example@lightspark.com
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                oauth:
+                  summary: OAuth credential created
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: OAUTH
+                    nickname: example@lightspark.com
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                passkey:
+                  summary: Passkey credential created with first-authentication challenge
+                  value:
+                    id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                    type: PASSKEY
+                    nickname: iPhone Face-ID
+                    createdAt: '2026-04-08T15:30:01Z'
+                    updatedAt: '2026-04-08T15:30:01Z'
+                    challenge: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+                    requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                    expiresAt: '2026-04-08T15:35:00Z'
         '202':
           description: An existing authentication credential is already registered on the internal account. The response contains a `payloadToSign` that must be signed with the session private key of an existing verified credential on the same internal account, along with a `requestId` that must be echoed back on the retry. The signature is passed as the `Grid-Wallet-Signature` header and the `requestId` as the `Request-Id` header on a retry of this request to complete registration.
           content:
@@ -13147,15 +13192,79 @@ components:
       allOf:
         - $ref: '#/components/schemas/AuthCredentialCreateRequest'
         - $ref: '#/components/schemas/OauthCredentialCreateRequestFields'
+    PasskeyAttestation:
+      title: Passkey Attestation
+      type: object
+      required:
+        - credentialId
+        - clientDataJson
+        - attestationObject
+      properties:
+        credentialId:
+          type: string
+          description: Base64url-encoded credential identifier produced by the authenticator at registration time. Typically the base64url of `PublicKeyCredential.rawId`.
+          example: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+        clientDataJson:
+          type: string
+          description: 'Base64url-encoded JSON client data collected by the browser during the WebAuthn `navigator.credentials.create()` call. Corresponds to `AuthenticatorAttestationResponse.clientDataJSON` from the WebAuthn spec — Grid''s field name is intentionally camelCased as `clientDataJson` (lowercase JSON) for consistency with the rest of the API; the value is the same bytes the browser returns. Contains the challenge, origin, and `type: "webauthn.create"`.'
+          example: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+        attestationObject:
+          type: string
+          description: Base64url-encoded CBOR attestation object produced by the authenticator during registration. Corresponds to `AuthenticatorAttestationResponse.attestationObject`.
+          example: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+        transports:
+          type: array
+          items:
+            type: string
+            enum:
+              - usb
+              - nfc
+              - ble
+              - internal
+              - hybrid
+          description: Optional. WebAuthn transports as returned by `AuthenticatorAttestationResponse.getTransports()`. Values follow the W3C `AuthenticatorTransport` enum — pass the raw values through to Grid; provider-specific translation is handled server-side. Some authenticators return an empty array; omit the field or send `[]` in that case.
+          example:
+            - internal
+            - hybrid
+    PasskeyCredentialCreateRequestFields:
+      type: object
+      required:
+        - type
+        - nickname
+        - challenge
+        - attestation
+      properties:
+        type:
+          type: string
+          enum:
+            - PASSKEY
+          description: Discriminator value identifying this as a passkey credential.
+        nickname:
+          type: string
+          description: Human-readable identifier for the passkey, chosen by the user at registration time (e.g. "iPhone Face-ID", "YubiKey 5C"). Shown back on `AuthMethod` responses and in credential listings.
+          example: iPhone Face-ID
+        challenge:
+          type: string
+          description: Base64url-encoded WebAuthn challenge issued by the platform backend and passed to the client before `navigator.credentials.create()`. Grid verifies it matches the challenge embedded in the attestation's `clientDataJson`, binding the attestation to this registration. Must be single-use.
+          example: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+        attestation:
+          $ref: '#/components/schemas/PasskeyAttestation'
+    PasskeyCredentialCreateRequest:
+      title: Passkey Credential Create Request
+      allOf:
+        - $ref: '#/components/schemas/AuthCredentialCreateRequest'
+        - $ref: '#/components/schemas/PasskeyCredentialCreateRequestFields'
     AuthCredentialCreateRequestOneOf:
       oneOf:
         - $ref: '#/components/schemas/EmailOtpCredentialCreateRequest'
         - $ref: '#/components/schemas/OauthCredentialCreateRequest'
+        - $ref: '#/components/schemas/PasskeyCredentialCreateRequest'
       discriminator:
         propertyName: type
         mapping:
           EMAIL_OTP: '#/components/schemas/EmailOtpCredentialCreateRequest'
           OAUTH: '#/components/schemas/OauthCredentialCreateRequest'
+          PASSKEY: '#/components/schemas/PasskeyCredentialCreateRequest'
     AuthMethod:
       type: object
       required:
@@ -13190,6 +13299,48 @@ components:
           format: date-time
           description: Last update timestamp.
           example: '2026-04-08T15:35:00Z'
+    AuthMethodResponse:
+      title: Auth Method Response
+      description: 'Strict wrapper around `AuthMethod` used inside `AuthCredentialResponseOneOf` for the `EMAIL_OTP` and `OAUTH` branches. The only difference from `AuthMethod` is `unevaluatedProperties: false`, which disambiguates the oneOf against `PasskeyAuthChallenge` — without the strictness, an `AuthMethod` with extra fields would ambiguously match both branches.'
+      allOf:
+        - $ref: '#/components/schemas/AuthMethod'
+      unevaluatedProperties: false
+    PasskeyAuthChallenge:
+      title: Passkey Auth Challenge
+      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials` (first-authentication case) and `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a Grid-issued `challenge`, the corresponding `requestId`, and the challenge's `expiresAt` to the base `AuthMethod` fields. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
+      allOf:
+        - $ref: '#/components/schemas/AuthMethod'
+        - type: object
+          required:
+            - challenge
+            - requestId
+            - expiresAt
+          properties:
+            challenge:
+              type: string
+              description: Base64url-encoded challenge issued by Grid for the pending passkey authentication. The client passes it into `navigator.credentials.get()` as the WebAuthn challenge; the resulting assertion is submitted to `POST /auth/credentials/{id}/verify`. Single-use; a new challenge is issued on the next call to `POST /auth/credentials/{id}/challenge`.
+              example: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+            requestId:
+              type: string
+              description: Unique identifier for this pending passkey authentication request. Must be echoed as the `Request-Id` header on the subsequent `POST /auth/credentials/{id}/verify` call so Grid can correlate the assertion with the issued challenge.
+              example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+            expiresAt:
+              type: string
+              format: date-time
+              description: Timestamp after which the issued challenge is no longer valid. The assertion must reach `POST /auth/credentials/{id}/verify` before this time; otherwise the client must request a fresh challenge via `POST /auth/credentials/{id}/challenge`.
+              example: '2026-04-08T15:35:00Z'
+    AuthCredentialResponseOneOf:
+      title: Auth Credential Response
+      description: Discriminated response shape returned from `POST /auth/credentials` (on successful registration) and `POST /auth/credentials/{id}/challenge` (on challenge re-issue). For `EMAIL_OTP` and `OAUTH` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion.
+      oneOf:
+        - $ref: '#/components/schemas/AuthMethodResponse'
+        - $ref: '#/components/schemas/PasskeyAuthChallenge'
+      discriminator:
+        propertyName: type
+        mapping:
+          EMAIL_OTP: '#/components/schemas/AuthMethodResponse'
+          OAUTH: '#/components/schemas/AuthMethodResponse'
+          PASSKEY: '#/components/schemas/PasskeyAuthChallenge'
     AuthCredentialAdditionalChallenge:
       type: object
       required:

--- a/openapi/components/schemas/auth/AuthCredentialCreateRequestOneOf.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialCreateRequestOneOf.yaml
@@ -1,8 +1,10 @@
 oneOf:
   - $ref: ./EmailOtpCredentialCreateRequest.yaml
   - $ref: ./OauthCredentialCreateRequest.yaml
+  - $ref: ./PasskeyCredentialCreateRequest.yaml
 discriminator:
   propertyName: type
   mapping:
     EMAIL_OTP: ./EmailOtpCredentialCreateRequest.yaml
     OAUTH: ./OauthCredentialCreateRequest.yaml
+    PASSKEY: ./PasskeyCredentialCreateRequest.yaml

--- a/openapi/components/schemas/auth/AuthCredentialResponseOneOf.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialResponseOneOf.yaml
@@ -1,0 +1,19 @@
+title: Auth Credential Response
+description: >-
+  Discriminated response shape returned from `POST /auth/credentials` (on
+  successful registration) and `POST /auth/credentials/{id}/challenge` (on
+  challenge re-issue). For `EMAIL_OTP` and `OAUTH` credentials the body is
+  a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate
+  the oneOf). For `PASSKEY` credentials the body is a
+  `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the
+  Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the
+  subsequent assertion.
+oneOf:
+  - $ref: ./AuthMethodResponse.yaml
+  - $ref: ./PasskeyAuthChallenge.yaml
+discriminator:
+  propertyName: type
+  mapping:
+    EMAIL_OTP: ./AuthMethodResponse.yaml
+    OAUTH: ./AuthMethodResponse.yaml
+    PASSKEY: ./PasskeyAuthChallenge.yaml

--- a/openapi/components/schemas/auth/AuthMethodResponse.yaml
+++ b/openapi/components/schemas/auth/AuthMethodResponse.yaml
@@ -1,0 +1,11 @@
+title: Auth Method Response
+description: >-
+  Strict wrapper around `AuthMethod` used inside
+  `AuthCredentialResponseOneOf` for the `EMAIL_OTP` and `OAUTH` branches.
+  The only difference from `AuthMethod` is `unevaluatedProperties: false`,
+  which disambiguates the oneOf against `PasskeyAuthChallenge` — without
+  the strictness, an `AuthMethod` with extra fields would ambiguously
+  match both branches.
+allOf:
+  - $ref: ./AuthMethod.yaml
+unevaluatedProperties: false

--- a/openapi/components/schemas/auth/PasskeyAttestation.yaml
+++ b/openapi/components/schemas/auth/PasskeyAttestation.yaml
@@ -1,0 +1,52 @@
+title: Passkey Attestation
+type: object
+required:
+  - credentialId
+  - clientDataJson
+  - attestationObject
+properties:
+  credentialId:
+    type: string
+    description: >-
+      Base64url-encoded credential identifier produced by the authenticator
+      at registration time. Typically the base64url of
+      `PublicKeyCredential.rawId`.
+    example: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+  clientDataJson:
+    type: string
+    description: >-
+      Base64url-encoded JSON client data collected by the browser during
+      the WebAuthn `navigator.credentials.create()` call. Corresponds to
+      `AuthenticatorAttestationResponse.clientDataJSON` from the WebAuthn
+      spec — Grid's field name is intentionally camelCased as
+      `clientDataJson` (lowercase JSON) for consistency with the rest of
+      the API; the value is the same bytes the browser returns. Contains
+      the challenge, origin, and `type: "webauthn.create"`.
+    example: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+  attestationObject:
+    type: string
+    description: >-
+      Base64url-encoded CBOR attestation object produced by the authenticator
+      during registration. Corresponds to
+      `AuthenticatorAttestationResponse.attestationObject`.
+    example: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+  transports:
+    type: array
+    items:
+      type: string
+      enum:
+        - usb
+        - nfc
+        - ble
+        - internal
+        - hybrid
+    description: >-
+      Optional. WebAuthn transports as returned by
+      `AuthenticatorAttestationResponse.getTransports()`. Values follow
+      the W3C `AuthenticatorTransport` enum — pass the raw values through
+      to Grid; provider-specific translation is handled server-side.
+      Some authenticators return an empty array; omit the field or send
+      `[]` in that case.
+    example:
+      - internal
+      - hybrid

--- a/openapi/components/schemas/auth/PasskeyAuthChallenge.yaml
+++ b/openapi/components/schemas/auth/PasskeyAuthChallenge.yaml
@@ -1,0 +1,45 @@
+title: Passkey Auth Challenge
+description: >-
+  Extended `AuthMethod` shape returned for `PASSKEY` credentials from
+  `POST /auth/credentials` (first-authentication case) and
+  `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a
+  Grid-issued `challenge`, the corresponding `requestId`, and the
+  challenge's `expiresAt` to the base `AuthMethod` fields. The client signs
+  the challenge with the passkey to produce the assertion submitted to
+  `POST /auth/credentials/{id}/verify`.
+allOf:
+  - $ref: ./AuthMethod.yaml
+  - type: object
+    required:
+      - challenge
+      - requestId
+      - expiresAt
+    properties:
+      challenge:
+        type: string
+        description: >-
+          Base64url-encoded challenge issued by Grid for the pending
+          passkey authentication. The client passes it into
+          `navigator.credentials.get()` as the WebAuthn challenge; the
+          resulting assertion is submitted to
+          `POST /auth/credentials/{id}/verify`. Single-use; a new
+          challenge is issued on the next call to
+          `POST /auth/credentials/{id}/challenge`.
+        example: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+      requestId:
+        type: string
+        description: >-
+          Unique identifier for this pending passkey authentication
+          request. Must be echoed as the `Request-Id` header on the
+          subsequent `POST /auth/credentials/{id}/verify` call so Grid
+          can correlate the assertion with the issued challenge.
+        example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+      expiresAt:
+        type: string
+        format: date-time
+        description: >-
+          Timestamp after which the issued challenge is no longer valid.
+          The assertion must reach `POST /auth/credentials/{id}/verify`
+          before this time; otherwise the client must request a fresh
+          challenge via `POST /auth/credentials/{id}/challenge`.
+        example: '2026-04-08T15:35:00Z'

--- a/openapi/components/schemas/auth/PasskeyCredentialCreateRequest.yaml
+++ b/openapi/components/schemas/auth/PasskeyCredentialCreateRequest.yaml
@@ -1,0 +1,4 @@
+title: Passkey Credential Create Request
+allOf:
+  - $ref: ./AuthCredentialCreateRequest.yaml
+  - $ref: ./PasskeyCredentialCreateRequestFields.yaml

--- a/openapi/components/schemas/auth/PasskeyCredentialCreateRequestFields.yaml
+++ b/openapi/components/schemas/auth/PasskeyCredentialCreateRequestFields.yaml
@@ -1,0 +1,30 @@
+type: object
+required:
+  - type
+  - nickname
+  - challenge
+  - attestation
+properties:
+  type:
+    type: string
+    enum:
+      - PASSKEY
+    description: Discriminator value identifying this as a passkey credential.
+  nickname:
+    type: string
+    description: >-
+      Human-readable identifier for the passkey, chosen by the user at
+      registration time (e.g. "iPhone Face-ID", "YubiKey 5C"). Shown
+      back on `AuthMethod` responses and in credential listings.
+    example: iPhone Face-ID
+  challenge:
+    type: string
+    description: >-
+      Base64url-encoded WebAuthn challenge issued by the platform backend
+      and passed to the client before `navigator.credentials.create()`.
+      Grid verifies it matches the challenge embedded in the attestation's
+      `clientDataJson`, binding the attestation to this registration. Must
+      be single-use.
+    example: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+  attestation:
+    $ref: ./PasskeyAttestation.yaml

--- a/openapi/paths/auth/auth_credentials.yaml
+++ b/openapi/paths/auth/auth_credentials.yaml
@@ -17,7 +17,21 @@ post:
     `oidcToken` is validated inline against the issuer's `.well-known`
     OpenID configuration (the token's `iat` must be less than 60 seconds
     before the request); activation still happens via
-    `POST /auth/credentials/{id}/verify`.
+    `POST /auth/credentials/{id}/verify`. For `PASSKEY` credentials, the
+    client completes a WebAuthn registration (`navigator.credentials.create()`)
+    using a `challenge` issued by the platform backend and submits the
+    resulting `attestation` here; the credential must still be activated
+    via `POST /auth/credentials/{id}/verify` by completing a WebAuthn
+    assertion. Unlike the registration `challenge` (platform-issued), the
+    challenge for the first authentication is issued by Grid and returned
+    inline on the `201` response alongside the `AuthMethod` fields, plus a
+    `requestId` and challenge `expiresAt` (see `PasskeyAuthChallenge`).
+    The client uses that Grid-issued `challenge` to produce the assertion
+    and submits it with `Request-Id: <requestId>` to
+    `POST /auth/credentials/{id}/verify`. On every subsequent
+    reauthentication the challenge is re-issued via
+    `POST /auth/credentials/{id}/challenge`. Only one `PASSKEY` credential
+    is supported per internal account in v1.
 
 
     **Adding an additional credential**
@@ -84,13 +98,63 @@ post:
               type: OAUTH
               accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
               oidcToken: eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTIyMzM0NDU1IiwiYXVkIjoiMTIzNDU2Ny5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImVtYWlsIjoidXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0NjczNjUwOSwiZXhwIjoxNzQ2NzQwMTA5fQ.signature
+          passkey:
+            summary: Register a passkey credential
+            value:
+              type: PASSKEY
+              accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+              nickname: iPhone Face-ID
+              challenge: ArkQi2yAYHPlgnJNFBlneIwchQdWXBOTrdB-AmMUB21Lx
+              attestation:
+                credentialId: AdKXJEch1aV5Wo7bj7qLHskVY4OoNaj9qu8TPdJ7kSAgUeRxWNngXlcNIGt4gexZGKVGcqZpqqWordXb_he1izY
+                clientDataJson: eyJjaGFsbGVuZ2UiOiJBcktRaTJ5QVlIUGxnbkpORkJsbmVJd2NoUWRXWEJPVHJkQi1BbU1VQjIxTHgiLCJjbGllbnRFeHRlbnNpb25zIjp7fSwiaGFzaEFsZ29yaXRobSI6IlNIQS0yNTYiLCJvcmlnaW4iOiJodHRwczovL2Rldi5kb250bmVlZGEucHciLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0
+                attestationObject: o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjFPdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQHSlyRHIdWleVqO24-6ix7JFWODqDWo_arvEz3Se5EgIFHkcVjZ4F5XDSBreIHsWRilRnKmaaqlqK3V2_4XtYs2pQECAyYgASFYID5PQTZQQg6haZFQWFzqfAOyQ_ENsMH8xxQ4GRiNPsqrIlggU8IVUOV8qpgk_Jh-OTaLuZL52KdX1fTht07X4DiQPow
+                transports:
+                  - internal
+                  - hybrid
   responses:
     '201':
-      description: Authentication credential created successfully
+      description: >-
+        Authentication credential created successfully. For `EMAIL_OTP`
+        and `OAUTH`, the body is a plain `AuthMethod`. For `PASSKEY`, the
+        body is a `PasskeyAuthChallenge` — an `AuthMethod` with the
+        Grid-issued `challenge`, `requestId`, and `expiresAt` that drive
+        the first authentication assertion.
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/auth/AuthMethod.yaml
+            $ref: ../../components/schemas/auth/AuthCredentialResponseOneOf.yaml
+          examples:
+            emailOtp:
+              summary: Email OTP credential created
+              value:
+                id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                type: EMAIL_OTP
+                nickname: example@lightspark.com
+                createdAt: '2026-04-08T15:30:01Z'
+                updatedAt: '2026-04-08T15:30:01Z'
+            oauth:
+              summary: OAuth credential created
+              value:
+                id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                type: OAUTH
+                nickname: example@lightspark.com
+                createdAt: '2026-04-08T15:30:01Z'
+                updatedAt: '2026-04-08T15:30:01Z'
+            passkey:
+              summary: Passkey credential created with first-authentication challenge
+              value:
+                id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
+                accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                type: PASSKEY
+                nickname: iPhone Face-ID
+                createdAt: '2026-04-08T15:30:01Z'
+                updatedAt: '2026-04-08T15:30:01Z'
+                challenge: VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW
+                requestId: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+                expiresAt: '2026-04-08T15:35:00Z'
     '202':
       description: >-
         An existing authentication credential is already registered on the


### PR DESCRIPTION
Adds the PASSKEY branch to `AuthCredentialCreateRequestOneOf`, letting platforms register a WebAuthn passkey as an authentication credential on an Embedded Wallet internal account. The 201 response shape becomes a discriminated `oneOf` on `type` so a PASSKEY response can return the Grid-issued first-authentication challenge.

**Request shape**

- `POST /auth/credentials` body: `{ type: "PASSKEY", accountId, nickname, challenge, attestation }`. `challenge` is platform-generated (used by the client before `navigator.credentials.create()`).

**Response shape**

- 201 response `$ref` swapped from `AuthMethod` to `AuthCredentialResponseOneOf`:
    - `EMAIL_OTP` → `AuthMethod` (plain)
    - `OAUTH` → `AuthMethod` (plain)
    - `PASSKEY` → `PasskeyAuthChallenge` (AuthMethod + `challenge`, `requestId`, `expiresAt`)
- For `PASSKEY`, the Grid-issued `challenge` returned inline is what the client signs with the passkey for the first authentication assertion. The `requestId` must be echoed as `Request-Id` on the subsequent `POST /auth/credentials/{id}/verify`. The `expiresAt` is the time at which the challenge expires.

**Schemas added**

- `PasskeyAttestation` — `{ credentialId, clientDataJson, attestationObject, transports? }`. `credentialId`, `clientDataJson`, `attestationObject` are required base64url-encoded fields. `transports` is an optional W3C-enum-validated array (values: `usb | nfc | ble | internal | hybrid`) — optional because `AuthenticatorAttestationResponse.getTransports()` can legitimately return an empty array on some authenticators.
- `PasskeyCredentialCreateRequestFields` — `{ type: "PASSKEY", nickname, challenge, attestation }` (variant single-value enum on `type`).
- `PasskeyCredentialCreateRequest` — `allOf(AuthCredentialCreateRequest, PasskeyCredentialCreateRequestFields)`.
- `PasskeyAuthChallenge` — `allOf(AuthMethod, { challenge, requestId, expiresAt })`. Extended response for PASSKEY; reused by `POST /auth/credentials/{id}/challenge` on reauthentication (see later PR in the stack).
- `AuthCredentialResponseOneOf` — discriminated oneOf on `type` mapping EMAIL_OTP/OAUTH → `AuthMethod`, PASSKEY → `PasskeyAuthChallenge`.

**Wire-up**

- `AuthCredentialCreateRequestOneOf.yaml` discriminator map extended with `PASSKEY → PasskeyCredentialCreateRequest`.

**Design notes**

- `nickname` is user-chosen at registration (unlike EMAIL_OTP where it's derived from the email address) and appears on `AuthMethod` responses for credential listings.
- Only one PASSKEY credential per internal account is allowed in v1 (the error path is wired up in the later PR that also adds the error code). 

**Notes**

- This PR only wires the create flow. `POST /auth/credentials/{id}/verify` gets its PASSKEY branch (including the new `Request-Id` header) in the next PR, and `POST /auth/credentials/{id}/challenge` gets its PASSKEY branch later in the stack.