### PR TITLE
refactor: expose session.id on verify response via AuthSession

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -13323,18 +13323,23 @@ components:
         - $ref: '#/components/schemas/AuthMethod'
         - type: object
           required:
+            - id
             - encryptedSessionSigningKey
             - expiresAt
           properties:
+            id:
+              type: string
+              description: System-generated unique identifier for the session. Pass this value to `DELETE /auth/sessions/{id}` to revoke the session before `expiresAt`. Overrides the `id` inherited from `AuthMethod` so the verify response identifies the session that was just issued; the caller already has the authenticating credential's `AuthMethod` id from the path of the verify request.
+              example: Session:019542f5-b3e7-1d02-0000-000000000003
             encryptedSessionSigningKey:
               type: string
-              description: 'HPKE-encrypted session signing key, sealed to the `clientPublicKey` supplied when the credential was created. Encoded as a base58check string: the decoded payload is a 33-byte compressed P-256 encapsulated public key followed by AES-256-GCM ciphertext. The client decrypts this key with its private key and uses it to sign subsequent Embedded Wallet requests until `expiresAt`.'
+              description: 'HPKE-encrypted session signing key, sealed to the `clientPublicKey` supplied on the verify request. Encoded as a base58check string: the decoded payload is a 33-byte compressed P-256 encapsulated public key followed by AES-256-GCM ciphertext. The client decrypts this key with its private key and uses it to sign subsequent Embedded Wallet requests until `expiresAt`.'
               example: w99a5xV6A75TfoAUkZn869fVyDYvgVsKrawMALZXmrauZd8hEv66EkPU1Z42CUaHESQjcA5bqd8dynTGBMLWB9ewtXWPEVbZvocB4Tw2K1vQVp7uwjf
             expiresAt:
               type: string
               format: date-time
-              description: Timestamp after which the session signing key is no longer valid.
-              example: '2026-04-08T15:35:00Z'
+              description: Timestamp after which the session is no longer valid and the `encryptedSessionSigningKey` must not be used to sign further requests.
+              example: '2026-04-09T15:30:01Z'
     Error429:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13323,18 +13323,23 @@ components:
         - $ref: '#/components/schemas/AuthMethod'
         - type: object
           required:
+            - id
             - encryptedSessionSigningKey
             - expiresAt
           properties:
+            id:
+              type: string
+              description: System-generated unique identifier for the session. Pass this value to `DELETE /auth/sessions/{id}` to revoke the session before `expiresAt`. Overrides the `id` inherited from `AuthMethod` so the verify response identifies the session that was just issued; the caller already has the authenticating credential's `AuthMethod` id from the path of the verify request.
+              example: Session:019542f5-b3e7-1d02-0000-000000000003
             encryptedSessionSigningKey:
               type: string
-              description: 'HPKE-encrypted session signing key, sealed to the `clientPublicKey` supplied when the credential was created. Encoded as a base58check string: the decoded payload is a 33-byte compressed P-256 encapsulated public key followed by AES-256-GCM ciphertext. The client decrypts this key with its private key and uses it to sign subsequent Embedded Wallet requests until `expiresAt`.'
+              description: 'HPKE-encrypted session signing key, sealed to the `clientPublicKey` supplied on the verify request. Encoded as a base58check string: the decoded payload is a 33-byte compressed P-256 encapsulated public key followed by AES-256-GCM ciphertext. The client decrypts this key with its private key and uses it to sign subsequent Embedded Wallet requests until `expiresAt`.'
               example: w99a5xV6A75TfoAUkZn869fVyDYvgVsKrawMALZXmrauZd8hEv66EkPU1Z42CUaHESQjcA5bqd8dynTGBMLWB9ewtXWPEVbZvocB4Tw2K1vQVp7uwjf
             expiresAt:
               type: string
               format: date-time
-              description: Timestamp after which the session signing key is no longer valid.
-              example: '2026-04-08T15:35:00Z'
+              description: Timestamp after which the session is no longer valid and the `encryptedSessionSigningKey` must not be used to sign further requests.
+              example: '2026-04-09T15:30:01Z'
     Error429:
       type: object
       required:

--- a/openapi/components/schemas/auth/AuthSession.yaml
+++ b/openapi/components/schemas/auth/AuthSession.yaml
@@ -2,21 +2,37 @@ allOf:
   - $ref: ./AuthMethod.yaml
   - type: object
     required:
+      - id
       - encryptedSessionSigningKey
       - expiresAt
     properties:
+      id:
+        type: string
+        description: >-
+          System-generated unique identifier for the session. Pass this
+          value to `DELETE /auth/sessions/{id}` to revoke the session
+          before `expiresAt`. Overrides the `id` inherited from
+          `AuthMethod` so the verify response identifies the session
+          that was just issued; the caller already has the authenticating
+          credential's `AuthMethod` id from the path of the verify
+          request.
+        example: Session:019542f5-b3e7-1d02-0000-000000000003
       encryptedSessionSigningKey:
         type: string
         description: >-
-          HPKE-encrypted session signing key, sealed to the `clientPublicKey`
-          supplied when the credential was created. Encoded as a base58check
-          string: the decoded payload is a 33-byte compressed P-256 encapsulated
-          public key followed by AES-256-GCM ciphertext. The client decrypts
-          this key with its private key and uses it to sign subsequent Embedded
+          HPKE-encrypted session signing key, sealed to the
+          `clientPublicKey` supplied on the verify request. Encoded as
+          a base58check string: the decoded payload is a 33-byte
+          compressed P-256 encapsulated public key followed by
+          AES-256-GCM ciphertext. The client decrypts this key with
+          its private key and uses it to sign subsequent Embedded
           Wallet requests until `expiresAt`.
         example: w99a5xV6A75TfoAUkZn869fVyDYvgVsKrawMALZXmrauZd8hEv66EkPU1Z42CUaHESQjcA5bqd8dynTGBMLWB9ewtXWPEVbZvocB4Tw2K1vQVp7uwjf
       expiresAt:
         type: string
         format: date-time
-        description: Timestamp after which the session signing key is no longer valid.
-        example: '2026-04-08T15:35:00Z'
+        description: >-
+          Timestamp after which the session is no longer valid and the
+          `encryptedSessionSigningKey` must not be used to sign further
+          requests.
+        example: '2026-04-09T15:30:01Z'


### PR DESCRIPTION
refactor: expose session id on verify response via AuthSession

Retargets `AuthSession.id` (the 200 response on `POST /auth/credentials/{id}/verify`) from the authenticating credential's `AuthMethod` id to the session's own id, so clients can revoke directly via `DELETE /auth/sessions/{id}` without a preceding `GET /auth/sessions` lookup.

**Shape before**
```
{
  id: AuthMethod:...,     // inherited from AuthMethod
  accountId, type, nickname, createdAt, updatedAt,
  encryptedSessionSigningKey,
  expiresAt
}
```

**Shape after**
```
{
  id: Session:...,        // now the session id (overridden via allOf)
  accountId, type, nickname, createdAt, updatedAt,
  encryptedSessionSigningKey,
  expiresAt
}
```

**What changed**
- `openapi/components/schemas/auth/AuthSession.yaml` — second `allOf` element now redefines `id` with `example: Session:<uuid>` and a description that points at `DELETE /auth/sessions/{id}`. `id` is added to the inline `required` list to make the override explicit. `encryptedSessionSigningKey` and `expiresAt` remain at the top level (unchanged wire position). Descriptions on both tightened: `encryptedSessionSigningKey` now notes the `clientPublicKey` comes from the verify request (not credential creation); `expiresAt` now describes session expiry rather than signing-key expiry.

**Applies to**
- EMAIL_OTP, OAUTH, and PASSKEY verify responses all use `AuthSession`, so the new session `id` surfaces uniformly across all three credential types.

**Why override `id` rather than add a `sessionId` field**
- The verify response represents the session that was just issued — the session id is the primary identifier of the returned resource. Overriding the inherited `AuthMethod.id` keeps the response session-centric and parallels the shape of `Session` (introduced in the list-sessions PR later in the stack). Clients still have the credential's `AuthMethod` id from the verify request's path param, so no information is lost.

**Why this belongs at the bottom of the stack**
- `DELETE /auth/sessions/{id}` (introduced later in the stack) depends on clients knowing the session id. Landing the id on the verify response first keeps the revoke PR self-contained and lets clients skip the list step.

**Notes**
- Reshaping the meaning of the top-level `id` is a breaking change for EMAIL_OTP/OAUTH callers that read `response.id` as the credential id. The endpoint is on an unreleased Embedded Wallet Auth surface, so the break is acceptable pre-GA.
- The `allOf` property override on `id` is valid OpenAPI 3.1 / JSON Schema 2020-12 and passes both Redocly and Spectral lint. Stainless handles it without a transform because both branches agree on `type: string` and differ only in documentation metadata.
- Does not reference the `Session` schema introduced later in the stack. Once the full stack lands, a follow-up can consolidate `AuthSession` as `allOf(Session, { encryptedSessionSigningKey })`.
- Bundled `openapi.yaml` + `mintlify/openapi.yaml` regenerated via `make build`.

