### PR TITLE
docs: move passkey clientPublicKey from /verify to /challenge

### DIFF
--- a/mintlify/snippets/global-accounts/authentication.mdx
+++ b/mintlify/snippets/global-accounts/authentication.mdx
@@ -10,18 +10,22 @@ A single internal account can hold one credential of each type concurrently. Onl
 
 ## Registration vs. verification
 
-Every credential type uses the same two-step shape:
+Every credential type starts the same way:
 
-1. **`POST /auth/credentials`** creates the credential record. This triggers the out-of-band channel (OTP email sent, WebAuthn attestation stored) but does not yet issue a session.
-2. **`POST /auth/credentials/{id}/verify`** completes activation by presenting proof of control (the OTP value, a fresh OIDC token, or a WebAuthn assertion) plus a `clientPublicKey`. The response carries the `encryptedSessionSigningKey`.
+1. **`POST /auth/credentials`** creates the credential record and triggers the out-of-band channel (OTP email sent, WebAuthn attestation stored). The response is a plain `AuthMethod` for all three credential types — registration alone does not issue a session.
 
-Re-authentication after a session expires skips the original `POST /auth/credentials` create call, but still needs a fresh challenge for `PASSKEY` and `EMAIL_OTP` — call `POST /auth/credentials/{id}/challenge` first (to re-issue the WebAuthn challenge or send a new OTP email), then `POST /auth/credentials/{id}/verify`. `OAUTH` is the exception — since proof of control is a fresh OIDC token, there's nothing to pre-issue, so `/verify` alone suffices. Each credential type's re-auth path is covered in its section below.
+To produce the first session:
+
+- **`EMAIL_OTP`** and **`OAUTH`** — call **`POST /auth/credentials/{id}/verify`** with the OTP value (or a fresh OIDC token) plus a `clientPublicKey`. The response carries the `encryptedSessionSigningKey`.
+- **`PASSKEY`** — call **`POST /auth/credentials/{id}/challenge`** with your `clientPublicKey` to receive a Grid-issued WebAuthn `challenge` and `requestId`, run `navigator.credentials.get()` against that challenge, then call **`POST /auth/credentials/{id}/verify`** with the resulting assertion and the `Request-Id` header. Grid bakes the `clientPublicKey` from the `/challenge` call into the session-creation payload, so it does **not** appear on the `/verify` body.
+
+Re-authentication after a session expires skips the original `POST /auth/credentials` create call but otherwise follows the same per-type pattern. `EMAIL_OTP` re-auth needs a fresh OTP email, so call `POST /auth/credentials/{id}/challenge` first; `PASSKEY` re-auth uses the same `/challenge` (with `clientPublicKey`) → `/verify` two-step as the first authentication; `OAUTH` is the exception — since proof of control is a fresh OIDC token, there's nothing to pre-issue, so `/verify` alone suffices.
 
 ## Passkey
 
 ### Passkey registration
 
