### PR TITLE
add DELETE /auth/sessions/{id} to revoke authentication sessions

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -360,6 +360,7 @@ resources:
       sessions:
         methods:
           list: get /auth/sessions
+          delete: delete /auth/sessions/{id}
         models:
           session_list_response: '#/components/schemas/SessionListResponse'
   exchange_rates:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4125,6 +4125,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /auth/sessions/{id}:
+    delete:
+      summary: Revoke an authentication session
+      description: |
+        Revoke an authentication session on an Embedded Wallet internal account. Revocation is a two-step signed-retry flow:
+
+        1. Call `DELETE /auth/sessions/{id}` with no headers. The response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
+
+        2. Sign the `payloadToSign` with the session private key of a verified session on the same internal account (this can be the session being revoked, for self-logout) and retry the same `DELETE` request with the signature as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The signed retry returns `204`.
+      operationId: revokeAuthSession
+      tags:
+        - Embedded Wallet Auth
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The id of the session to revoke.
+          required: true
+          schema:
+            type: string
+        - name: Grid-Wallet-Signature
+          in: header
+          required: false
+          description: Signature over the `payloadToSign` returned in a prior `202` response, produced with the session private key of a verified session on the same internal account and base64-encoded. Required on the signed retry; ignored on the initial call.
+          schema:
+            type: string
+          example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
+        - name: Request-Id
+          in: header
+          required: false
+          description: The `requestId` returned in a prior `202` response, echoed back on the signed retry so the server can correlate it with the issued challenge. Required on the signed retry; must be paired with `Grid-Wallet-Signature`.
+          schema:
+            type: string
+          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+      responses:
+        '202':
+          description: Challenge issued. The response contains a `payloadToSign` that must be signed with the session private key of a verified session on the same internal account, along with a `requestId` that must be echoed back on the retry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSignedRequestChallenge'
+        '204':
+          description: Session revoked successfully.
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized. Returned when the provided `Grid-Wallet-Signature` is missing, malformed, or does not match a pending revocation challenge for this session, or when the `Request-Id` does not match an unexpired pending challenge.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 webhooks:
   incoming-payment:
     post:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4125,6 +4125,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /auth/sessions/{id}:
+    delete:
+      summary: Revoke an authentication session
+      description: |
+        Revoke an authentication session on an Embedded Wallet internal account. Revocation is a two-step signed-retry flow:
+
+        1. Call `DELETE /auth/sessions/{id}` with no headers. The response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
+
+        2. Sign the `payloadToSign` with the session private key of a verified session on the same internal account (this can be the session being revoked, for self-logout) and retry the same `DELETE` request with the signature as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The signed retry returns `204`.
+      operationId: revokeAuthSession
+      tags:
+        - Embedded Wallet Auth
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The id of the session to revoke.
+          required: true
+          schema:
+            type: string
+        - name: Grid-Wallet-Signature
+          in: header
+          required: false
+          description: Signature over the `payloadToSign` returned in a prior `202` response, produced with the session private key of a verified session on the same internal account and base64-encoded. Required on the signed retry; ignored on the initial call.
+          schema:
+            type: string
+          example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
+        - name: Request-Id
+          in: header
+          required: false
+          description: The `requestId` returned in a prior `202` response, echoed back on the signed retry so the server can correlate it with the issued challenge. Required on the signed retry; must be paired with `Grid-Wallet-Signature`.
+          schema:
+            type: string
+          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+      responses:
+        '202':
+          description: Challenge issued. The response contains a `payloadToSign` that must be signed with the session private key of a verified session on the same internal account, along with a `requestId` that must be echoed back on the retry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSignedRequestChallenge'
+        '204':
+          description: Session revoked successfully.
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized. Returned when the provided `Grid-Wallet-Signature` is missing, malformed, or does not match a pending revocation challenge for this session, or when the `Request-Id` does not match an unexpired pending challenge.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 webhooks:
   incoming-payment:
     post:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -186,6 +186,8 @@ paths:
     $ref: paths/auth/auth_credentials_{id}_challenge.yaml
   /auth/sessions:
     $ref: paths/auth/auth_sessions.yaml
+  /auth/sessions/{id}:
+    $ref: paths/auth/auth_sessions_{id}.yaml
 webhooks:
   incoming-payment:
     $ref: webhooks/incoming-payment.yaml

--- a/openapi/paths/auth/auth_sessions_{id}.yaml
+++ b/openapi/paths/auth/auth_sessions_{id}.yaml
@@ -1,0 +1,92 @@
+delete:
+  summary: Revoke an authentication session
+  description: >
+    Revoke an authentication session on an Embedded Wallet internal
+    account. Revocation is a two-step signed-retry flow:
+
+
+    1. Call `DELETE /auth/sessions/{id}` with no headers. The response
+    is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
+
+
+    2. Sign the `payloadToSign` with the session private key of a
+    verified session on the same internal account (this can be the
+    session being revoked, for self-logout) and retry the same `DELETE`
+    request with the signature as the `Grid-Wallet-Signature` header
+    and the `requestId` echoed back as the `Request-Id` header. The
+    signed retry returns `204`.
+  operationId: revokeAuthSession
+  tags:
+    - Embedded Wallet Auth
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: id
+      in: path
+      description: The id of the session to revoke.
+      required: true
+      schema:
+        type: string
+    - name: Grid-Wallet-Signature
+      in: header
+      required: false
+      description: >-
+        Signature over the `payloadToSign` returned in a prior `202`
+        response, produced with the session private key of a verified
+        session on the same internal account and base64-encoded.
+        Required on the signed retry; ignored on the initial call.
+      schema:
+        type: string
+      example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
+    - name: Request-Id
+      in: header
+      required: false
+      description: >-
+        The `requestId` returned in a prior `202` response, echoed back
+        on the signed retry so the server can correlate it with the
+        issued challenge. Required on the signed retry; must be paired
+        with `Grid-Wallet-Signature`.
+      schema:
+        type: string
+      example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
+  responses:
+    '202':
+      description: >-
+        Challenge issued. The response contains a `payloadToSign` that
+        must be signed with the session private key of a verified
+        session on the same internal account, along with a `requestId`
+        that must be echoed back on the retry.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/auth/AuthSignedRequestChallenge.yaml
+    '204':
+      description: Session revoked successfully.
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: >-
+        Unauthorized. Returned when the provided `Grid-Wallet-Signature`
+        is missing, malformed, or does not match a pending revocation
+        challenge for this session, or when the `Request-Id` does not
+        match an unexpired pending challenge.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Session not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
feat: add DELETE /auth/sessions/{id} to revoke authentication sessions

Two-step signed-retry session revocation. Same pattern as the credential-delete and add-credential flows.

**Flow**
1. \`DELETE /auth/sessions/{id}\` → \`202 AuthSignedRequestChallenge\` (\`type\`, \`payloadToSign\`, \`requestId\`, \`expiresAt\`).
2. Sign and retry with \`Grid-Wallet-Signature\` + \`Request-Id\` headers → \`204\`.

**Notes**
- Reuses \`AuthSignedRequestChallenge\` (introduced in the credential-delete PR). \`type\` here is the credential type that issued the session being revoked.
- Self-logout is supported: a session can sign its own revocation payload.
- 202 doesn't echo session \`id\` — client has it from the URL path.
- Bundled \`openapi.yaml\` + \`mintlify/openapi.yaml\` regenerated.

