### PR TITLE
feat(openapi): add type discriminator to InternalAccount

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4966,6 +4966,7 @@ webhooks:
                   data:
                     id: InternalAccount:019542f5-b3e7-1d02-0000-000000000005
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
+                    type: INTERNAL_FIAT
                     balance:
                       amount: 10000
                       currency:
@@ -6323,6 +6324,19 @@ components:
           type: string
           description: The customer id of the newly created customer on the system
           example: Customer:019542f5-b3e7-1d02-0000-000000000001
+    InternalAccountType:
+      title: Internal Account Type
+      type: string
+      enum:
+        - INTERNAL_FIAT
+        - INTERNAL_CRYPTO
+        - EMBEDDED_WALLET
+      description: |-
+        Classification of an internal account.
+
+        - `INTERNAL_FIAT`: A Grid-managed fiat holding account (for example, the USD holding account used as the source for Payouts flows).
+        - `INTERNAL_CRYPTO`: A Grid-managed crypto holding account denominated in a stablecoin such as USDC.
+        - `EMBEDDED_WALLET`: A self-custodial Embedded Wallet provisioned for the customer. Outbound transfers require a session signature produced by the customer's device — see the Embedded Wallets guide.
     CurrencyAmount:
       type: object
       required:
@@ -8638,6 +8652,7 @@ components:
       type: object
       required:
         - id
+        - type
         - balance
         - fundingPaymentInstructions
         - createdAt
@@ -8651,6 +8666,8 @@ components:
           type: string
           description: The ID of the customer associated with the internal account. If this field is empty, the internal account belongs to the platform.
           example: Customer:019542f5-b3e7-1d02-0000-000000000001
+        type:
+          $ref: '#/components/schemas/InternalAccountType'
         balance:
           $ref: '#/components/schemas/CurrencyAmount'
         fundingPaymentInstructions:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4966,6 +4966,7 @@ webhooks:
                   data:
                     id: InternalAccount:019542f5-b3e7-1d02-0000-000000000005
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
+                    type: INTERNAL_FIAT
                     balance:
                       amount: 10000
                       currency:
@@ -6323,6 +6324,19 @@ components:
           type: string
           description: The customer id of the newly created customer on the system
           example: Customer:019542f5-b3e7-1d02-0000-000000000001
+    InternalAccountType:
+      title: Internal Account Type
+      type: string
+      enum:
+        - INTERNAL_FIAT
+        - INTERNAL_CRYPTO
+        - EMBEDDED_WALLET
+      description: |-
+        Classification of an internal account.
+
+        - `INTERNAL_FIAT`: A Grid-managed fiat holding account (for example, the USD holding account used as the source for Payouts flows).
+        - `INTERNAL_CRYPTO`: A Grid-managed crypto holding account denominated in a stablecoin such as USDC.
+        - `EMBEDDED_WALLET`: A self-custodial Embedded Wallet provisioned for the customer. Outbound transfers require a session signature produced by the customer's device — see the Embedded Wallets guide.
     CurrencyAmount:
       type: object
       required:
@@ -8638,6 +8652,7 @@ components:
       type: object
       required:
         - id
+        - type
         - balance
         - fundingPaymentInstructions
         - createdAt
@@ -8651,6 +8666,8 @@ components:
           type: string
           description: The ID of the customer associated with the internal account. If this field is empty, the internal account belongs to the platform.
           example: Customer:019542f5-b3e7-1d02-0000-000000000001
+        type:
+          $ref: '#/components/schemas/InternalAccountType'
         balance:
           $ref: '#/components/schemas/CurrencyAmount'
         fundingPaymentInstructions:

--- a/openapi/components/schemas/customers/InternalAccount.yaml
+++ b/openapi/components/schemas/customers/InternalAccount.yaml
@@ -1,6 +1,7 @@
 type: object
 required:
   - id
+  - type
   - balance
   - fundingPaymentInstructions
   - createdAt
@@ -14,6 +15,8 @@ properties:
     type: string
     description: The ID of the customer associated with the internal account. If this field is empty, the internal account belongs to the platform.
     example: Customer:019542f5-b3e7-1d02-0000-000000000001
+  type:
+    $ref: ./InternalAccountType.yaml
   balance:
     $ref: ../common/CurrencyAmount.yaml
   fundingPaymentInstructions:

--- a/openapi/components/schemas/customers/InternalAccountType.yaml
+++ b/openapi/components/schemas/customers/InternalAccountType.yaml
@@ -1,0 +1,19 @@
+title: Internal Account Type
+type: string
+enum:
+  - INTERNAL_FIAT
+  - INTERNAL_CRYPTO
+  - EMBEDDED_WALLET
+description: >-
+  Classification of an internal account.
+
+
+  - `INTERNAL_FIAT`: A Grid-managed fiat holding account (for example, the USD
+  holding account used as the source for Payouts flows).
+
+  - `INTERNAL_CRYPTO`: A Grid-managed crypto holding account denominated in a
+  stablecoin such as USDC.
+
+  - `EMBEDDED_WALLET`: A self-custodial Embedded Wallet provisioned for the
+  customer. Outbound transfers require a session signature produced by the
+  customer's device — see the Embedded Wallets guide.

--- a/openapi/paths/internal-accounts/internal_accounts.yaml
+++ b/openapi/paths/internal-accounts/internal_accounts.yaml
@@ -24,6 +24,15 @@ get:
       required: false
       schema:
         type: string
+    - name: type
+      in: query
+      description: >-
+        Filter by internal account type. Use `EMBEDDED_WALLET` to find the
+        self-custodial wallet provisioned for a customer, or `INTERNAL_FIAT` /
+        `INTERNAL_CRYPTO` for the platform-managed holding accounts.
+      required: false
+      schema:
+        $ref: ../../components/schemas/customers/InternalAccountType.yaml
     - name: limit
       in: query
       description: Maximum number of results to return (default 20, max 100)

--- a/openapi/webhooks/internal-account-status.yaml
+++ b/openapi/webhooks/internal-account-status.yaml
@@ -56,6 +56,7 @@ post:
               data:
                 id: InternalAccount:019542f5-b3e7-1d02-0000-000000000005
                 customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
+                type: INTERNAL_FIAT
                 balance:
                   amount: 10000
                   currency:


### PR DESCRIPTION
Add an InternalAccountType enum (INTERNAL_FIAT, INTERNAL_CRYPTO,
EMBEDDED_WALLET) as a required field on InternalAccount and as an
optional query filter on GET /internal-accounts. Needed so integrators
can distinguish the self-custodial Embedded Wallet from platform-managed
holding accounts on the same customer.

Also updates the internal-account-status webhook example to carry the
new required field.