-Passkey registration spans four parties: the **client** (browser or app), your **integrator backend**, **Grid**, and the platform authenticator (Touch ID / Face ID / Windows Hello / a security key). Your backend issues the WebAuthn registration challenge; Grid issues the subsequent authentication challenge used to prove that the passkey actually works end-to-end before a session is issued.
+Passkey registration spans four parties: the **client** (browser or app), your **integrator backend**, **Grid**, and the platform authenticator (Touch ID / Face ID / Windows Hello / a security key). Your backend issues the WebAuthn registration challenge; the first authentication challenge is requested explicitly via `POST /auth/credentials/{id}/challenge` — same call shape used for every subsequent reauthentication.
 
 ```mermaid
 sequenceDiagram
@@ -37,19 +41,23 @@ sequenceDiagram
   A-->>C: attestation (credentialId, clientDataJson, attestationObject)
   C->>IB: POST /my-backend/passkey/register (attestation)
   IB->>G: POST /auth/credentials { type: PASSKEY, challenge, attestation, … }
-  G-->>IB: 201 PasskeyAuthChallenge { id, challenge, requestId, expiresAt }
-  IB-->>C: { credentialId, gridChallenge, requestId }
+  G-->>IB: 201 AuthMethod { id, type, accountId, … }
+  IB-->>C: { credentialId }
   C->>C: generateClientKeyPair()
-  C->>A: navigator.credentials.get({ challenge: gridChallenge, … })
+  C->>IB: POST /my-backend/passkey/challenge (clientPublicKey)
+  IB->>G: POST /auth/credentials/{id}/challenge<br/>{ clientPublicKey }
+  G-->>IB: 200 PasskeyAuthChallenge { challenge, requestId, expiresAt }
+  IB-->>C: { challenge, requestId }
+  C->>A: navigator.credentials.get({ challenge, … })
   A-->>C: assertion (credentialId, clientDataJson, authenticatorData, signature)
-  C->>IB: POST /my-backend/passkey/verify (assertion, clientPublicKey)
-  IB->>G: POST /auth/credentials/{id}/verify<br/>Request-Id: requestId<br/>{ type: PASSKEY, assertion, clientPublicKey }
+  C->>IB: POST /my-backend/passkey/verify (assertion, requestId)
+  IB->>G: POST /auth/credentials/{id}/verify<br/>Request-Id: requestId<br/>{ type: PASSKEY, assertion }
   G-->>IB: 200 AuthSession { encryptedSessionSigningKey, expiresAt }
   IB-->>C: { encryptedSessionSigningKey, expiresAt }
   C->>C: decrypt with private key, hold session signing key
 ```
 
-The `challenge` on `POST /auth/credentials` is the one your backend issued. Grid rebinds to a fresh challenge for the *first* authentication and hands it back on the 201 response as `PasskeyAuthChallenge.challenge` with an accompanying `requestId`.
+The `challenge` on `POST /auth/credentials` is the one your backend issued (registration only). The challenge used for the WebAuthn assertion comes from `POST /auth/credentials/{id}/challenge` — Grid bakes the `clientPublicKey` you send there into the session-creation payload, sealing the resulting session signing key to the device that generated it. Because that key plumbing happens on `/challenge`, the subsequent `/verify` call carries only the assertion (plus the `Request-Id` header).
 
 <Tip>
   Passkeys are domain-bound. Before shipping, set up your `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` entries so the platform authenticator binds the passkey to your origin and app bundles:
@@ -101,10 +109,20 @@ const registerRes = await fetch("/my-backend/passkey/register", {
     transports: att.getTransports?.() ?? [],
   }),
 });
-const { credentialId, gridChallenge, requestId } = await registerRes.json();
+const { credentialId } = await registerRes.json();
 
-// 4. Generate the client key pair and run an assertion against the Grid-issued challenge.
+// 4. Generate the client key pair and ask Grid for an authentication challenge
+//    sealed to its public key.
 const { keyPair, publicKeyHex } = await generateClientKeyPair();
