### PR TITLE
docs: drop 109 → 500 row from sandbox beneficiary verification table

### DIFF
--- a/mintlify/snippets/sandbox-beneficiary-verification.mdx
+++ b/mintlify/snippets/sandbox-beneficiary-verification.mdx
@@ -8,5 +8,4 @@ For account types that support beneficiary name verification, you can simulate d
 | **105** | _(error)_ | Returns `400` — invalid account |
 | **106** | `UNSUPPORTED` | Payment rail does not support name verification |
 | **107** | `CHECKED_BY_RECEIVING_FI` | Verification deferred to receiving financial institution (e.g., ACH) |
-| **109** | _(error)_ | Returns `500` — simulated API error |
 | **Any other** | `MATCHED` | Account is valid, name matches exactly |


### PR DESCRIPTION
## Summary
- Removes the `109 → 500` simulated API error row from the sandbox beneficiary verification suffix table.

## Test plan
- [ ] Verify the table renders correctly in `mint dev` without the 109 row.