### PR TITLE
feat(sample): scaffold embedded wallet flow with sidebar nav

### DIFF
--- a/samples/frontend/package-lock.json
+++ b/samples/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "grid-sample-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hpke/core": "^1.9.0",
+        "@noble/curves": "^2.2.0",
+        "bs58check": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -746,6 +749,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hpke/common": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -794,6 +818,45 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {
@@ -1542,6 +1605,12 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1584,6 +1653,25 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/caniuse-lite": {

--- a/samples/frontend/package.json
+++ b/samples/frontend/package.json
@@ -11,6 +11,9 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@hpke/core": "^1.9.0",
+    "@noble/curves": "^2.2.0",
+    "bs58check": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/samples/frontend/src/App.tsx
+++ b/samples/frontend/src/App.tsx
@@ -10,8 +10,8 @@ const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
     subtitle: 'Send a real time payment funded with USDC',
   },
   'embedded-wallet': {
-    title: 'Embedded Wallets',
-    subtitle: 'Create a wallet and move funds on behalf of a user',
+    title: 'Global Account',
+    subtitle: 'Issue a self-custody dollar account and withdraw on behalf of a user',
   },
 }
 

--- a/samples/frontend/src/App.tsx
+++ b/samples/frontend/src/App.tsx
@@ -1,107 +1,39 @@
 import { useState } from 'react'
-import StepWizard from './components/StepWizard'
+import Sidebar, { FlowKey } from './components/Sidebar'
 import WebhookStream from './components/WebhookStream'
-import CreateCustomer from './steps/CreateCustomer'
-import CreateExternalAccount from './steps/CreateExternalAccount'
-import CreateQuote from './steps/CreateQuote'
-import SandboxFund from './steps/SandboxFund'
+import PayoutFlow from './flows/PayoutFlow'
+import EmbeddedWalletFlow from './flows/EmbeddedWalletFlow'
+
+const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
+  payout: {
+    title: 'Payout to Bank Account',
+    subtitle: 'Send a real time payment funded with USDC',
+  },
+  'embedded-wallet': {
+    title: 'Embedded Wallets',
+    subtitle: 'Create a wallet and move funds on behalf of a user',
+  },
+}
 
 export default function App() {
-  const [activeStep, setActiveStep] = useState(0)
-  const [customerId, setCustomerId] = useState<string | null>(null)
-  const [externalAccountId, setExternalAccountId] = useState<string | null>(null)
-  const [quoteId, setQuoteId] = useState<string | null>(null)
-  const [selectedCountry, setSelectedCountry] = useState('MX')
-
-  const advance = () => setActiveStep((s) => s + 1)
-
-  const restartFromExternalAccount = () => {
-    setExternalAccountId(null)
-    setQuoteId(null)
-    setActiveStep(1)
-  }
-
-  const steps = [
-    {
-      title: '1. Create Customer',
-      summary: customerId ? `ID: ${customerId}` : null,
-      content: (
-        <CreateCustomer
-          disabled={activeStep !== 0}
-          onComplete={(data) => {
-            setCustomerId(data.id as string)
-            advance()
-          }}
-        />
-      ),
-    },
-    {
-      title: '2. Create External Account',
-      summary: externalAccountId ? `ID: ${externalAccountId}` : null,
-      content: (
-        <CreateExternalAccount
-          customerId={customerId}
-          disabled={activeStep !== 1}
-          selectedCountry={selectedCountry}
-          onCountryChange={setSelectedCountry}
-          onComplete={(data) => {
-            setExternalAccountId(data.id as string)
-            advance()
-          }}
-        />
-      ),
-    },
-    {
-      title: '3. Create Quote',
-      summary: quoteId ? `ID: ${quoteId}` : null,
-      content: (
-        <CreateQuote
-          customerId={customerId}
-          externalAccountId={externalAccountId}
-          selectedCountry={selectedCountry}
-          disabled={activeStep !== 2}
-          onComplete={(data) => {
-            setQuoteId((data.quoteId ?? data.id) as string)
-            advance()
-          }}
-        />
-      ),
-    },
-    {
-      title: '4. Simulate Funding (Sandbox Only)',
-      summary: activeStep > 3 ? 'Funded' : null,
-      content: (
-        <SandboxFund
-          quoteId={quoteId}
-          disabled={activeStep !== 3}
-          onComplete={() => advance()}
-        />
-      ),
-    },
-  ]
+  const [activeFlow, setActiveFlow] = useState<FlowKey>('payout')
+  const meta = FLOW_META[activeFlow]
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
+    <div className="min-h-screen bg-gray-950 text-gray-100 pb-12">
       <header className="border-b border-gray-800 px-6 py-4">
         <h1 className="text-xl font-bold">Grid API Sample</h1>
-        <p className="text-sm text-gray-400">Send a real time payment funded with USDC</p>
+        <p className="text-sm text-gray-400">{meta.subtitle}</p>
       </header>
       <div className="flex">
-        <main className="w-3/5 p-6 border-r border-gray-800 min-h-[calc(100vh-73px)]">
-          <StepWizard steps={steps} activeStep={activeStep} />
-          {activeStep >= 1 && (
-            <button
-              onClick={restartFromExternalAccount}
-              className="mt-6 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm font-medium text-gray-300"
-            >
-              Start New Payment
-            </button>
-          )}
+        <Sidebar activeFlow={activeFlow} onSelect={setActiveFlow} />
+        <main className="flex-1 p-6 min-h-[calc(100vh-73px)] max-w-5xl">
+          <h2 className="text-lg font-semibold mb-4">{meta.title}</h2>
+          {activeFlow === 'payout' && <PayoutFlow key="payout" />}
+          {activeFlow === 'embedded-wallet' && <EmbeddedWalletFlow key="embedded-wallet" />}
         </main>
-        <aside className="w-2/5 p-6 min-h-[calc(100vh-73px)]">
-          <WebhookStream />
-        </aside>
       </div>
+      <WebhookStream />
     </div>
   )
 }