+const challengeRes = await fetch("/my-backend/passkey/challenge", {
+  method: "POST",
+  credentials: "include",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ credentialId, clientPublicKey: publicKeyHex }),
+});
+const { challenge: gridChallenge, requestId } = await challengeRes.json();
+
+// 5. Run the WebAuthn assertion against the Grid-issued challenge.
 const assertion = (await navigator.credentials.get({
   publicKey: {
     challenge: base64urlToBytes(gridChallenge),
@@ -115,7 +133,7 @@ const assertion = (await navigator.credentials.get({
 })) as PublicKeyCredential;
 const asr = assertion.response as AuthenticatorAssertionResponse;
 
-// 5. Send the assertion + client public key to your backend; it relays to POST /verify.
+// 6. Send the assertion to your backend; it relays to POST /verify with Request-Id.
 const verifyRes = await fetch("/my-backend/passkey/verify", {
   method: "POST",
   credentials: "include",
@@ -132,7 +150,6 @@ const verifyRes = await fetch("/my-backend/passkey/verify", {
         ? bytesToBase64url(new Uint8Array(asr.userHandle))
         : null,
     },
-    clientPublicKey: publicKeyHex,
   }),
 });
 const { encryptedSessionSigningKey, expiresAt } = await verifyRes.json();
@@ -162,13 +179,20 @@ suspend fun registerPasskey(context: Context, api: MyBackendApi): EmbeddedWallet
     ) as androidx.credentials.CreatePublicKeyCredentialResponse
     val attestationJson = createResp.registrationResponseJson
 
-    // 3. Backend → POST /auth/credentials. Returns Grid-issued challenge + requestId.
+    // 3. Backend → POST /auth/credentials. Returns AuthMethod { credentialId, rpId, ... }.
     val registerResp = api.passkeyRegister(attestationJson, nickname = "This device")
 
-    // 4. Generate client key pair and run assertion against Grid-issued challenge.
+    // 4. Generate client key pair, then ask Grid for an authentication challenge
+    //    sealed to that public key via POST /auth/credentials/{id}/challenge.
     val clientKeys = generateClientKeyPair(alias = "embedded-wallet-${registerResp.credentialId}")
+    val challengeResp = api.passkeyChallenge(
+        credentialId = registerResp.credentialId,
+        clientPublicKeyHex = clientKeys.publicKeyHex,
+    )
+
+    // 5. Run WebAuthn assertion against Grid-issued challenge.
     val getOptionsJson = buildWebAuthnGetOptionsJson(
-        challenge = registerResp.gridChallenge,
+        challenge = challengeResp.challenge,
         rpId = registerResp.rpId,
         credentialId = registerResp.credentialId,
     )
@@ -178,12 +202,11 @@ suspend fun registerPasskey(context: Context, api: MyBackendApi): EmbeddedWallet
     ).credential as PublicKeyCredential
     val assertionJson = getResp.authenticationResponseJson
 
-    // 5. Backend → POST /verify. Returns encryptedSessionSigningKey.
+    // 6. Backend → POST /verify with Request-Id. Returns encryptedSessionSigningKey.
     return api.passkeyVerify(
         credentialId = registerResp.credentialId,
-        requestId = registerResp.requestId,
+        requestId = challengeResp.requestId,
         assertionJson = assertionJson,
-        clientPublicKeyHex = clientKeys.publicKeyHex,
     )
 }
 ```
@@ -222,7 +245,7 @@ final class PasskeyCoordinator: NSObject, ASAuthorizationControllerDelegate {
             controller.performRequests()
         }
 
-        // 3. Backend → POST /auth/credentials.
+        // 3. Backend → POST /auth/credentials. Returns AuthMethod.
         let registered = try await api.passkeyRegister(
             credentialId: attestation.credentialID.base64URLEncoded,
             clientDataJson: attestation.rawClientDataJSON.base64URLEncoded,
@@ -230,10 +253,17 @@ final class PasskeyCoordinator: NSObject, ASAuthorizationControllerDelegate {
             nickname: "This device",
         )
 
-        // 4. Generate client key pair, run assertion against Grid challenge.
+        // 4. Generate client key pair, ask Grid for an authentication challenge
+        //    sealed to that public key via POST /auth/credentials/{id}/challenge.
         let keys = generateClientKeyPair()
+        let challengeResp = try await api.passkeyChallenge(
+            credentialId: registered.credentialId,
+            clientPublicKeyHex: keys.publicKeyHex,
+        )
+
+        // 5. Run WebAuthn assertion against Grid-issued challenge.
         let assertRequest = provider.createCredentialAssertionRequest(
-            challenge: registered.gridChallenge,
+            challenge: challengeResp.challenge,
         )
         assertRequest.allowedCredentials = [
             ASAuthorizationPlatformPublicKeyCredentialDescriptor(
@@ -249,15 +279,14 @@ final class PasskeyCoordinator: NSObject, ASAuthorizationControllerDelegate {
             controller.performRequests()
         }
 
-        // 5. Backend → POST /verify.
+        // 6. Backend → POST /verify with Request-Id. Returns encryptedSessionSigningKey.
         return try await api.passkeyVerify(
             credentialId: registered.credentialId,
-            requestId: registered.requestId,
+            requestId: challengeResp.requestId,
             clientDataJson: assertion.rawClientDataJSON.base64URLEncoded,
             authenticatorData: assertion.rawAuthenticatorData.base64URLEncoded,
             signature: assertion.signature.base64URLEncoded,
             userHandle: assertion.userID?.base64URLEncoded,
-            clientPublicKeyHex: keys.publicKeyHex,
         )
     }
 }
@@ -280,7 +309,13 @@ These are the fields you need to pass through on each hop.
 | *(backend-chosen)* | `nickname` | `nickname` |
 | *(Grid account id)* | — | `accountId` |
 
-**Assertion (`/auth/credentials/{id}/verify` and passkey reauthentication):**
+**Authentication challenge (`/auth/credentials/{id}/challenge`):**
+
+| Source | Your backend payload | Grid request body |
+|---|---|---|
+| *(client-generated)* | `clientPublicKey` | `clientPublicKey` |
+
+**Assertion (`/auth/credentials/{id}/verify`):**
 
 | Browser (`credential`) | Your backend payload | Grid request body |
 |---|---|---|
@@ -289,8 +324,7 @@ These are the fields you need to pass through on each hop.
 | `response.authenticatorData` | `authenticatorData` | `assertion.authenticatorData` |
 | `response.signature` | `signature` | `assertion.signature` |
 | `response.userHandle` | `userHandle` | `assertion.userHandle` *(optional)* |
-| *(from 201/200 challenge response)* | `requestId` | `Request-Id` header |
-| *(client-generated)* | `clientPublicKey` | `clientPublicKey` |
+| *(from `/challenge` response)* | `requestId` | `Request-Id` header |
 
 <Note>
   The WebAuthn spec names the field `clientDataJSON`. Grid spells it `clientDataJson` (lowercase `json`) for consistency with the rest of the API. The **bytes are identical** — only the field name changes.
@@ -298,7 +332,7 @@ These are the fields you need to pass through on each hop.
 
 ### Passkey reauthentication
 
-When a session expires the client re-verifies without recreating the credential. Call `POST /auth/credentials/{id}/challenge` for a fresh Grid-issued challenge, run `navigator.credentials.get()`, then call `/verify` with the assertion and a new `clientPublicKey`.
+When a session expires the client re-verifies without recreating the credential. Reauthentication uses the same `/challenge` → `/verify` shape as the first authentication: generate a fresh client key pair, call `POST /auth/credentials/{id}/challenge` with the new `clientPublicKey`, run `navigator.credentials.get()` against the returned challenge, then call `/verify` with the assertion and the matching `Request-Id` header.
 
 ```mermaid
 sequenceDiagram
