### PR TITLE
docs: sync country coverage with source of truth sheet

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 54 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 55 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="54 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="55 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -32,6 +32,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇫🇷 France | FR | `SEPA` `SEPA Instant` |
 | 🇩🇪 Germany | DE | `SEPA` `SEPA Instant` |
 | 🇬🇷 Greece | GR | `SEPA` `SEPA Instant` |
+| 🇭🇺 Hungary | HU | `SEPA` `SEPA Instant` |
 | 🇮🇸 Iceland | IS | `SEPA` `SEPA Instant` |
 | 🇮🇳 India | IN | `UPI` |
 | 🇮🇩 Indonesia | ID | `Bank Transfer` |
@@ -75,7 +76,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 Regional Summary
 
 <FeatureCardGrid cols={4}>
-  <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="31 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="32 countries">
     Primary: SEPA/SEPA Instant
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="13 countries">
@@ -95,21 +96,7 @@ Grid is rapidly expanding. These corridors are next on our roadmap — get in to
 
 | Country | ISO Code |
 |---|---|
-| 🇧🇩 Bangladesh | BD |
+| 🇨🇦 Canada | CA |
 | 🇨🇳 China | CN |
-| 🇨🇴 Colombia | CO |
-| 🇩🇴 Dominican Republic | DO |
-| 🇪🇬 Egypt | EG |
-| 🇸🇻 El Salvador | SV |
-| 🇪🇹 Ethiopia | ET |
-| 🇬🇭 Ghana | GH |
-| 🇬🇹 Guatemala | GT |
-| 🇭🇹 Haiti | HT |
-| 🇭🇳 Honduras | HN |
 | 🇭🇰 Hong Kong | HK |
-| 🇯🇲 Jamaica | JM |
-| 🇱🇷 Liberia | LR |
-| 🇲🇦 Morocco | MA |
-| 🇳🇵 Nepal | NP |
-| 🇵🇰 Pakistan | PK |
-| 🇹🇴 Tonga | TO |
+| 🇰🇷 South Korea | KR |


### PR DESCRIPTION
## Summary

Syncs `mintlify/snippets/country-support.mdx` with our internal country coverage source of truth.

- **Live countries**: added 🇭🇺 Hungary (HU) to the SEPA Instant table. Totals updated from 54 → 55; Europe count 31 → 32.
- **Coming Soon**: updated to reflect current roadmap — 🇨🇦 Canada, 🇨🇳 China, 🇭🇰 Hong Kong, 🇰🇷 South Korea.

## Test plan

- [ ] Preview `mint dev` — Supported Countries page renders with Hungary in the EU table and the updated Coming Soon list
- [ ] Regional summary card reads "Europe — 32 countries"