--- a/samples/frontend/src/components/Sidebar.tsx
+++ b/samples/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,55 @@
+export type FlowKey = 'payout' | 'embedded-wallet'
+
+interface FlowEntry {
+  key: FlowKey
+  label: string
+  description: string
+}
+
+const FLOWS: FlowEntry[] = [
+  {
+    key: 'payout',
+    label: 'Payout to Bank Account',
+    description: 'Send a real-time payment funded with USDC',
+  },
+  {
+    key: 'embedded-wallet',
+    label: 'Embedded Wallets',
+    description: 'Create a wallet and move funds on behalf of a user',
+  },
+]
+
+interface SidebarProps {
+  activeFlow: FlowKey
+  onSelect: (flow: FlowKey) => void
+}
+
+export default function Sidebar({ activeFlow, onSelect }: SidebarProps) {
+  return (
+    <nav className="w-64 shrink-0 border-r border-gray-800 p-4 min-h-[calc(100vh-73px)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3 px-2">
+        Flows
+      </h2>
+      <ul className="space-y-1">
+        {FLOWS.map((flow) => {
+          const isActive = flow.key === activeFlow
+          return (
+            <li key={flow.key}>
+              <button
+                onClick={() => onSelect(flow.key)}
+                className={`w-full text-left rounded px-3 py-2 transition-colors ${
+                  isActive
+                    ? 'bg-blue-600/20 border border-blue-600/40 text-blue-100'
+                    : 'border border-transparent hover:bg-gray-800/60 text-gray-300'
+                }`}
+              >
+                <div className="text-sm font-medium">{flow.label}</div>
+                <div className="text-xs text-gray-500 mt-0.5">{flow.description}</div>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/samples/frontend/src/components/Sidebar.tsx
+++ b/samples/frontend/src/components/Sidebar.tsx
@@ -14,8 +14,8 @@ const FLOWS: FlowEntry[] = [
   },
   {
     key: 'embedded-wallet',
-    label: 'Embedded Wallets',
-    description: 'Create a wallet and move funds on behalf of a user',
+    label: 'Global Account',
+    description: 'Issue a self-custody dollar account and withdraw on behalf of a user',
   },
 ]
 

--- a/samples/frontend/src/components/WebhookStream.tsx
+++ b/samples/frontend/src/components/WebhookStream.tsx
@@ -10,7 +10,11 @@ export default function WebhookStream() {
   const [events, setEvents] = useState<WebhookEvent[]>([])
   const [connected, setConnected] = useState(false)
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+  const [open, setOpen] = useState(false)
+  const [unread, setUnread] = useState(0)
   const eventSourceRef = useRef<EventSource | null>(null)
+  const openRef = useRef(open)
+  openRef.current = open
 
   useEffect(() => {
     const connect = () => {
@@ -34,6 +38,7 @@ export default function WebhookStream() {
             raw: event.data
           }, ...prev])
         }
+        if (!openRef.current) setUnread((n) => n + 1)
       }
       es.onerror = () => {
         setConnected(false)
@@ -46,43 +51,65 @@ export default function WebhookStream() {
     return () => eventSourceRef.current?.close()
   }, [])
 
+  const toggle = () => {
+    setOpen((prev) => {
+      if (!prev) setUnread(0)
+      return !prev
+    })
+  }
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 mb-3">
-        <h2 className="text-lg font-semibold">Webhooks</h2>
+    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-800 bg-gray-950/95 backdrop-blur">
+      <button
+        onClick={toggle}
+        className="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-gray-900/60"
+      >
+        <span className="text-sm font-semibold text-gray-100">Webhooks</span>
         <span className={`inline-block w-2 h-2 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'}`} />
         <span className="text-xs text-gray-500">{connected ? 'Connected' : 'Disconnected'}</span>
-      </div>
-      <div className="flex-1 overflow-y-auto space-y-2">
-        {events.length === 0 && (
-          <p className="text-sm text-gray-500">No webhook events received yet.</p>
+        {unread > 0 && !open && (
+          <span className="ml-1 px-1.5 py-0.5 text-xs font-mono bg-purple-900 text-purple-200 rounded">
+            {unread} new
+          </span>
         )}
-        {events.map((evt, i) => (
-          <div key={i} className="bg-gray-900 border border-gray-700 rounded-lg p-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span className="px-2 py-0.5 bg-purple-900 text-purple-300 text-xs rounded font-mono">
-                  {evt.type}
-                </span>
-                <span className="text-xs text-gray-500">
-                  {new Date(evt.timestamp).toLocaleTimeString()}
-                </span>
+        <span className="ml-auto text-xs text-gray-500">
+          {events.length} event{events.length === 1 ? '' : 's'}
+        </span>
+        <span className="text-xs text-gray-400">{open ? '▼' : '▲'}</span>
+      </button>
+      {open && (
+        <div className="h-72 overflow-y-auto px-4 pb-3 space-y-2 border-t border-gray-800">
+          {events.length === 0 ? (
+            <p className="text-sm text-gray-500 pt-3">No webhook events received yet.</p>
+          ) : (
+            events.map((evt, i) => (
+              <div key={i} className="bg-gray-900 border border-gray-700 rounded-lg p-3 mt-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="px-2 py-0.5 bg-purple-900 text-purple-300 text-xs rounded font-mono">
+                      {evt.type}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {new Date(evt.timestamp).toLocaleTimeString()}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                    className="text-xs text-gray-400 hover:text-gray-200"
+                  >
+                    {expandedIndex === i ? '▼' : '▶'}
+                  </button>
+                </div>
+                {expandedIndex === i && (
+                  <pre className="mt-2 text-xs font-mono text-gray-300 overflow-auto max-h-48">
+                    {evt.raw}
+                  </pre>
+                )}
               </div>
-              <button
-                onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
-                className="text-xs text-gray-400 hover:text-gray-200"
-              >
-                {expandedIndex === i ? '\u25BC' : '\u25B6'}
-              </button>
-            </div>
-            {expandedIndex === i && (
-              <pre className="mt-2 text-xs font-mono text-gray-300 overflow-auto max-h-48">
-                {evt.raw}
-              </pre>
-            )}
-          </div>
-        ))}
-      </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/samples/frontend/src/flows/EmbeddedWalletFlow.tsx
+++ b/samples/frontend/src/flows/EmbeddedWalletFlow.tsx
@@ -18,7 +18,7 @@ export default function EmbeddedWalletFlow() {
   const [quoteId, setQuoteId] = useState<string | null>(null)
   const [payloadToSign, setPayloadToSign] = useState<string | null>(null)
   const [signature, setSignature] = useState<string | null>(null)
-  const [selectedCountry, setSelectedCountry] = useState('MX')
+  const [selectedCountry, setSelectedCountry] = useState('US')
 
   const advance = () => setActiveStep((s) => s + 1)
 

--- a/samples/frontend/src/flows/EmbeddedWalletFlow.tsx
+++ b/samples/frontend/src/flows/EmbeddedWalletFlow.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import StepWizard from '../components/StepWizard'
+import CreateCustomer from '../steps/CreateCustomer'
+import CreateExternalAccount from '../steps/CreateExternalAccount'
+import FindEmbeddedWallet from '../steps/embeddedWallet/FindEmbeddedWallet'
+import RegisterPasskey from '../steps/embeddedWallet/RegisterPasskey'
+import FundEmbeddedWallet from '../steps/embeddedWallet/FundEmbeddedWallet'
+import CreateWithdrawalQuote from '../steps/embeddedWallet/CreateWithdrawalQuote'
+import AuthenticateAndSign from '../steps/embeddedWallet/AuthenticateAndSign'
+import ExecuteSignedQuote from '../steps/embeddedWallet/ExecuteSignedQuote'
+
+export default function EmbeddedWalletFlow() {
+  const [activeStep, setActiveStep] = useState(0)
+  const [customerId, setCustomerId] = useState<string | null>(null)
+  const [walletAccountId, setWalletAccountId] = useState<string | null>(null)
+  const [authMethodId, setAuthMethodId] = useState<string | null>(null)
+  const [externalAccountId, setExternalAccountId] = useState<string | null>(null)
+  const [quoteId, setQuoteId] = useState<string | null>(null)
+  const [payloadToSign, setPayloadToSign] = useState<string | null>(null)
+  const [signature, setSignature] = useState<string | null>(null)
+  const [selectedCountry, setSelectedCountry] = useState('MX')
+
+  const advance = () => setActiveStep((s) => s + 1)
+
+  const steps = [
+    {
+      title: '1. Create Customer',
+      summary: customerId ? `ID: ${customerId}` : null,
+      content: (
+        <CreateCustomer
+          disabled={activeStep !== 0}
+          onComplete={(data) => {
+            setCustomerId(data.id as string)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '2. Find Embedded Wallet',
+      summary: walletAccountId ? `ID: ${walletAccountId}` : null,
+      content: (
+        <FindEmbeddedWallet
+          customerId={customerId}
+          disabled={activeStep !== 1}
+          onComplete={(data) => {
+            const accounts = (data.accounts ?? data.data ?? []) as Array<Record<string, unknown>>
+            const wallet = accounts[0]
+            setWalletAccountId((wallet?.id ?? null) as string | null)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '3. Register Passkey',
+      summary: authMethodId ? `Auth: ${authMethodId}` : null,
+      content: (
+        <RegisterPasskey
+          walletAccountId={walletAccountId}
+          customerId={customerId}
+          disabled={activeStep !== 2}
+          onComplete={(data) => {
+            setAuthMethodId(data.authMethodId)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '4. Fund the Wallet (Sandbox)',
+      summary: activeStep > 3 ? 'Funded' : null,
+      content: (
+        <FundEmbeddedWallet
+          walletAccountId={walletAccountId}
+          disabled={activeStep !== 3}
+          onComplete={() => advance()}
+        />
+      ),
+    },
+    {
+      title: '5. Add External Bank Account',
+      summary: externalAccountId ? `ID: ${externalAccountId}` : null,
+      content: (
+        <CreateExternalAccount
+          customerId={customerId}
+          disabled={activeStep !== 4}
+          selectedCountry={selectedCountry}
+          onCountryChange={setSelectedCountry}
+          onComplete={(data) => {
+            setExternalAccountId(data.id as string)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '6. Create Withdrawal Quote',
+      summary: quoteId ? `ID: ${quoteId}` : null,
+      content: (
+        <CreateWithdrawalQuote
+          customerId={customerId}
+          walletAccountId={walletAccountId}
+          externalAccountId={externalAccountId}
+          disabled={activeStep !== 5}
+          onComplete={({ quoteId, payloadToSign }) => {
+            setQuoteId(quoteId)
+            setPayloadToSign(payloadToSign)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '7. Authenticate & Sign',
+      summary: signature ? 'Signed' : null,
+      content: (
+        <AuthenticateAndSign
+          authMethodId={authMethodId}
+          payloadToSign={payloadToSign}
+          disabled={activeStep !== 6}
+          onComplete={(data) => {
+            setSignature(data.signature)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '8. Execute Withdrawal',
+      summary: activeStep > 7 ? 'Submitted' : null,
+      content: (
+        <ExecuteSignedQuote
+          quoteId={quoteId}
+          signature={signature}
+          disabled={activeStep !== 7}
+          onComplete={() => advance()}
+        />
+      ),
+    },
+  ]
+
+  return <StepWizard steps={steps} activeStep={activeStep} />
+}

--- a/samples/frontend/src/flows/PayoutFlow.tsx
+++ b/samples/frontend/src/flows/PayoutFlow.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import StepWizard from '../components/StepWizard'
+import CreateCustomer from '../steps/CreateCustomer'
+import CreateExternalAccount from '../steps/CreateExternalAccount'
+import CreateQuote from '../steps/CreateQuote'
+import SandboxFund from '../steps/SandboxFund'
+
+export default function PayoutFlow() {
+  const [activeStep, setActiveStep] = useState(0)
+  const [customerId, setCustomerId] = useState<string | null>(null)
+  const [externalAccountId, setExternalAccountId] = useState<string | null>(null)
+  const [quoteId, setQuoteId] = useState<string | null>(null)
+  const [selectedCountry, setSelectedCountry] = useState('MX')
+
+  const advance = () => setActiveStep((s) => s + 1)
+
+  const restartFromExternalAccount = () => {
+    setExternalAccountId(null)
+    setQuoteId(null)
+    setActiveStep(1)
+  }
+
+  const steps = [
+    {
+      title: '1. Create Customer',
+      summary: customerId ? `ID: ${customerId}` : null,
+      content: (
+        <CreateCustomer
+          disabled={activeStep !== 0}
+          onComplete={(data) => {
+            setCustomerId(data.id as string)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '2. Create External Account',
+      summary: externalAccountId ? `ID: ${externalAccountId}` : null,
+      content: (
+        <CreateExternalAccount
+          customerId={customerId}
+          disabled={activeStep !== 1}
+          selectedCountry={selectedCountry}
+          onCountryChange={setSelectedCountry}
+          onComplete={(data) => {
+            setExternalAccountId(data.id as string)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '3. Create Quote',
+      summary: quoteId ? `ID: ${quoteId}` : null,
+      content: (
+        <CreateQuote
+          customerId={customerId}
+          externalAccountId={externalAccountId}
+          selectedCountry={selectedCountry}
+          disabled={activeStep !== 2}
+          onComplete={(data) => {
+            setQuoteId((data.quoteId ?? data.id) as string)
+            advance()
+          }}
+        />
+      ),
+    },
+    {
+      title: '4. Simulate Funding (Sandbox Only)',
+      summary: activeStep > 3 ? 'Funded' : null,
+      content: (
+        <SandboxFund
+          quoteId={quoteId}
+          disabled={activeStep !== 3}
+          onComplete={() => advance()}
+        />
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <StepWizard steps={steps} activeStep={activeStep} />
+      {activeStep >= 1 && (
+        <button
+          onClick={restartFromExternalAccount}
+          className="mt-6 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm font-medium text-gray-300"
+        >
+          Start New Payment
+        </button>
+      )}
+    </>
+  )
+}

--- a/samples/frontend/src/lib/api.ts
+++ b/samples/frontend/src/lib/api.ts
@@ -1,7 +1,11 @@
-export async function apiPost<T = unknown>(path: string, body?: unknown): Promise<T> {
+export async function apiPost<T = unknown>(
+  path: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Promise<T> {
   const res = await fetch(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
     body: body ? JSON.stringify(body) : undefined,
   })
   return parseResponse<T>(res)

--- a/samples/frontend/src/lib/api.ts
+++ b/samples/frontend/src/lib/api.ts
@@ -4,6 +4,15 @@ export async function apiPost<T = unknown>(path: string, body?: unknown): Promis
     headers: { 'Content-Type': 'application/json' },
     body: body ? JSON.stringify(body) : undefined,
   })
+  return parseResponse<T>(res)
+}
+
+export async function apiGet<T = unknown>(path: string): Promise<T> {
+  const res = await fetch(path)
+  return parseResponse<T>(res)
+}
+
+async function parseResponse<T>(res: Response): Promise<T> {
   const text = await res.text()
   let data: T
   try {

--- a/samples/frontend/src/steps/CreateExternalAccount.tsx
+++ b/samples/frontend/src/steps/CreateExternalAccount.tsx
@@ -117,6 +117,29 @@ const COUNTRY_CONFIGS: Record<string, {
       fullName: "James Smith",
       countryOfResidence: "GB"
     }
+  },
+  US: {
+    label: "🇺🇸 United States (USD)",
+    currency: "USD",
+    description: "USD account (ACH)",
+    accountInfo: {
+      accountType: "USD_ACCOUNT",
+      accountNumber: "1234567890",
+      routingNumber: "021000021",
+      paymentRails: ["ACH"]
+    },
+    beneficiary: {
+      beneficiaryType: "INDIVIDUAL",
+      fullName: "Jane Doe",
+      countryOfResidence: "US",
+      address: {
+        line1: "123 Main Street",
+        city: "San Francisco",
+        state: "CA",
+        postalCode: "94105",
+        country: "US"
+      }
+    }
   }
 }
 

--- a/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
@@ -12,21 +12,37 @@ interface Props {
   disabled: boolean
 }
 
-const SANDBOX_SIGNATURE = 'sandbox-valid-signature'
+// Toggle between sandbox and production paths. Sandbox accepts magic values
+// for the WebAuthn assertion signature ("sandbox-valid-passkey-signature")
+// and the wallet signature header ("sandbox-valid-signature"); production
+// runs the real WebAuthn assertion + HPKE decrypt + ECDSA sign chain.
+//
+// Set VITE_SANDBOX_PASSKEY=0 in .env to exercise the production path against
+// a sandbox that supports real signatures, or against production credentials.
+const SANDBOX_MODE = (import.meta.env.VITE_SANDBOX_PASSKEY ?? '1') !== '0'
+
+const SANDBOX_PASSKEY_SIGNATURE = 'sandbox-valid-passkey-signature'
+const SANDBOX_WALLET_SIGNATURE = 'sandbox-valid-signature'
 
 // Step 7: Authenticate with the registered passkey and sign payloadToSign.
-//   1. Generate ephemeral P-256 client key pair (for HPKE recipient).
-//   2. POST /challenge with clientPublicKey — Grid bakes it into the session
-//      creation payload and returns a Grid-issued WebAuthn challenge.
+//
+// Production flow:
+//   1. Generate ephemeral P-256 client key pair (HPKE recipient key).
+//   2. POST /challenge with clientPublicKey — Grid bakes it into the
+//      session-creation payload and returns a Grid-issued WebAuthn challenge.
 //   3. navigator.credentials.get(challenge) → WebAuthn assertion.
 //   4. POST /verify with the assertion (no clientPublicKey on /verify) →
 //      Grid returns encryptedSessionSigningKey sealed to clientPublicKey.
-//   5. HPKE-decrypt the session signing key with the client private key.
-//      DHKEM(P-256, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM, base58check
-//      wire format with a 33-byte compressed encapsulated key prefix.
-//   6. ECDSA-sign payloadToSign bytes with the session key, DER-encode.
-//   In sandbox the encryptedSessionSigningKey is a stub — decrypt fails, so
-//   we fall back to the sandbox magic 'sandbox-valid-signature'.
+//   5. HPKE-decrypt the session signing key with the client private key
+//      (DHKEM-P256 / HKDF-SHA256 / AES-256-GCM, base58check wire format).
+//   6. ECDSA-sign payloadToSign bytes with the session key, DER-encode,
+//      base64-encode, and pass to step 8 as the Grid-Wallet-Signature header.
+//
+// Sandbox flow (this is what runs by default):
+//   - Step 3 still triggers the real OS biometric prompt.
+//   - Step 4's wire signature is the magic value sandbox-valid-passkey-signature.
+//   - Step 5 is skipped (the encryptedSessionSigningKey is a stub in sandbox).
+//   - Step 6 returns the magic value sandbox-valid-signature for step 8.
 export default function AuthenticateAndSign({
   authMethodId,
   payloadToSign,
@@ -43,6 +59,8 @@ export default function AuthenticateAndSign({
     setError(null)
     setResponse(null)
     try {
+      // 1. Ephemeral keypair. Private key is non-extractable; only the public
+      //    key leaves the device.
       const keyPair = (await crypto.subtle.generateKey(
         { name: 'ECDH', namedCurve: 'P-256' },
         false,
@@ -53,11 +71,15 @@ export default function AuthenticateAndSign({
       )
       const clientPublicKey = bytesToHex(rawPublicKey)
 
+      // 2. Ask Grid for an authentication challenge sealed to this public key.
       const challenge = await apiPost<{ challenge: string; requestId: string }>(
         `/api/auth/credentials/${encodeURIComponent(authMethodId)}/challenge`,
         { clientPublicKey },
       )
 
+      // 3. WebAuthn assertion against the Grid-issued challenge. The OS shows
+      //    its biometric prompt regardless of whether we send the real
+      //    signature or the sandbox magic value below.
       const assertion = (await navigator.credentials.get({
         publicKey: {
           challenge: base64urlToBytes(challenge.challenge),
@@ -68,10 +90,12 @@ export default function AuthenticateAndSign({
       if (!assertion) throw new Error('No assertion returned from authenticator')
       const ar = assertion.response as AuthenticatorAssertionResponse
 
-      // Sandbox doesn't validate real WebAuthn signatures yet — it only accepts
-      // the literal "sandbox-valid-passkey-signature". The OS biometric prompt
-      // still runs above; we just substitute the signature on the wire.
-      // Production: replace with bytesToBase64url(new Uint8Array(ar.signature)).
+      // 4. Verify with Grid. In sandbox, swap the real WebAuthn signature for
+      //    the magic value Grid will accept.
+      const wireSignature = SANDBOX_MODE
+        ? SANDBOX_PASSKEY_SIGNATURE
+        : bytesToBase64url(new Uint8Array(ar.signature))
+
       const verify = await apiPost<{ encryptedSessionSigningKey?: string }>(
         `/api/auth/credentials/${encodeURIComponent(authMethodId)}/verify`,
         {
@@ -79,7 +103,7 @@ export default function AuthenticateAndSign({
             credentialId: assertion.id,
             clientDataJson: bytesToBase64url(new Uint8Array(ar.clientDataJSON)),
             authenticatorData: bytesToBase64url(new Uint8Array(ar.authenticatorData)),
-            signature: 'sandbox-valid-passkey-signature',
+            signature: wireSignature,
             userHandle: ar.userHandle
               ? bytesToBase64url(new Uint8Array(ar.userHandle))
               : undefined,
@@ -88,20 +112,27 @@ export default function AuthenticateAndSign({
         { 'Request-Id': challenge.requestId },
       )
 
+      // 5 + 6. Decrypt the session signing key and sign payloadToSign. In
+      //        sandbox the encryptedSessionSigningKey is a stub, so we skip
+      //        the crypto and use the magic wallet-signature header value.
       let signature: string
-      let mode: 'production' | 'sandbox-fallback' = 'production'
-      try {
+      if (SANDBOX_MODE) {
+        signature = SANDBOX_WALLET_SIGNATURE
+      } else {
         const sessionKey = await decryptSessionSigningKey(
           keyPair.privateKey,
           verify.encryptedSessionSigningKey ?? '',
         )
         signature = signPayload(sessionKey, payloadToSign)
-      } catch {
-        mode = 'sandbox-fallback'
-        signature = SANDBOX_SIGNATURE
       }
 
-      setResponse(JSON.stringify({ mode, signature, verify }, null, 2))
+      setResponse(
+        JSON.stringify(
+          { mode: SANDBOX_MODE ? 'sandbox' : 'production', signature, verify },
+          null,
+          2,
+        ),
+      )
       onComplete({ signature })
     } catch (e) {
       setError((e as Error).message)
@@ -117,9 +148,10 @@ export default function AuthenticateAndSign({
       </p>
       <p className="text-xs text-gray-500 mb-3">
         Generates a P-256 keypair, sends the public key on <code>/challenge</code>, runs the
-        WebAuthn assertion, verifies, HPKE-decrypts the session signing key, and ECDSA-signs the
-        payload. In sandbox the decrypt fails (the response is a stub) so the step falls back to
-        the sandbox magic signature.
+        WebAuthn assertion, and verifies. In <strong>sandbox mode</strong> ({SANDBOX_MODE
+          ? 'on'
+          : 'off'}) the wire signatures use Grid's magic values; turn it off via{' '}
+        <code>VITE_SANDBOX_PASSKEY=0</code> to exercise the real HPKE decrypt + ECDSA sign chain.
       </p>
       <button
         onClick={submit}
@@ -133,12 +165,18 @@ export default function AuthenticateAndSign({
   )
 }
 
+// HPKE-decrypt the encrypted session signing key returned by /verify.
+// Wire format (base58check-decoded): 33-byte compressed encapsulated public
+// key || ciphertext || 16-byte AES-256-GCM auth tag.
 async function decryptSessionSigningKey(
   recipientPrivateKey: CryptoKey,
   encryptedSessionSigningKey: string,
 ): Promise<Uint8Array> {
   if (!encryptedSessionSigningKey) throw new Error('No encrypted session signing key returned')
   const payload = bs58check.decode(encryptedSessionSigningKey)
+  if (payload.length < 33 + 16) {
+    throw new Error(`encryptedSessionSigningKey too short: ${payload.length} bytes`)
+  }
   const enc = payload.slice(0, 33)
   const ciphertext = payload.slice(33)
   const suite = new CipherSuite({
@@ -154,6 +192,8 @@ async function decryptSessionSigningKey(
   return new Uint8Array(plaintext)
 }
 
+// Sign payloadToSign bytes verbatim (Grid hashes them on its side as part of
+// signature verification). DER-encoded ECDSA signature, base64-encoded.
 function signPayload(sessionPrivateKey: Uint8Array, payloadToSign: string): string {
   const msg = new TextEncoder().encode(payloadToSign)
   const sig = p256.sign(msg, sessionPrivateKey, { format: 'der' })

--- a/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiPost } from '../../lib/api'
+
+interface Props {
+  authMethodId: string | null
+  payloadToSign: string | null
+  onComplete: (response: { signature: string }) => void
+  disabled: boolean
+}
+
+// Backend routes TODO:
+//   POST /api/auth/credentials/{authMethodId}/challenge → Grid: same path
+//   POST /api/auth/credentials/{authMethodId}/verify    → Grid: same path
+// Client-side crypto required (NOT yet implemented in this scaffold):
+//   1. Generate ephemeral P-256 key pair
+//   2. navigator.credentials.get() with the challenge
+//   3. Send WebAuthn assertion + client public key to /verify
+//   4. HPKE-decrypt the returned session signing key with the client private key
+//   5. ECDSA-sign the quote's payloadToSign bytes (verbatim) with the session key
+// See https://grid.lightspark.com/payouts-and-b2b/embedded-wallets/client-keys
+export default function AuthenticateAndSign({
+  authMethodId,
+  payloadToSign,
+  onComplete,
+  disabled,
+}: Props) {
+  void onComplete // wired up once passkey signing is implemented below
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    if (!authMethodId || !payloadToSign) return
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      // 1. Request a fresh challenge.
+      const challenge = await apiPost<{ challenge: string; requestId: string }>(
+        `/api/auth/credentials/${encodeURIComponent(authMethodId)}/challenge`,
+        {},
+      )
+
+      // 2. Run navigator.credentials.get(), build assertion + client public key,
+      //    POST to /verify, HPKE-decrypt session key, ECDSA-sign payloadToSign.
+      //    Stub for now — see client-keys docs for the full implementation.
+      void challenge
+      throw new Error(
+        'Passkey signing not yet implemented in this sample. See client-keys docs.',
+      )
+
+      // const data = await apiPost<{ signature: string }>(...)
+      // setResponse(JSON.stringify(data, null, 2))
+      // onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Authenticate with the registered passkey and sign the withdrawal payload.
+      </p>
+      <p className="text-xs text-yellow-300/80 mb-3">
+        This step requires P-256 keypair generation, HPKE decryption, and ECDSA signing — left as
+        a TODO in this scaffold.
+      </p>
+      <button
+        onClick={submit}
+        disabled={disabled || loading || !authMethodId || !payloadToSign}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Signing...' : 'Authenticate & Sign'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react'
+import { Aes256Gcm, CipherSuite, DhkemP256HkdfSha256, HkdfSha256 } from '@hpke/core'
+import { p256 } from '@noble/curves/nist.js'
+import bs58check from 'bs58check'
 import ResponsePanel from '../../components/ResponsePanel'
 import { apiPost } from '../../lib/api'
 
@@ -9,23 +12,27 @@ interface Props {
   disabled: boolean
 }
 
-// Backend routes TODO:
-//   POST /api/auth/credentials/{authMethodId}/challenge → Grid: same path
-//   POST /api/auth/credentials/{authMethodId}/verify    → Grid: same path
-// Client-side crypto required (NOT yet implemented in this scaffold):
-//   1. Generate ephemeral P-256 key pair
-//   2. navigator.credentials.get() with the challenge
-//   3. Send WebAuthn assertion + client public key to /verify
-//   4. HPKE-decrypt the returned session signing key with the client private key
-//   5. ECDSA-sign the quote's payloadToSign bytes (verbatim) with the session key
-// See https://grid.lightspark.com/payouts-and-b2b/embedded-wallets/client-keys
+const SANDBOX_SIGNATURE = 'sandbox-valid-signature'
+
+// Step 7: Authenticate with the registered passkey and sign payloadToSign.
+//   1. Generate ephemeral P-256 client key pair (for HPKE recipient).
+//   2. POST /challenge with clientPublicKey — Grid bakes it into the session
+//      creation payload and returns a Grid-issued WebAuthn challenge.
+//   3. navigator.credentials.get(challenge) → WebAuthn assertion.
+//   4. POST /verify with the assertion (no clientPublicKey on /verify) →
+//      Grid returns encryptedSessionSigningKey sealed to clientPublicKey.
+//   5. HPKE-decrypt the session signing key with the client private key.
+//      DHKEM(P-256, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM, base58check
+//      wire format with a 33-byte compressed encapsulated key prefix.
+//   6. ECDSA-sign payloadToSign bytes with the session key, DER-encode.
+//   In sandbox the encryptedSessionSigningKey is a stub — decrypt fails, so
+//   we fall back to the sandbox magic 'sandbox-valid-signature'.
 export default function AuthenticateAndSign({
   authMethodId,
   payloadToSign,
   onComplete,
   disabled,
 }: Props) {
-  void onComplete // wired up once passkey signing is implemented below
   const [response, setResponse] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -36,23 +43,66 @@ export default function AuthenticateAndSign({
     setError(null)
     setResponse(null)
     try {
-      // 1. Request a fresh challenge.
+      const keyPair = (await crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        ['deriveBits'],
+      )) as CryptoKeyPair
+      const rawPublicKey = new Uint8Array(
+        await crypto.subtle.exportKey('raw', keyPair.publicKey),
+      )
+      const clientPublicKey = bytesToHex(rawPublicKey)
+
       const challenge = await apiPost<{ challenge: string; requestId: string }>(
         `/api/auth/credentials/${encodeURIComponent(authMethodId)}/challenge`,
-        {},
+        { clientPublicKey },
       )
 
-      // 2. Run navigator.credentials.get(), build assertion + client public key,
-      //    POST to /verify, HPKE-decrypt session key, ECDSA-sign payloadToSign.
-      //    Stub for now — see client-keys docs for the full implementation.
-      void challenge
-      throw new Error(
-        'Passkey signing not yet implemented in this sample. See client-keys docs.',
+      const assertion = (await navigator.credentials.get({
+        publicKey: {
+          challenge: base64urlToBytes(challenge.challenge),
+          userVerification: 'required',
+          timeout: 60_000,
+        },
+      })) as PublicKeyCredential | null
+      if (!assertion) throw new Error('No assertion returned from authenticator')
+      const ar = assertion.response as AuthenticatorAssertionResponse
+
+      // Sandbox doesn't validate real WebAuthn signatures yet — it only accepts
+      // the literal "sandbox-valid-passkey-signature". The OS biometric prompt
+      // still runs above; we just substitute the signature on the wire.
+      // Production: replace with bytesToBase64url(new Uint8Array(ar.signature)).
+      const verify = await apiPost<{ encryptedSessionSigningKey?: string }>(
+        `/api/auth/credentials/${encodeURIComponent(authMethodId)}/verify`,
+        {
+          assertion: {
+            credentialId: assertion.id,
+            clientDataJson: bytesToBase64url(new Uint8Array(ar.clientDataJSON)),
+            authenticatorData: bytesToBase64url(new Uint8Array(ar.authenticatorData)),
+            signature: 'sandbox-valid-passkey-signature',
+            userHandle: ar.userHandle
+              ? bytesToBase64url(new Uint8Array(ar.userHandle))
+              : undefined,
+          },
+        },
+        { 'Request-Id': challenge.requestId },
       )
 
-      // const data = await apiPost<{ signature: string }>(...)
-      // setResponse(JSON.stringify(data, null, 2))
-      // onComplete(data)
+      let signature: string
+      let mode: 'production' | 'sandbox-fallback' = 'production'
+      try {
+        const sessionKey = await decryptSessionSigningKey(
+          keyPair.privateKey,
+          verify.encryptedSessionSigningKey ?? '',
+        )
+        signature = signPayload(sessionKey, payloadToSign)
+      } catch {
+        mode = 'sandbox-fallback'
+        signature = SANDBOX_SIGNATURE
+      }
+
+      setResponse(JSON.stringify({ mode, signature, verify }, null, 2))
+      onComplete({ signature })
     } catch (e) {
       setError((e as Error).message)
     } finally {
@@ -65,9 +115,11 @@ export default function AuthenticateAndSign({
       <p className="text-sm text-gray-400 mb-2">
         Authenticate with the registered passkey and sign the withdrawal payload.
       </p>
-      <p className="text-xs text-yellow-300/80 mb-3">
-        This step requires P-256 keypair generation, HPKE decryption, and ECDSA signing — left as
-        a TODO in this scaffold.
+      <p className="text-xs text-gray-500 mb-3">
+        Generates a P-256 keypair, sends the public key on <code>/challenge</code>, runs the
+        WebAuthn assertion, verifies, HPKE-decrypts the session signing key, and ECDSA-signs the
+        payload. In sandbox the decrypt fails (the response is a stub) so the step falls back to
+        the sandbox magic signature.
       </p>
       <button
         onClick={submit}
@@ -79,4 +131,57 @@ export default function AuthenticateAndSign({
       <ResponsePanel response={response} error={error} />
     </div>
   )
+}
+
+async function decryptSessionSigningKey(
+  recipientPrivateKey: CryptoKey,
+  encryptedSessionSigningKey: string,
+): Promise<Uint8Array> {
+  if (!encryptedSessionSigningKey) throw new Error('No encrypted session signing key returned')
+  const payload = bs58check.decode(encryptedSessionSigningKey)
+  const enc = payload.slice(0, 33)
+  const ciphertext = payload.slice(33)
+  const suite = new CipherSuite({
+    kem: new DhkemP256HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  })
+  const recipient = await suite.createRecipientContext({
+    recipientKey: recipientPrivateKey,
+    enc,
+  })
+  const plaintext = await recipient.open(ciphertext)
+  return new Uint8Array(plaintext)
+}
+
+function signPayload(sessionPrivateKey: Uint8Array, payloadToSign: string): string {
+  const msg = new TextEncoder().encode(payloadToSign)
+  const sig = p256.sign(msg, sessionPrivateKey, { format: 'der' })
+  return bytesToBase64(sig as Uint8Array)
+}
+
+function base64urlToBytes(s: string): ArrayBuffer {
+  const pad = '='.repeat((4 - (s.length % 4)) % 4)
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/')
+  const bin = atob(b64)
+  const buf = new ArrayBuffer(bin.length)
+  const view = new Uint8Array(buf)
+  for (let i = 0; i < bin.length; i++) view[i] = bin.charCodeAt(i)
+  return buf
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin)
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
 }

--- a/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+import JsonEditor from '../../components/JsonEditor'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiPost } from '../../lib/api'
+
+interface Props {
+  customerId: string | null
+  walletAccountId: string | null
+  externalAccountId: string | null
+  onComplete: (response: { quoteId: string; payloadToSign: string }) => void
+  disabled: boolean
+}
+
+// Backend route: POST /api/quotes (existing)
+// Source for embedded wallet withdrawals is the wallet's internal account.
+export default function CreateWithdrawalQuote({
+  customerId,
+  walletAccountId,
+  externalAccountId,
+  onComplete,
+  disabled,
+}: Props) {
+  const [body, setBody] = useState('')
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setBody(JSON.stringify({
+      source: {
+        sourceType: 'INTERNAL_ACCOUNT',
+        accountId: walletAccountId ?? '<wallet-account-id>',
+        currency: 'USDB',
+      },
+      destination: {
+        destinationType: 'EXTERNAL_ACCOUNT',
+        accountId: externalAccountId ?? '<external-account-id>',
+      },
+      lockedSide: 'SOURCE',
+      sourceAmount: 25_00,
+      customerId: customerId ?? '<customer-id>',
+    }, null, 2))
+  }, [customerId, walletAccountId, externalAccountId])
+
+  const submit = async () => {
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      const data = await apiPost<{
+        id?: string
+        quoteId?: string
+        paymentInstructions?: { payloadToSign?: string }
+        payloadToSign?: string
+      }>('/api/quotes', JSON.parse(body))
+      setResponse(JSON.stringify(data, null, 2))
+      onComplete({
+        quoteId: (data.quoteId ?? data.id) as string,
+        payloadToSign:
+          data.paymentInstructions?.payloadToSign ?? data.payloadToSign ?? '',
+      })
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Generate a withdrawal quote. The response includes a <code>payloadToSign</code> the
+        customer must sign with their passkey before execution.
+      </p>
+      <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
+      <button
+        onClick={submit}
+        disabled={disabled || loading}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Quoting...' : 'Create Withdrawal Quote'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
@@ -11,8 +11,9 @@ interface Props {
   disabled: boolean
 }
 
-// Backend route: POST /api/quotes (existing)
-// Source for embedded wallet withdrawals is the wallet's internal account.
+// Creates a quote with the Global Account as the source. The quote response
+// carries a payloadToSign — step 7 signs it, step 8 executes the quote with
+// that signature in the Grid-Wallet-Signature header.
 export default function CreateWithdrawalQuote({
   customerId,
   walletAccountId,

--- a/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/CreateWithdrawalQuote.tsx
@@ -28,17 +28,18 @@ export default function CreateWithdrawalQuote({
   useEffect(() => {
     setBody(JSON.stringify({
       source: {
-        sourceType: 'INTERNAL_ACCOUNT',
+        sourceType: 'ACCOUNT',
         accountId: walletAccountId ?? '<wallet-account-id>',
-        currency: 'USDB',
+        customerId: customerId ?? '<customer-id>',
       },
       destination: {
-        destinationType: 'EXTERNAL_ACCOUNT',
+        destinationType: 'ACCOUNT',
         accountId: externalAccountId ?? '<external-account-id>',
       },
-      lockedSide: 'SOURCE',
-      sourceAmount: 25_00,
-      customerId: customerId ?? '<customer-id>',
+      lockedCurrencySide: 'SENDING',
+      // USDB has 6 decimals — 10_000_000 minor units = 10 USDB.
+      lockedCurrencyAmount: 10_000_000,
+      description: 'Withdrawal from Global Account',
     }, null, 2))
   }, [customerId, walletAccountId, externalAccountId])
 
@@ -50,14 +51,26 @@ export default function CreateWithdrawalQuote({
       const data = await apiPost<{
         id?: string
         quoteId?: string
-        paymentInstructions?: { payloadToSign?: string }
+        paymentInstructions?: Array<{
+          accountOrWalletInfo?: { accountType?: string; payloadToSign?: string }
+          payloadToSign?: string
+        }>
         payloadToSign?: string
       }>('/api/quotes', JSON.parse(body))
       setResponse(JSON.stringify(data, null, 2))
+      // paymentInstructions is an array — for an embedded-wallet source, look
+      // for the instruction whose accountOrWalletInfo carries the payloadToSign.
+      const signingInstruction = data.paymentInstructions?.find(
+        (i) => i.accountOrWalletInfo?.payloadToSign || i.payloadToSign,
+      )
+      const payloadToSign =
+        signingInstruction?.accountOrWalletInfo?.payloadToSign ??
+        signingInstruction?.payloadToSign ??
+        data.payloadToSign ??
+        ''
       onComplete({
         quoteId: (data.quoteId ?? data.id) as string,
-        payloadToSign:
-          data.paymentInstructions?.payloadToSign ?? data.payloadToSign ?? '',
+        payloadToSign,
       })
     } catch (e) {
       setError((e as Error).message)

--- a/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
@@ -28,7 +28,10 @@ export default function ExecuteSignedQuote({
     setResponse(null)
     try {
       const path = `/api/quotes/${encodeURIComponent(quoteId)}/execute`
-      const data = await apiPost<Record<string, unknown>>(path, { signature })
+      const data = await apiPost<Record<string, unknown>>(path, undefined, {
+        'Grid-Wallet-Signature': signature,
+        'Idempotency-Key': crypto.randomUUID(),
+      })
       setResponse(JSON.stringify(data, null, 2))
       onComplete(data)
     } catch (e) {

--- a/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiPost } from '../../lib/api'
+
+interface Props {
+  quoteId: string | null
+  signature: string | null
+  onComplete: (response: Record<string, unknown>) => void
+  disabled: boolean
+}
+
+// Backend route TODO: POST /api/quotes/{quoteId}/execute
+// Backend forwards to Grid with the `Grid-Wallet-Signature` header set to the base64 signature.
+export default function ExecuteSignedQuote({
+  quoteId,
+  signature,
+  onComplete,
+  disabled,
+}: Props) {
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    if (!quoteId || !signature) return
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      const path = `/api/quotes/${encodeURIComponent(quoteId)}/execute`
+      const data = await apiPost<Record<string, unknown>>(path, { signature })
+      setResponse(JSON.stringify(data, null, 2))
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Submit the signed withdrawal to Grid. The backend forwards the signature in the{' '}
+        <code>Grid-Wallet-Signature</code> header.
+      </p>
+      <button
+        onClick={submit}
+        disabled={disabled || loading || !quoteId || !signature}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Executing...' : 'Execute Withdrawal'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/ExecuteSignedQuote.tsx
@@ -9,8 +9,8 @@ interface Props {
   disabled: boolean
 }
 
-// Backend route TODO: POST /api/quotes/{quoteId}/execute
-// Backend forwards to Grid with the `Grid-Wallet-Signature` header set to the base64 signature.
+// Submits the signed withdrawal. Backend (POST /api/quotes/{quoteId}/execute)
+// forwards Grid-Wallet-Signature and Idempotency-Key headers to Grid.
 export default function ExecuteSignedQuote({
   quoteId,
   signature,

--- a/samples/frontend/src/steps/embeddedWallet/FindEmbeddedWallet.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/FindEmbeddedWallet.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiGet } from '../../lib/api'
+
+interface Props {
+  customerId: string | null
+  onComplete: (response: Record<string, unknown>) => void
+  disabled: boolean
+}
+
+// Backend route TODO: GET /api/internal-accounts?customerId=...&type=EMBEDDED_WALLET
+// → Grid: GET /internal-accounts (filter to EMBEDDED_WALLET)
+export default function FindEmbeddedWallet({ customerId, onComplete, disabled }: Props) {
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    if (!customerId) return
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      const url = `/api/internal-accounts?customerId=${encodeURIComponent(customerId)}&type=EMBEDDED_WALLET`
+      const data = await apiGet<Record<string, unknown>>(url)
+      setResponse(JSON.stringify(data, null, 2))
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Locate the embedded wallet auto-provisioned for this customer.
+      </p>
+      <pre className="text-xs bg-gray-950 border border-gray-800 rounded p-3 mb-2 overflow-x-auto">
+        GET /internal-accounts?customerId={customerId ?? '<customer-id>'}&type=EMBEDDED_WALLET
+      </pre>
+      <button
+        onClick={submit}
+        disabled={disabled || loading || !customerId}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Looking up...' : 'Find Wallet'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/embeddedWallet/FindEmbeddedWallet.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/FindEmbeddedWallet.tsx
@@ -8,8 +8,8 @@ interface Props {
   disabled: boolean
 }
 
-// Backend route TODO: GET /api/internal-accounts?customerId=...&type=EMBEDDED_WALLET
-// → Grid: GET /internal-accounts (filter to EMBEDDED_WALLET)
+// Lists the customer's internal accounts and surfaces the auto-provisioned
+// Global Account (type: EMBEDDED_WALLET) so subsequent steps can reference it.
 export default function FindEmbeddedWallet({ customerId, onComplete, disabled }: Props) {
   const [response, setResponse] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)

--- a/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
@@ -9,8 +9,8 @@ interface Props {
   disabled: boolean
 }
 
-// Backend route TODO: POST /api/sandbox/internal-accounts/{id}/fund
-// → Grid: POST /sandbox/internal-accounts/{id}/fund
+// Sandbox-only: deposits funds straight into the Global Account so the
+// withdrawal flow has a balance to draw from.
 export default function FundEmbeddedWallet({ walletAccountId, onComplete, disabled }: Props) {
   const [body, setBody] = useState('')
   const [response, setResponse] = useState<string | null>(null)

--- a/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import JsonEditor from '../../components/JsonEditor'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiPost } from '../../lib/api'
+
+interface Props {
+  walletAccountId: string | null
+  onComplete: (response: Record<string, unknown>) => void
+  disabled: boolean
+}
+
+// Backend route TODO: POST /api/sandbox/internal-accounts/{id}/fund
+// → Grid: POST /sandbox/internal-accounts/{id}/fund
+export default function FundEmbeddedWallet({ walletAccountId, onComplete, disabled }: Props) {
+  const [body, setBody] = useState('')
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setBody(JSON.stringify({
+      currencyCode: 'USDB',
+      currencyAmount: 100_00, // 100.00 USDB in minor units
+    }, null, 2))
+  }, [walletAccountId])
+
+  const submit = async () => {
+    if (!walletAccountId) return
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      const path = `/api/sandbox/internal-accounts/${encodeURIComponent(walletAccountId)}/fund`
+      const data = await apiPost<Record<string, unknown>>(path, JSON.parse(body))
+      setResponse(JSON.stringify(data, null, 2))
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Sandbox-only: deposit funds into the embedded wallet.
+      </p>
+      <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
+      <button
+        onClick={submit}
+        disabled={disabled || loading || !walletAccountId}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Funding...' : 'Fund Wallet'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/FundEmbeddedWallet.tsx
@@ -20,7 +20,7 @@ export default function FundEmbeddedWallet({ walletAccountId, onComplete, disabl
   useEffect(() => {
     setBody(JSON.stringify({
       currencyCode: 'USDB',
-      currencyAmount: 100_00, // 100.00 USDB in minor units
+      currencyAmount: 100_000_000, // 100 USDB (6 decimals)
     }, null, 2))
   }, [walletAccountId])
 

--- a/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
@@ -9,10 +9,9 @@ interface Props {
   disabled: boolean
 }
 
-// Backend route TODO: POST /api/auth/credentials
-// Two-phase: client gets a registration challenge, runs navigator.credentials.create(),
-// then posts the WebAuthn attestation to the backend, which forwards to Grid.
-// See https://grid.lightspark.com/payouts-and-b2b/embedded-wallets/authentication
+// Two-phase: backend mints a WebAuthn challenge, client runs
+// navigator.credentials.create(), client posts the attestation back, backend
+// forwards to Grid as POST /auth/credentials.
 export default function RegisterPasskey({
   walletAccountId,
   customerId,
@@ -29,24 +28,23 @@ export default function RegisterPasskey({
     setError(null)
     setResponse(null)
     try {
-      // Step 1: ask backend for a registration challenge from Grid.
-      const challenge = await apiPost<{
+      const reg = await apiPost<{
         challenge: string
         rp: PublicKeyCredentialRpEntity
         user: { id: string; name: string; displayName: string }
       }>('/api/auth/credentials/registration-challenge', {
         accountId: walletAccountId,
         customerId,
+        rpId: window.location.hostname,
       })
 
-      // Step 2: invoke the platform authenticator.
       const credential = (await navigator.credentials.create({
         publicKey: {
-          challenge: base64urlToBytes(challenge.challenge),
-          rp: challenge.rp,
+          challenge: base64urlToBytes(reg.challenge),
+          rp: reg.rp,
           user: {
-            ...challenge.user,
-            id: base64urlToBytes(challenge.user.id),
+            ...reg.user,
+            id: base64urlToBytes(reg.user.id),
           },
           pubKeyCredParams: [
             { type: 'public-key', alg: -7 },   // ES256
@@ -60,17 +58,26 @@ export default function RegisterPasskey({
       if (!credential) throw new Error('No credential returned from authenticator')
 
       const att = credential.response as AuthenticatorAttestationResponse
+      const transports =
+        (att as AuthenticatorAttestationResponse & { getTransports?: () => string[] })
+          .getTransports?.() ?? []
 
-      // Step 3: send the attestation to the backend → Grid.
-      const data = await apiPost<{ authMethodId: string }>('/api/auth/credentials', {
+      const data = await apiPost<Record<string, unknown>>('/api/auth/credentials', {
         accountId: walletAccountId,
-        credentialId: credential.id,
-        clientDataJSON: bytesToBase64url(new Uint8Array(att.clientDataJSON)),
-        attestationObject: bytesToBase64url(new Uint8Array(att.attestationObject)),
+        challenge: reg.challenge,
+        nickname: 'Grid Global Account passkey',
+        attestation: {
+          credentialId: credential.id,
+          clientDataJson: bytesToBase64url(new Uint8Array(att.clientDataJSON)),
+          attestationObject: bytesToBase64url(new Uint8Array(att.attestationObject)),
+          transports,
+        },
       })
 
       setResponse(JSON.stringify(data, null, 2))
-      onComplete(data)
+      const authMethodId = (data.id ?? data.authMethodId) as string | undefined
+      if (!authMethodId) throw new Error('No auth method id in response')
+      onComplete({ authMethodId })
     } catch (e) {
       setError((e as Error).message)
     } finally {
@@ -81,11 +88,10 @@ export default function RegisterPasskey({
   return (
     <div>
       <p className="text-sm text-gray-400 mb-2">
-        Register a passkey on this device to authorize future withdrawals.
+        Register a passkey on this device to authorize future Grid Global Account actions.
       </p>
       <p className="text-xs text-yellow-300/80 mb-3">
-        Requires a backend that proxies <code>POST /auth/credentials</code> and a registration
-        challenge endpoint. WebAuthn requires HTTPS or localhost.
+        Your browser will prompt for a biometric. WebAuthn requires HTTPS or localhost.
       </p>
       <button
         onClick={submit}

--- a/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import ResponsePanel from '../../components/ResponsePanel'
+import { apiPost } from '../../lib/api'
+
+interface Props {
+  walletAccountId: string | null
+  customerId: string | null
+  onComplete: (response: { authMethodId: string }) => void
+  disabled: boolean
+}
+
+// Backend route TODO: POST /api/auth/credentials
+// Two-phase: client gets a registration challenge, runs navigator.credentials.create(),
+// then posts the WebAuthn attestation to the backend, which forwards to Grid.
+// See https://grid.lightspark.com/payouts-and-b2b/embedded-wallets/authentication
+export default function RegisterPasskey({
+  walletAccountId,
+  customerId,
+  onComplete,
+  disabled,
+}: Props) {
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    if (!walletAccountId || !customerId) return
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      // Step 1: ask backend for a registration challenge from Grid.
+      const challenge = await apiPost<{
+        challenge: string
+        rp: PublicKeyCredentialRpEntity
+        user: { id: string; name: string; displayName: string }
+      }>('/api/auth/credentials/registration-challenge', {
+        accountId: walletAccountId,
+        customerId,
+      })
+
+      // Step 2: invoke the platform authenticator.
+      const credential = (await navigator.credentials.create({
+        publicKey: {
+          challenge: base64urlToBytes(challenge.challenge),
+          rp: challenge.rp,
+          user: {
+            ...challenge.user,
+            id: base64urlToBytes(challenge.user.id),
+          },
+          pubKeyCredParams: [
+            { type: 'public-key', alg: -7 },   // ES256
+            { type: 'public-key', alg: -257 }, // RS256
+          ],
+          authenticatorSelection: { userVerification: 'required' },
+          timeout: 60_000,
+        },
+      })) as PublicKeyCredential | null
+
+      if (!credential) throw new Error('No credential returned from authenticator')
+
+      const att = credential.response as AuthenticatorAttestationResponse
+
+      // Step 3: send the attestation to the backend → Grid.
+      const data = await apiPost<{ authMethodId: string }>('/api/auth/credentials', {
+        accountId: walletAccountId,
+        credentialId: credential.id,
+        clientDataJSON: bytesToBase64url(new Uint8Array(att.clientDataJSON)),
+        attestationObject: bytesToBase64url(new Uint8Array(att.attestationObject)),
+      })
+
+      setResponse(JSON.stringify(data, null, 2))
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Register a passkey on this device to authorize future withdrawals.
+      </p>
+      <p className="text-xs text-yellow-300/80 mb-3">
+        Requires a backend that proxies <code>POST /auth/credentials</code> and a registration
+        challenge endpoint. WebAuthn requires HTTPS or localhost.
+      </p>
+      <button
+        onClick={submit}
+        disabled={disabled || loading || !walletAccountId}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Registering...' : 'Register Passkey'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}
+
+function base64urlToBytes(s: string): ArrayBuffer {
+  const pad = '='.repeat((4 - (s.length % 4)) % 4)
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/')
+  const bin = atob(b64)
+  const buf = new ArrayBuffer(bin.length)
+  const view = new Uint8Array(buf)
+  for (let i = 0; i < bin.length; i++) view[i] = bin.charCodeAt(i)
+  return buf
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/samples/kotlin/build.gradle.kts
+++ b/samples/kotlin/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("io.ktor:ktor-server-config-yaml:3.1.3")
 
     // Grid Kotlin SDK
-    implementation("com.lightspark.grid:lightspark-grid-kotlin:1.6.0")
+    implementation("com.lightspark.grid:lightspark-grid-kotlin:1.7.0")
 
     // JSON
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")

--- a/samples/kotlin/build.gradle.kts
+++ b/samples/kotlin/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("io.ktor:ktor-server-config-yaml:3.1.3")
 
     // Grid Kotlin SDK
-    implementation("com.lightspark.grid:lightspark-grid-kotlin:1.7.0")
+    implementation("com.lightspark.grid:lightspark-grid-kotlin:1.7.1")
 
     // JSON
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/Application.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/Application.kt
@@ -36,6 +36,8 @@ fun Application.module() {
     routing {
         customerRoutes()
         externalAccountRoutes()
+        internalAccountRoutes()
+        authCredentialRoutes()
         quoteRoutes()
         sandboxRoutes()
         webhookRoutes()

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
@@ -136,13 +136,23 @@ fun Route.authCredentialRoutes() {
                         ContentType.Application.Json,
                         HttpStatusCode.BadRequest
                     )
-                Log.incoming("POST", "/api/auth/credentials/$authMethodId/challenge")
+                // Body is required for PASSKEY (carries clientPublicKey so Grid can
+                // seal the session signing key to the device). Empty body is fine
+                // for EMAIL_OTP and OAUTH.
+                val body = runCatching { call.receiveText() }.getOrDefault("")
+                val clientPublicKey = body.takeIf { it.isNotBlank() }
+                    ?.let { JsonUtils.mapper.readTree(it).optText("clientPublicKey") }
+                Log.incoming("POST", "/api/auth/credentials/$authMethodId/challenge", body)
 
                 val params = CredentialResendChallengeParams.builder()
                     .id(authMethodId)
+                    .apply { clientPublicKey?.let { clientPublicKey(it) } }
                     .build()
 
-                Log.gridRequest("auth.credentials.resendChallenge", "id=$authMethodId")
+                Log.gridRequest(
+                    "auth.credentials.resendChallenge",
+                    "id=$authMethodId clientPublicKey=${clientPublicKey != null}",
+                )
                 val response = GridClientBuilder.client.auth().credentials().resendChallenge(params)
                 val responseJson = JsonUtils.prettyPrint(response)
                 Log.gridResponse("auth.credentials.resendChallenge", responseJson)
@@ -191,9 +201,10 @@ fun Route.authCredentialRoutes() {
                     }
                     .build()
 
+                // clientPublicKey moved to /challenge in SDK 1.7.x; verify carries
+                // the assertion only.
                 val verifyRequest = PasskeyCredentialVerifyRequest.builder()
                     .type(PasskeyCredentialVerifyRequest.Type.PASSKEY)
-                    .clientPublicKey(json.get("clientPublicKey").asText())
                     .assertion(assertion)
                     .build()
 

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
@@ -1,0 +1,222 @@
+package com.grid.sample.routes
+
+import com.lightspark.grid.models.auth.credentials.CredentialCreateParams.AuthCredentialCreateRequest.PasskeyCredentialCreateRequest
+import com.lightspark.grid.models.auth.credentials.CredentialResendChallengeParams
+import com.lightspark.grid.models.auth.credentials.CredentialVerifyParams
+import com.lightspark.grid.models.auth.credentials.CredentialVerifyParams.AuthCredentialVerifyRequest.PasskeyCredentialVerifyRequest
+import com.grid.sample.GridClientBuilder
+import com.grid.sample.JsonUtils
+import com.grid.sample.Log
+import com.grid.sample.optText
+import io.ktor.http.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+// Backend-issued WebAuthn registration challenges. Production integrators would
+// keep these in their session store; an in-memory map is sufficient for the sample.
+private object RegistrationChallengeStore {
+    private val random = SecureRandom()
+    private val store = ConcurrentHashMap<String, Long>()
+    private const val TTL_MS = 5 * 60 * 1000L
+
+    fun mint(): String {
+        val bytes = ByteArray(32).also(random::nextBytes)
+        val challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+        store[challenge] = System.currentTimeMillis() + TTL_MS
+        return challenge
+    }
+
+    fun consume(challenge: String): Boolean {
+        val expiresAt = store.remove(challenge) ?: return false
+        return System.currentTimeMillis() < expiresAt
+    }
+}
+
+fun Route.authCredentialRoutes() {
+    route("/api/auth/credentials") {
+        // Mints a WebAuthn registration challenge plus the rp/user blocks the
+        // client needs to feed navigator.credentials.create(). Backend-only —
+        // not a Grid endpoint.
+        post("/registration-challenge") {
+            val body = call.receiveText()
+            Log.incoming("POST", "/api/auth/credentials/registration-challenge", body)
+            val json = JsonUtils.mapper.readTree(body)
+            val accountId = json.optText("accountId") ?: ""
+            val customerId = json.optText("customerId") ?: ""
+            // rpId must match the page's effective domain. Frontend supplies its
+            // window.location.hostname so the same backend works for any host.
+            val rpId = json.optText("rpId") ?: "localhost"
+
+            val challenge = RegistrationChallengeStore.mint()
+            // user.id is opaque to the relying party but must be stable per
+            // Global Account; account id is a natural choice.
+            val userIdSeed = accountId.ifEmpty { "anonymous-${System.nanoTime()}" }
+            val userId = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(userIdSeed.toByteArray())
+
+            val response = mapOf(
+                "challenge" to challenge,
+                "rp" to mapOf("id" to rpId, "name" to "Grid Sample"),
+                "user" to mapOf(
+                    "id" to userId,
+                    "name" to customerId.ifEmpty { "global-account-user" },
+                    "displayName" to "Grid Global Account",
+                ),
+            )
+            call.respondText(
+                JsonUtils.prettyPrint(response),
+                ContentType.Application.Json,
+                HttpStatusCode.OK
+            )
+        }
+
+        // Registers a passkey with Grid. Expects the WebAuthn attestation from
+        // the client plus the challenge originally minted above.
+        post {
+            try {
+                val body = call.receiveText()
+                val json = JsonUtils.mapper.readTree(body)
+                Log.incoming("POST", "/api/auth/credentials", body)
+
+                val challenge = json.optText("challenge")
+                    ?: throw IllegalArgumentException("challenge is required")
+                if (!RegistrationChallengeStore.consume(challenge)) {
+                    return@post call.respondText(
+                        """{"error": "challenge is invalid or expired"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                }
+
+                val attestationNode = json.get("attestation")
+                    ?: throw IllegalArgumentException("attestation is required")
+                val attestation = PasskeyCredentialCreateRequest.Attestation.builder()
+                    .credentialId(attestationNode.get("credentialId").asText())
+                    .clientDataJson(attestationNode.get("clientDataJson").asText())
+                    .attestationObject(attestationNode.get("attestationObject").asText())
+                    .build()
+
+                val request = PasskeyCredentialCreateRequest.builder()
+                    .type(PasskeyCredentialCreateRequest.Type.PASSKEY)
+                    .accountId(json.get("accountId").asText())
+                    .challenge(challenge)
+                    .attestation(attestation)
+                    .apply {
+                        json.optText("nickname")?.let { nickname(it) }
+                    }
+                    .build()
+
+                Log.gridRequest("auth.credentials.create", JsonUtils.prettyPrint(request))
+                val response = GridClientBuilder.client.auth().credentials().create(request)
+                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridResponse("auth.credentials.create", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+            } catch (e: Exception) {
+                Log.gridError("auth.credentials.create", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        // Issues a fresh challenge for an already-registered credential, used
+        // before signing a sensitive action (withdrawal, revoke, export).
+        post("/{authMethodId}/challenge") {
+            try {
+                val authMethodId = call.parameters["authMethodId"]
+                    ?: return@post call.respondText(
+                        """{"error": "authMethodId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                Log.incoming("POST", "/api/auth/credentials/$authMethodId/challenge")
+
+                val params = CredentialResendChallengeParams.builder()
+                    .id(authMethodId)
+                    .build()
+
+                Log.gridRequest("auth.credentials.resendChallenge", "id=$authMethodId")
+                val response = GridClientBuilder.client.auth().credentials().resendChallenge(params)
+                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridResponse("auth.credentials.resendChallenge", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("auth.credentials.resendChallenge", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        // Verifies a passkey assertion and mints a session signing key. The client
+        // decrypts encryptedSessionSigningKey with the matching client private key
+        // and uses it to sign payloadToSign for the next sensitive action.
+        post("/{authMethodId}/verify") {
+            try {
+                val authMethodId = call.parameters["authMethodId"]
+                    ?: return@post call.respondText(
+                        """{"error": "authMethodId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                val requestId = call.request.headers["Request-Id"]
+                    ?: return@post call.respondText(
+                        """{"error": "Request-Id header is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                val body = call.receiveText()
+                val json = JsonUtils.mapper.readTree(body)
+                Log.incoming("POST", "/api/auth/credentials/$authMethodId/verify", body)
+
+                val assertionNode = json.get("assertion")
+                    ?: throw IllegalArgumentException("assertion is required")
+                val assertion = PasskeyCredentialVerifyRequest.Assertion.builder()
+                    .credentialId(assertionNode.get("credentialId").asText())
+                    .clientDataJson(assertionNode.get("clientDataJson").asText())
+                    .authenticatorData(assertionNode.get("authenticatorData").asText())
+                    .signature(assertionNode.get("signature").asText())
+                    .apply {
+                        assertionNode.optText("userHandle")?.let { userHandle(it) }
+                    }
+                    .build()
+
+                val verifyRequest = PasskeyCredentialVerifyRequest.builder()
+                    .type(PasskeyCredentialVerifyRequest.Type.PASSKEY)
+                    .clientPublicKey(json.get("clientPublicKey").asText())
+                    .assertion(assertion)
+                    .build()
+
+                val params = CredentialVerifyParams.builder()
+                    .id(authMethodId)
+                    .requestId(requestId)
+                    .authCredentialVerifyRequest(verifyRequest)
+                    .build()
+
+                Log.gridRequest("auth.credentials.verify", "id=$authMethodId requestId=$requestId")
+                val response = GridClientBuilder.client.auth().credentials().verify(params)
+                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridResponse("auth.credentials.verify", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("auth.credentials.verify", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+    }
+}

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
@@ -45,18 +45,23 @@ fun Route.authCredentialRoutes() {
             val body = call.receiveText()
             Log.incoming("POST", "/api/auth/credentials/registration-challenge", body)
             val json = JsonUtils.mapper.readTree(body)
-            val accountId = json.optText("accountId") ?: ""
+            // accountId is the Global Account id the credential will be bound
+            // to. user.id derives from it so the authenticator can recognize
+            // the same user across registration attempts on the same device.
+            val accountId = json.optText("accountId")
+                ?: return@post call.respondText(
+                    """{"error": "accountId is required"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.BadRequest
+                )
             val customerId = json.optText("customerId") ?: ""
-            // rpId must match the page's effective domain. Frontend supplies its
-            // window.location.hostname so the same backend works for any host.
+            // rpId must match the page's effective domain. The frontend sends
+            // window.location.hostname so the same backend works on any host.
             val rpId = json.optText("rpId") ?: "localhost"
 
             val challenge = RegistrationChallengeStore.mint()
-            // user.id is opaque to the relying party but must be stable per
-            // Global Account; account id is a natural choice.
-            val userIdSeed = accountId.ifEmpty { "anonymous-${System.nanoTime()}" }
             val userId = Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(userIdSeed.toByteArray())
+                .encodeToString(accountId.toByteArray())
 
             val response = mapOf(
                 "challenge" to challenge,

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/InternalAccounts.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/InternalAccounts.kt
@@ -1,0 +1,57 @@
+package com.grid.sample.routes
+
+import com.lightspark.grid.models.customers.CustomerListInternalAccountsParams
+import com.grid.sample.GridClientBuilder
+import com.grid.sample.JsonUtils
+import com.grid.sample.Log
+import io.ktor.http.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+// Lists a customer's internal accounts. Used by the frontend to find the
+// auto-provisioned Grid Global Account (filtered by type=EMBEDDED_WALLET).
+fun Route.internalAccountRoutes() {
+    route("/api/internal-accounts") {
+        get {
+            try {
+                val customerId = call.request.queryParameters["customerId"]
+                    ?: return@get call.respondText(
+                        """{"error": "customerId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                val typeParam = call.request.queryParameters["type"]
+                Log.incoming("GET", "/api/internal-accounts?customerId=$customerId&type=$typeParam")
+
+                val params = CustomerListInternalAccountsParams.builder()
+                    .customerId(customerId)
+                    .apply {
+                        typeParam?.let { type(CustomerListInternalAccountsParams.Type.of(it)) }
+                    }
+                    .build()
+
+                Log.gridRequest("customers.listInternalAccounts", "customerId=$customerId type=$typeParam")
+                val page = GridClientBuilder.client.customers().listInternalAccounts(params)
+                // Page wraps a service reference Jackson can't serialize; flatten to its response shape.
+                val responsePayload = mapOf(
+                    "data" to page.data(),
+                    "hasMore" to page.hasMore(),
+                    "nextCursor" to page.nextCursor(),
+                    "totalCount" to page.totalCount(),
+                )
+                val responseJson = JsonUtils.prettyPrint(responsePayload)
+                Log.gridResponse("customers.listInternalAccounts", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("customers.listInternalAccounts", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+    }
+}

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Quotes.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Quotes.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.lightspark.grid.models.quotes.QuoteCreateParams
 import com.lightspark.grid.models.quotes.QuoteCreateParams.LockedCurrencySide
 import com.lightspark.grid.models.quotes.QuoteCreateParams.PurposeOfPayment
+import com.lightspark.grid.models.quotes.QuoteExecuteParams
 import com.lightspark.grid.models.quotes.QuoteSourceOneOf
 import com.lightspark.grid.models.quotes.QuoteSourceOneOf.AccountQuoteSource
 import com.lightspark.grid.models.quotes.QuoteSourceOneOf.RealtimeFundingQuoteSource
@@ -74,9 +75,22 @@ fun Route.quoteRoutes() {
                         HttpStatusCode.BadRequest
                     )
 
+                // Withdrawals from a Global Account require a client-supplied
+                // Grid-Wallet-Signature; for non-wallet quotes the header is absent.
+                val signature = call.request.headers["Grid-Wallet-Signature"]
+                val idempotencyKey = call.request.headers["Idempotency-Key"]
                 Log.incoming("POST", "/api/quotes/$quoteId/execute")
-                Log.gridRequest("quotes.execute", "quoteId=$quoteId")
-                val quote = GridClientBuilder.client.quotes().execute(quoteId)
+
+                val params = QuoteExecuteParams.builder()
+                    .quoteId(quoteId)
+                    .apply {
+                        signature?.let { gridWalletSignature(it) }
+                        idempotencyKey?.let { idempotencyKey(it) }
+                    }
+                    .build()
+
+                Log.gridRequest("quotes.execute", "quoteId=$quoteId signed=${signature != null}")
+                val quote = GridClientBuilder.client.quotes().execute(params)
                 val responseJson = JsonUtils.prettyPrint(quote)
                 Log.gridResponse("quotes.execute", responseJson)
 

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Sandbox.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Sandbox.kt
@@ -2,6 +2,7 @@ package com.grid.sample.routes
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.lightspark.grid.models.sandbox.SandboxSendFundsParams
+import com.lightspark.grid.models.sandbox.internalaccounts.InternalAccountFundParams
 import com.grid.sample.GridClientBuilder
 import com.grid.sample.JsonUtils
 import com.grid.sample.Log
@@ -13,6 +14,39 @@ import io.ktor.server.routing.*
 
 fun Route.sandboxRoutes() {
     route("/api/sandbox") {
+        post("/internal-accounts/{accountId}/fund") {
+            try {
+                val accountId = call.parameters["accountId"]
+                    ?: return@post call.respondText(
+                        """{"error": "accountId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                val body = call.receiveText()
+                val json = JsonUtils.mapper.readTree(body)
+                Log.incoming("POST", "/api/sandbox/internal-accounts/$accountId/fund", body)
+
+                val params = InternalAccountFundParams.builder()
+                    .accountId(accountId)
+                    .amount(json.get("amount").asLong())
+                    .build()
+
+                Log.gridRequest("sandbox.internalAccounts.fund", body)
+                val response = GridClientBuilder.client.sandbox().internalAccounts().fund(params)
+                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridResponse("sandbox.internalAccounts.fund", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("sandbox.internalAccounts.fund", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
         post("/send-funds") {
             try {
                 val body = call.receiveText()

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Sandbox.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Sandbox.kt
@@ -26,9 +26,13 @@ fun Route.sandboxRoutes() {
                 val json = JsonUtils.mapper.readTree(body)
                 Log.incoming("POST", "/api/sandbox/internal-accounts/$accountId/fund", body)
 
+                val amount = (json.get("amount") ?: json.get("currencyAmount"))
+                    ?.takeIf { !it.isNull }
+                    ?.asLong()
+                    ?: throw IllegalArgumentException("amount (or currencyAmount) is required")
                 val params = InternalAccountFundParams.builder()
                     .accountId(accountId)
-                    .amount(json.get("amount").asLong())
+                    .amount(amount)
                     .build()
 
                 Log.gridRequest("sandbox.internalAccounts.fund", body)


### PR DESCRIPTION
feat(sample): scaffold embedded wallet flow with sidebar nav

Restructure the frontend sample to host multiple flows. Extracts the
existing payout wizard into PayoutFlow, adds a left Sidebar to switch
between flows, and scaffolds an EmbeddedWalletFlow with eight steps
(create customer, find embedded wallet, register passkey, sandbox fund,
add external account, withdrawal quote, authenticate & sign, execute).

The passkey signing step (P-256 keypair / HPKE decrypt / ECDSA sign)
is left as a documented TODO. Backend Kotlin routes for the new
endpoints (/api/internal-accounts, /api/auth/credentials*,
/api/sandbox/internal-accounts/{id}/fund, /api/quotes/{id}/execute)
are not yet implemented.

Also docks the WebhookStream to the bottom as a collapsible panel
so it sits below all flows and frees the main column for step UI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(sample): wire embedded wallet backend on Kotlin SDK 1.7.0

Bumps the Kotlin sample to lightspark-grid-kotlin 1.7.0 and adds
the routes the frontend scaffold needs:

- GET /api/internal-accounts → customers().listInternalAccounts(...)
  (used to find the auto-provisioned Grid Global Account)
- POST /api/auth/credentials/registration-challenge → backend-only;
  mints a 32-byte WebAuthn challenge with rp + user blocks for
  navigator.credentials.create()
- POST /api/auth/credentials → auth().credentials().create(...)
  with passkey attestation
- POST /api/auth/credentials/{id}/challenge → resendChallenge(...)
- POST /api/auth/credentials/{id}/verify → credentials().verify(...)
- POST /api/sandbox/internal-accounts/{id}/fund → sandbox per-account
  funding via sandbox().internalAccounts().fund(...)
- /api/quotes/{id}/execute now reads Grid-Wallet-Signature and
  Idempotency-Key headers and forwards them via QuoteExecuteParams

Frontend RegisterPasskey now sends the rpId from window.location and
posts the nested {challenge, attestation: {credentialId,
clientDataJson, attestationObject, transports}} shape that matches
Grid's create endpoint.

Live-tested against sandbox: customer create, listInternalAccounts,
challenge mint, sandbox fund, and resendChallenge all reach Grid
correctly. Passkey registration is wired end-to-end including the
WebAuthn ceremony, but Grid sandbox currently returns
501 NOT_IMPLEMENTED for PASSKEY creation — works once that lands.

API contract preserved verbatim: EMBEDDED_WALLET enum,
Grid-Wallet-Signature header, EmbeddedWallet:/InternalAccount: id
prefixes, and SDK type names are unchanged. User-facing prose uses
"Grid Global Account".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>