@@ -308,14 +342,15 @@ sequenceDiagram
   participant A as Authenticator
 
   C->>IB: session expired, re-authenticate
-  IB->>G: POST /auth/credentials/{id}/challenge
+  C->>C: generateClientKeyPair()
+  C->>IB: POST /my-backend/passkey/challenge (clientPublicKey)
+  IB->>G: POST /auth/credentials/{id}/challenge<br/>{ clientPublicKey }
   G-->>IB: 200 PasskeyAuthChallenge { challenge, requestId, expiresAt }
   IB-->>C: { challenge, requestId }
-  C->>C: generateClientKeyPair()
   C->>A: navigator.credentials.get({ challenge })
   A-->>C: assertion
-  C->>IB: POST /my-backend/passkey/reauth (assertion, clientPublicKey)
-  IB->>G: POST /auth/credentials/{id}/verify<br/>Request-Id: requestId
+  C->>IB: POST /my-backend/passkey/reauth (assertion, requestId)
+  IB->>G: POST /auth/credentials/{id}/verify<br/>Request-Id: requestId<br/>{ type: PASSKEY, assertion }
   G-->>IB: 200 AuthSession { encryptedSessionSigningKey, expiresAt }
   IB-->>C: { encryptedSessionSigningKey, expiresAt }
 ```
@@ -580,7 +615,7 @@ Requires an active session on an *existing* credential on the same account. The 
     **Response (201):** a plain `AuthMethod`. For `EMAIL_OTP`, Grid delivers the OTP email on this signed retry, not on the first call.
   </Step>
   <Step title="Activate the new credential">
-    Call `POST /auth/credentials/{id}/verify` with the OTP (or the OIDC token / passkey assertion, depending on type) and a fresh `clientPublicKey` — same as activating any first credential.
+    Activate the new credential the same way you would activate the first credential of that type — `EMAIL_OTP` and `OAUTH` go straight to `POST /auth/credentials/{id}/verify` with a fresh `clientPublicKey`; `PASSKEY` first calls `POST /auth/credentials/{id}/challenge` with the `clientPublicKey` to get a Grid-issued WebAuthn challenge, then `POST /auth/credentials/{id}/verify` with the assertion and the `Request-Id` header.
   </Step>
 </Steps>
 

--- a/mintlify/snippets/global-accounts/client-keys.mdx
+++ b/mintlify/snippets/global-accounts/client-keys.mdx
@@ -9,7 +9,7 @@ This page covers generating the client key pair, sending the public key to your 
 
 ## 1. Generate a client key pair
 
-Generate a fresh P-256 key pair for every `POST /auth/credentials/{id}/verify` call and for every wallet export. Keep the private key in device-local secure storage (browser `IndexedDB` gated by Web Crypto's non-extractable flag, iOS Keychain, Android Keystore). Send the public key hex-encoded — a 130-character string starting with `04` — to your integrator backend, which passes it to Grid as `clientPublicKey`. The Web Crypto, iOS, and Android APIs shown below all produce this format natively.
+Generate a fresh P-256 key pair for every authentication and for every wallet export. The public key is sent to Grid as `clientPublicKey` — for `PASSKEY` credentials this happens on `POST /auth/credentials/{id}/challenge`; for `EMAIL_OTP` and `OAUTH` it happens on `POST /auth/credentials/{id}/verify`; for wallet export it goes on both `/export` calls. Keep the private key in device-local secure storage (browser `IndexedDB` gated by Web Crypto's non-extractable flag, iOS Keychain, Android Keystore). Send the public key hex-encoded — a 130-character string starting with `04` — through your integrator backend. The Web Crypto, iOS, and Android APIs shown below all produce this format natively.
 
 <Tip>
   For local development, you can generate a P-256 key pair from the command line:

--- a/mintlify/snippets/global-accounts/overview.mdx
+++ b/mintlify/snippets/global-accounts/overview.mdx
@@ -285,13 +285,19 @@ curl -X POST "$GRID_BASE_URL/quotes" \
 
 ### 7. Authenticate and sign
 
-The customer has an outstanding quote with a `payloadToSign`. Now we need a session signing key to sign it with — this is when the passkey actually gets used. The flow is challenge → assertion → verify → decrypt → sign.
+The customer has an outstanding quote with a `payloadToSign`. Now we need a session signing key to sign it with — this is when the passkey actually gets used. The flow is keypair → challenge → assertion → verify → decrypt → sign.
 
 <Steps>
-  <Step title="Your backend requests a fresh challenge">
+  <Step title="Your backend requests a fresh challenge sealed to the client public key">
+    The client generates a fresh <a href="client-keys#1-generate-a-client-key-pair">P-256 client key pair</a> and posts the public key (uncompressed hex) to your backend, which forwards it to Grid. Grid bakes the public key into the session-creation payload so the resulting session signing key is sealed to that device.
+
     ```bash
     curl -X POST "$GRID_BASE_URL/auth/credentials/AuthMethod:019542f5-b3e7-1d02-0000-000000000001/challenge" \
