### PR TITLE
refactor: migrate AuthCredentialAdditionalChallenge onto SignedRequestChallenge base

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -13790,30 +13790,16 @@ components:
           PASSKEY: '#/components/schemas/PasskeyAuthChallenge'
     AuthCredentialAdditionalChallenge:
       title: Authentication Credential Additional Challenge
-      description: 202 response returned from `POST /auth/credentials` when the target internal account already has a verified credential. Identical shape across all three credential types (EMAIL_OTP, OAUTH, PASSKEY) — the `type` field simply echoes the credential type being added.
-      type: object
-      required:
-        - type
-        - payloadToSign
-        - requestId
-        - expiresAt
-      properties:
-        type:
-          $ref: '#/components/schemas/AuthMethodType'
-          description: Credential type being registered as an additional credential. Echoes the `type` from the originating `POST /auth/credentials` request.
-        payloadToSign:
-          type: string
-          description: JSON-encoded challenge payload that must be signed, as-is (byte-for-byte, without re-serialization), with the session private key of an existing verified authentication credential on the internal account. The resulting signature is passed as the `Grid-Wallet-Signature` header on the retry of `POST /auth/credentials` to complete registration of the additional credential.
-          example: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
-        requestId:
-          type: string
-          description: Unique identifier for this additional-credential registration request. Must be echoed in the `Request-Id` header on the signed retry of `POST /auth/credentials` so the server can correlate the retry with the issued challenge.
-          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
-        expiresAt:
-          type: string
-          format: date-time
-          description: Timestamp after which this challenge is no longer valid. The signed retry must be submitted before this time.
-          example: '2026-04-08T15:35:00Z'
+      description: 202 response returned from `POST /auth/credentials` when the target internal account already has a verified credential. Identical shape across all three credential types (EMAIL_OTP, OAUTH, PASSKEY) — the `type` field simply echoes the credential type being added. Shares the `payloadToSign` / `requestId` / `expiresAt` signing fields with the other signed-retry challenges via `SignedRequestChallenge`.
+      allOf:
+        - $ref: '#/components/schemas/SignedRequestChallenge'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              $ref: '#/components/schemas/AuthMethodType'
+              description: Credential type being registered as an additional credential. Echoes the `type` from the originating `POST /auth/credentials` request.
     AuthCredentialDeleteChallenge:
       title: Authentication Credential Delete Challenge
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13790,30 +13790,16 @@ components:
           PASSKEY: '#/components/schemas/PasskeyAuthChallenge'
     AuthCredentialAdditionalChallenge:
       title: Authentication Credential Additional Challenge
-      description: 202 response returned from `POST /auth/credentials` when the target internal account already has a verified credential. Identical shape across all three credential types (EMAIL_OTP, OAUTH, PASSKEY) — the `type` field simply echoes the credential type being added.
-      type: object
-      required:
-        - type
-        - payloadToSign
-        - requestId
-        - expiresAt
-      properties:
-        type:
-          $ref: '#/components/schemas/AuthMethodType'
-          description: Credential type being registered as an additional credential. Echoes the `type` from the originating `POST /auth/credentials` request.
-        payloadToSign:
-          type: string
-          description: JSON-encoded challenge payload that must be signed, as-is (byte-for-byte, without re-serialization), with the session private key of an existing verified authentication credential on the internal account. The resulting signature is passed as the `Grid-Wallet-Signature` header on the retry of `POST /auth/credentials` to complete registration of the additional credential.
-          example: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
-        requestId:
-          type: string
-          description: Unique identifier for this additional-credential registration request. Must be echoed in the `Request-Id` header on the signed retry of `POST /auth/credentials` so the server can correlate the retry with the issued challenge.
-          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
-        expiresAt:
-          type: string
-          format: date-time
-          description: Timestamp after which this challenge is no longer valid. The signed retry must be submitted before this time.
-          example: '2026-04-08T15:35:00Z'
+      description: 202 response returned from `POST /auth/credentials` when the target internal account already has a verified credential. Identical shape across all three credential types (EMAIL_OTP, OAUTH, PASSKEY) — the `type` field simply echoes the credential type being added. Shares the `payloadToSign` / `requestId` / `expiresAt` signing fields with the other signed-retry challenges via `SignedRequestChallenge`.
+      allOf:
+        - $ref: '#/components/schemas/SignedRequestChallenge'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              $ref: '#/components/schemas/AuthMethodType'
+              description: Credential type being registered as an additional credential. Echoes the `type` from the originating `POST /auth/credentials` request.
     AuthCredentialDeleteChallenge:
       title: Authentication Credential Delete Challenge
       allOf:

--- a/openapi/components/schemas/auth/AuthCredentialAdditionalChallenge.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialAdditionalChallenge.yaml
@@ -3,42 +3,18 @@ description: >-
   202 response returned from `POST /auth/credentials` when the target
   internal account already has a verified credential. Identical shape
   across all three credential types (EMAIL_OTP, OAUTH, PASSKEY) — the
-  `type` field simply echoes the credential type being added.
-type: object
-required:
-  - type
-  - payloadToSign
-  - requestId
-  - expiresAt
-properties:
-  type:
-    $ref: ./AuthMethodType.yaml
-    description: >-
-      Credential type being registered as an additional credential.
-      Echoes the `type` from the originating `POST /auth/credentials`
-      request.
-  payloadToSign:
-    type: string
-    description: >-
-      JSON-encoded challenge payload that must be signed, as-is (byte-for-byte,
-      without re-serialization), with the session private key of an existing
-      verified authentication credential on the internal account. The resulting
-      signature is passed as the `Grid-Wallet-Signature` header on the retry of
-      `POST /auth/credentials` to complete registration of the additional
-      credential.
-    example: '{"requestId":"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21","type":"EMAIL_OTP","accountId":"InternalAccount:01HF3Z4QWERTY","expiresAt":"2026-04-08T15:35:00Z"}'
-  requestId:
-    type: string
-    description: >-
-      Unique identifier for this additional-credential registration request.
-      Must be echoed in the `Request-Id` header on the signed retry of
-      `POST /auth/credentials` so the server can correlate the retry with the
-      issued challenge.
-    example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
-  expiresAt:
-    type: string
-    format: date-time
-    description: >-
-      Timestamp after which this challenge is no longer valid. The signed retry
-      must be submitted before this time.
-    example: '2026-04-08T15:35:00Z'
+  `type` field simply echoes the credential type being added. Shares
+  the `payloadToSign` / `requestId` / `expiresAt` signing fields with
+  the other signed-retry challenges via `SignedRequestChallenge`.
+allOf:
+  - $ref: ../common/SignedRequestChallenge.yaml
+  - type: object
+    required:
+      - type
+    properties:
+      type:
+        $ref: ./AuthMethodType.yaml
+        description: >-
+          Credential type being registered as an additional credential.
+          Echoes the `type` from the originating `POST /auth/credentials`
+          request.


### PR DESCRIPTION
Retrofits the add-additional-credential 202 challenge (on `POST /auth/credentials`) to compose the shared `SignedRequestChallenge` base introduced earlier in this stack. Brings the add-credential flow to match the other flows that use the http 202 signed payload challenge: delete-credential, delete-session, and export-wallet challenges.

**What changed**

- `AuthCredentialAdditionalChallenge.yaml` — rewritten from a flat `{ type, payloadToSign, requestId, expiresAt }` object to `allOf(../common/SignedRequestChallenge.yaml, { type: AuthMethodType })`.

**What stays the same**

- Wire shape of 202 responses is unchanged — still `{ type, payloadToSign, requestId, expiresAt }` plus any per-variant fields.
- The discriminated `oneOf` wrapper `AuthCredentialAdditionalChallengeOneOf` and the three variant schemas (`EmailOtp…`, `Oauth…`, `Passkey…`) are untouched
- `payloadToSign`, `requestId`, `expiresAt` descriptions shift to the slightly more generic phrasing already in `SignedRequestChallenge`, but the semantics are identical