-      -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+      -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "clientPublicKey": "04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2"
+      }'
     ```
 
     **Response (200):**
@@ -312,8 +318,8 @@ The customer has an outstanding quote with a `payloadToSign`. Now we need a sess
 
     Return `challenge` and `requestId` to the client.
   </Step>
-  <Step title="Client generates a key pair and runs the WebAuthn assertion">
-    The client generates a fresh <a href="client-keys#1-generate-a-client-key-pair">P-256 client key pair</a>, then prompts the authenticator with the Grid-issued challenge:
+  <Step title="Client runs the WebAuthn assertion against the Grid-issued challenge">
+    Prompt the authenticator with the `challenge` returned in the previous step:
 
     ```js
     const base64urlToBytes = (value) => {
@@ -331,7 +337,7 @@ The customer has an outstanding quote with a `payloadToSign`. Now we need a sess
     });
     ```
 
-    Post the assertion plus `clientPublicKey` (uncompressed hex) back to your backend.
+    Post the assertion (and the `requestId` from the previous step) back to your backend.
   </Step>
   <Step title="Your backend verifies the assertion with Grid to mint a session">
     ```bash
@@ -346,10 +352,11 @@ The customer has an outstanding quote with a `payloadToSign`. Now we need a sess
           "clientDataJson": "eyJjaGFsbGVuZ2UiOiJWalo2bzhLZkU5VjNxM0xrUjJuSDVlWjZkTTh5QTF4VyIsIm9yaWdpbiI6Imh0dHBzOi8veW91cmFwcC5jb20iLCJ0eXBlIjoid2ViYXV0aG4uZ2V0In0",
           "authenticatorData": "PdxHEOnAiLIp26idVjIguzn3Ipr_RlsKZWsa-5qK-KABAAAAkA",
           "signature": "MEUCIQDYXBOpCWSWq2Ll4558GJKD2RoWg958lvJSB_GdeokxogIgWuEVQ7ee6AswQY0OsuQ6y8Ks6jhd45bDx92wjXKs900"
-        },
-        "clientPublicKey": "04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2"
+        }
       }'
     ```
+
+    `clientPublicKey` is no longer required here — Grid already has it from the `/challenge` call. The `Request-Id` header ties this verify to that earlier challenge.
 
     **Response (200):**
 

--- a/mintlify/snippets/sandbox-global-account-magic.mdx
+++ b/mintlify/snippets/sandbox-global-account-magic.mdx
@@ -24,7 +24,18 @@ Any other code returns `401 UNAUTHORIZED` with `reason: "Invalid OTP code"`.
 
 Pass `sandbox-valid-passkey-signature` as `assertion.signature` on `POST /auth/credentials/{id}/verify` when the credential type is `PASSKEY`. The sandbox accepts the rest of the assertion as-is and skips the WebAuthn signature check.
 
+Passkey reauthentication is a two-step `/challenge` → `/verify` flow. The `clientPublicKey` is sent on `/challenge` (so Grid can seal the session signing key to your device) — the magic value bypasses the credential check, not the HPKE plumbing, so the public key is still required.
+
 ```bash
+# 1. /challenge with clientPublicKey
+curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMethod:abc123/challenge \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientPublicKey": "04f45f2a..."
+  }'
+
+# 2. /verify with the magic signature, no clientPublicKey
 curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMethod:abc123/verify \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
@@ -36,12 +47,11 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMet
       "clientDataJson": "...",
       "authenticatorData": "...",
       "signature": "sandbox-valid-passkey-signature"
-    },
-    "clientPublicKey": "04f45f2a..."
+    }
   }'
 ```
 
-Any other signature returns `401 UNAUTHORIZED` with `reason: "Invalid passkey signature"`. `clientPublicKey` is still required — the magic value bypasses the credential check, not the HPKE plumbing that seals the session signing key to the public key you supply.
+Any other signature returns `401 UNAUTHORIZED` with `reason: "Invalid passkey signature"`.
 
 ### OAuth (OIDC) token
 


### PR DESCRIPTION
Reflects the API change in #407 — for PASSKEY credentials,
clientPublicKey now goes on POST /auth/credentials/{id}/challenge
instead of /verify. Grid bakes the public key into the Turnkey
session-creation payload that the returned challenge is computed
from, so the resulting session signing key is sealed to the device
that requested the challenge.

Knock-on flow change: registration response is now a plain AuthMethod
(no inline PasskeyAuthChallenge). Both first-time activation and
reauthentication for PASSKEY follow the same three-step shape:
register → /challenge (with clientPublicKey) → /verify (with
Request-Id, no clientPublicKey).

EMAIL_OTP and OAUTH are unchanged — clientPublicKey stays on /verify
for those types; /challenge takes an empty body.

Updates:
- snippets/global-accounts/authentication.mdx — overview, passkey
  registration sequence diagram + TS/Kotlin/Swift code samples,
  parameter map split into challenge + assertion tables, passkey
  reauth diagram, additional-credential activation prose
- snippets/global-accounts/overview.mdx — Quickstart Step 7 now
  generates the keypair before calling /challenge with
  clientPublicKey, and the /verify body drops it
- snippets/global-accounts/client-keys.mdx — clarifies which call
  carries clientPublicKey for each credential type
- snippets/sandbox-global-account-magic.mdx — passkey example now
  shows the /challenge + /verify pair; verify body drops
  clientPublicKey

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>