### PR TITLE
Add Turnkey USDB offramp instructions

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -8,7 +8,9 @@ description: >
   "fund sandbox account", "test a payment", "on-ramp", "off-ramp", "convert crypto to fiat",
   "convert fiat to crypto", "look up UMA", "real-time quote", "JIT funding", "check exchange rate",
   "FX rate", "payment corridor", "what rate will I get", "estimate withdrawal fee",
-  "crypto withdrawal fee", or any payment operations using the Grid API CLI.
+  "crypto withdrawal fee", "USDB", "USDB offramp", "embedded wallet", "embedded wallet sign",
+  "Grid-Wallet-Signature", "Turnkey stamp", "payloadToSign", "EMAIL_OTP credential",
+  "HPKE bundle", "decrypt credential bundle", or any payment operations using the Grid API CLI.
 allowed-tools:
   - Bash
   - Read
@@ -24,6 +26,17 @@ Assist users with global payment operations via the Grid API. Core capabilities:
 1. **Execute API Operations** - Use `curl` to interact with the Grid API directly
 2. **Answer Documentation Questions** - Fetch docs from <https://grid.lightspark.com/llms.txt> or the OpenAPI spec (<https://raw.githubusercontent.com/lightsparkdev/grid-api/refs/heads/main/openapi.yaml>)
 3. **Guide Payment Workflows** - Help users send payments to bank accounts, UMA addresses, and crypto wallets
+
+## Embedded Wallet Offramp (USDB → USD bank)
+
+The full **USDB embedded wallet → USD bank** offramp flow has dedicated documentation and helper scripts in the grid-api repo:
+
+- **`scripts/README.md`** — step-by-step walkthrough: onboarding → on-ramp → off-ramp with copy-pasteable curl, including the OTP / HPKE / Turnkey-stamp dance.
+- **`scripts/embedded-wallet-sign.js`** — three subcommands (`gen-keypair`, `decrypt-bundle`, `stamp`) wrapping `@turnkey/crypto` and `@turnkey/api-key-stamper`. One-time setup: `cd scripts && npm install`.
+
+**Read `scripts/README.md` whenever the user asks about**: USDB offramp, embedded-wallet signing, `payloadToSign`, `Grid-Wallet-Signature`, Turnkey stamp, OTP verify, HPKE bundle decrypt, the `EMAIL_OTP` credential flow, or the `/auth/credentials/{id}/verify` and `/auth/credentials/{id}/challenge` endpoints.
+
+**Onboarding gotcha**: register an `EMAIL_OTP` auth credential against the USDB embedded wallet **before the first quote**. Without it, on-ramp quotes fail with `to_network INTERNAL_FUNDED_FIAT does not support USDB` because the Turnkey sub-org / Spark network wallet aren't bootstrapped until the credential triggers it.
 
 ## Supporting References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,19 @@ mintlify/                   # Mintlify documentation (MDX)
 
 Bundled and linted with Redocly (`@redocly/cli`), configured in `.redocly.yaml`. Lint rules enforce operation descriptions, operation IDs, and security definitions.
 
+## Helper scripts (`scripts/`)
+
+For the **USDB embedded wallet → USD bank offramp** flow, see [`scripts/README.md`](./scripts/README.md). It walks through onboarding, on-ramp, and off-ramp with copy-pasteable curl, and points at the only operations that can't be done with curl alone:
+
+- HPKE bundle decrypt (the `encryptedSessionSigningKey` returned by `POST /auth/credentials/{id}/verify`)
+- Turnkey API stamp construction (the `Grid-Wallet-Signature` header on `POST /quotes/{id}/execute`)
+
+Both are wrapped by [`scripts/embedded-wallet-sign.js`](./scripts/embedded-wallet-sign.js) (uses `@turnkey/crypto` + `@turnkey/api-key-stamper`). One-time setup: `cd scripts && npm install`.
+
+**Important gotcha**: the USDB embedded wallet's Turnkey sub-org and Spark network wallet aren't fully bootstrapped when a customer is created. **Register an `EMAIL_OTP` auth credential against the USDB account before the first quote**, otherwise on-ramp quotes fail with `to_network INTERNAL_FUNDED_FIAT does not support USDB`. This is documented in `scripts/README.md` step 1.4.
+
+Read `scripts/README.md` whenever the task involves Turnkey signing, offramp, or `Grid-Wallet-Signature`.
+
 ## CSS Overrides (mintlify/styles/base.css)
 
 - Tailwind utility classes (e.g., `mb-3.5`) are hard to override even with `!important` — use negative margins on sibling elements as a workaround

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,247 @@
+# Grid offramp scripts
+
+Step-by-step guide for the **USDB embedded wallet → USD bank** offramp flow,
+plus onboarding and the on-ramp (USD → USDB) for completeness. Most steps
+are plain HTTP calls; the only operations that aren't expressible in curl
+are HPKE bundle decrypt and Turnkey API stamp construction, which live in
+[`embedded-wallet-sign.js`](./embedded-wallet-sign.js) (using
+`@turnkey/crypto` and `@turnkey/api-key-stamper`).
+
+## Prereqs
+
+Install once:
+
+```bash
+cd scripts && npm install
+```
+
+Then set credentials:
+
+```bash
+export GRID_BASE_URL="https://api.lightspark.com/grid/2025-10-13"
+export GRID_CLIENT_ID="<your client id>"
+export GRID_CLIENT_SECRET="<your client secret>"
+
+SIGN="node $(pwd)/scripts/embedded-wallet-sign.js"
+g() { curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" "$@"; }
+```
+
+`$SIGN --help` lists the three subcommands. `g` is a shorthand for
+authenticated curl used throughout the snippets below.
+
+## 1. Onboarding
+
+### 1.1 Create a customer
+
+```bash
+g -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "customerType": "INDIVIDUAL",
+    "platformCustomerId": "your-id-here",
+    "umaAddress": "$alice@yourplatform.example",
+    "email": "alice@example.com",
+    "fullName": "Alice Example",
+    "birthDate": "1990-01-15",
+    "nationality": "US"
+  }' "$GRID_BASE_URL/customers" | jq .
+```
+
+Capture the returned `id` (e.g. `Customer:01...`) into `$CUSTOMER_ID`.
+
+### 1.2 Wait for KYB / KYC approval
+
+Customer creation returns `kybStatus: "UNVERIFIED"`. Internal accounts
+auto-provision **after** approval. Poll:
+
+```bash
+g "$GRID_BASE_URL/customers/$CUSTOMER_ID" | jq '{kybStatus}'
+```
+
+### 1.3 Find the embedded-wallet accounts
+
+After approval, two internal accounts appear (USDB embedded wallet + USD):
+
+```bash
+g "$GRID_BASE_URL/customers/internal-accounts?customerId=$CUSTOMER_ID" \
+  | jq '.data[] | {id, currency: .balance.currency.code, type}'
+```
+
+Capture the **USDB account id** into `$USDB_ACCT`.
+
+### 1.4 Bootstrap the embedded wallet (register an EMAIL_OTP credential)
+
+> **Required before the first quote.** The USDB embedded wallet's Turnkey
+> sub-org and Spark network wallet aren't fully provisioned at customer
+> creation time. Registering an auth credential triggers that bootstrap.
+> Skipping causes the first on-ramp quote to fail with
+> `to_network INTERNAL_FUNDED_FIAT does not support USDB`.
+
+```bash
+CRED=$(g -X POST -H 'Content-Type: application/json' \
+  -d '{"type": "EMAIL_OTP", "accountId": "'$USDB_ACCT'"}' \
+  "$GRID_BASE_URL/auth/credentials")
+CRED_ID=$(echo "$CRED" | jq -r .id)
+```
+
+This also sends an OTP email to the address on the customer record. Keep
+the code handy; you'll use it for the offramp signing step (3.3) within
+the OTP TTL (~5 min). If it expires, re-issue via `/challenge` (3.2).
+
+### 1.5 Add a destination bank (USD external account)
+
+```bash
+g -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "customerId": "'$CUSTOMER_ID'",
+    "currency": "USD",
+    "accountInfo": {
+      "accountType": "USD_ACCOUNT",
+      "paymentRails": ["RTP"],
+      "routingNumber": "121042882",
+      "accountNumber": "0000000000",
+      "beneficiary": {
+        "beneficiaryType": "INDIVIDUAL",
+        "fullName": "Alice Example",
+        "birthDate": "1990-01-15",
+        "nationality": "US"
+      }
+    }
+  }' "$GRID_BASE_URL/customers/external-accounts" | jq .
+```
+
+Capture the returned `id` (e.g. `ExternalAccount:01...`) into `$BANK_ID`.
+
+## 2. On-ramp ($1 USD → 1 USDB)
+
+The platform funds USD into its own internal USD account first (real wire /
+ACH / RTP — out of scope for this script). Once the platform USD account
+has a balance, drive a quote from platform USD → customer USDB. No signing
+needed.
+
+```bash
+PLATFORM_USD=$(g "$GRID_BASE_URL/platform/internal-accounts?currency=USD" \
+  | jq -r '.data[0].id')
+
+QUOTE=$(g -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "source":      {"sourceType": "ACCOUNT", "accountId": "'$PLATFORM_USD'"},
+    "destination": {"destinationType": "ACCOUNT", "accountId": "'$USDB_ACCT'", "currency": "USDB"},
+    "lockedCurrencySide": "SENDING",
+    "lockedCurrencyAmount": 100
+  }' "$GRID_BASE_URL/quotes")
+QUOTE_ID=$(echo "$QUOTE" | jq -r .id)
+TXN_ID=$(echo "$QUOTE" | jq -r .transactionId)
+
+g -X POST -H 'Content-Type: application/json' -d '{}' \
+  "$GRID_BASE_URL/quotes/$QUOTE_ID/execute" | jq '.status'
+
+while :; do
+  S=$(g "$GRID_BASE_URL/transactions/$TXN_ID" | jq -r .status)
+  echo "$S"
+  [ "$S" = "COMPLETED" ] || [ "$S" = "FAILED" ] && break
+  sleep 2
+done
+```
+
+## 3. Off-ramp (USDB → USD bank)
+
+The customer's embedded wallet must produce a Turnkey-stamped signature
+over a `payloadToSign` returned by the quote. Step 1.4 already registered
+the credential — we just need a fresh OTP and an ephemeral keypair.
+
+### 3.1 Generate an ephemeral keypair
+
+The verify response is HPKE-sealed to a public key you supply. Generate a
+fresh P-256 pair per session:
+
+```bash
+$SIGN gen-keypair > /tmp/keys.json
+PUB_HEX=$(jq -r .pubHex /tmp/keys.json)
+PRIV_HEX=$(jq -r .privHex /tmp/keys.json)
+```
+
+### 3.2 (Re-)issue an OTP
+
+To get a fresh OTP (after expiry or for a new session):
+
+```bash
+g -X POST -H 'Content-Type: application/json' -d '{}' \
+  "$GRID_BASE_URL/auth/credentials/$CRED_ID/challenge"
+```
+
+Read the OTP code from the email and assign to `$OTP`.
+
+### 3.3 Verify the OTP and decrypt the session key
+
+```bash
+VERIFY=$(g -X POST -H 'Content-Type: application/json' \
+  -d '{"type": "EMAIL_OTP", "otp": "'$OTP'", "clientPublicKey": "'$PUB_HEX'"}' \
+  "$GRID_BASE_URL/auth/credentials/$CRED_ID/verify")
+
+BUNDLE=$(echo "$VERIFY" | jq -r .encryptedSessionSigningKey)
+SESSION_PRIV_HEX=$($SIGN decrypt-bundle "$BUNDLE" "$PRIV_HEX")
+echo "Session expires: $(echo "$VERIFY" | jq -r .expiresAt)"
+```
+
+Sessions are short-lived (~15 min). Cache `$SESSION_PRIV_HEX` and run the
+remaining steps before it expires; otherwise re-run `gen-keypair` →
+`/challenge` → `/verify` → `decrypt-bundle`.
+
+### 3.4 Create the offramp quote
+
+```bash
+QUOTE=$(g -X POST -H 'Content-Type: application/json' \
+  -d '{
+    "source":      {"sourceType": "ACCOUNT", "accountId": "'$USDB_ACCT'"},
+    "destination": {"destinationType": "ACCOUNT", "accountId": "'$BANK_ID'", "currency": "USD"},
+    "lockedCurrencySide": "SENDING",
+    "lockedCurrencyAmount": 1000000
+  }' "$GRID_BASE_URL/quotes")
+
+QUOTE_ID=$(echo "$QUOTE" | jq -r .id)
+TXN_ID=$(echo "$QUOTE" | jq -r .transactionId)
+PAYLOAD=$(echo "$QUOTE" \
+  | jq -r '.paymentInstructions[].accountOrWalletInfo
+           | select(.accountType=="EMBEDDED_WALLET").payloadToSign')
+```
+
+The quote response also includes a `SPARK_WALLET` invoice — that's the
+alternative funding path (pay USDB into the invoice from an external Spark
+wallet). The embedded-wallet path uses the existing on-chain balance and
+needs a stamp.
+
+### 3.5 Stamp the payload
+
+```bash
+STAMP=$($SIGN stamp "$SESSION_PRIV_HEX" "$PAYLOAD")
+```
+
+### 3.6 Execute
+
+```bash
+g -X POST -H 'Content-Type: application/json' \
+   -H "Grid-Wallet-Signature: $STAMP" \
+   -d '{}' \
+   "$GRID_BASE_URL/quotes/$QUOTE_ID/execute" | jq '.status'
+
+# Poll — typically 60–180s for the full chain to reach COMPLETED.
+while :; do
+  S=$(g "$GRID_BASE_URL/transactions/$TXN_ID" | jq -r .status)
+  echo "$S"
+  [ "$S" = "COMPLETED" ] || [ "$S" = "FAILED" ] && break
+  sleep 5
+done
+```
+
+On `COMPLETED`, the user's bank receives the USD via RTP.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `to_network INTERNAL_FUNDED_FIAT does not support USDB` on the first on-ramp quote | Embedded wallet not bootstrapped. Register an EMAIL_OTP credential first (step 1.4). |
+| `EMAIL_OTP_CREDENTIAL_ALREADY_EXISTS` on `POST /auth/credentials` | The wallet already has a credential. Use `POST /auth/credentials/{id}/challenge` to re-issue an OTP. |
+| `No pending OTP for this credential` on `/verify` | OTP expired (typically ~5 min). Re-run `/challenge` and verify quickly. |
+| `INSUFFICIENT_FUNDS` on offramp quote create | USDB on-chain balance at the embedded wallet's Spark address is below the requested amount. The Grid book balance can be ahead of the chain — check the on-chain side via `spark-cli` or your Spark explorer. |
+| Execute returns 500 / "INTERNAL_ERROR" | Often: bad `Grid-Wallet-Signature`. Verify `$SESSION_PRIV_HEX` matches the active session and `$PAYLOAD` is the exact `payloadToSign` byte string. |
+| Txn stuck in `PROCESSING` indefinitely | Grid build pre-dates the SP-2912 fix, or paycore detection of the on-chain Spark deposit hasn't fired. Check paycore worker logs. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,11 @@ are HPKE bundle decrypt and Turnkey API stamp construction, which live in
 [`embedded-wallet-sign.js`](./embedded-wallet-sign.js) (using
 `@turnkey/crypto` and `@turnkey/api-key-stamper`).
 
+> **For production integrations**, prefer the official Grid SDKs at
+> <https://grid.lightspark.com>. This README is intended for hands-on
+> tinkering, debugging, and end-to-end validation — it favors curl and
+> the minimal signing helpers over a full SDK stack.
+
 ## Prereqs
 
 Install once:
@@ -48,14 +53,18 @@ g -X POST -H 'Content-Type: application/json' \
 
 Capture the returned `id` (e.g. `Customer:01...`) into `$CUSTOMER_ID`.
 
-### 1.2 Wait for KYB / KYC approval
+### 1.2 Wait for KYC / KYB approval
 
-Customer creation returns `kybStatus: "UNVERIFIED"`. Internal accounts
-auto-provision **after** approval. Poll:
+Internal accounts auto-provision **after** approval.
 
-```bash
-g "$GRID_BASE_URL/customers/$CUSTOMER_ID" | jq '{kybStatus}'
-```
+- **`INDIVIDUAL` customers** are auto-KYC'd today — they jump straight to
+  `kycStatus: "APPROVED"` on creation, so there's nothing to wait for.
+- **`BUSINESS` customers** start at `kybStatus: "UNVERIFIED"` and require
+  an out-of-band verification step. Poll until approved:
+
+  ```bash
+  g "$GRID_BASE_URL/customers/$CUSTOMER_ID" | jq '{kybStatus}'
+  ```
 
 ### 1.3 Find the embedded-wallet accounts
 
@@ -171,6 +180,9 @@ g -X POST -H 'Content-Type: application/json' -d '{}' \
 
 Read the OTP code from the email and assign to `$OTP`.
 
+> **Sandbox tip**: in sandbox mode, no email is sent — verify with the fixed
+> OTP code `000000`.
+
 ### 3.3 Verify the OTP and decrypt the session key
 
 ```bash
@@ -205,10 +217,28 @@ PAYLOAD=$(echo "$QUOTE" \
            | select(.accountType=="EMBEDDED_WALLET").payloadToSign')
 ```
 
-The quote response also includes a `SPARK_WALLET` invoice — that's the
-alternative funding path (pay USDB into the invoice from an external Spark
-wallet). The embedded-wallet path uses the existing on-chain balance and
-needs a stamp.
+The quote response returns **both** signing/funding options in
+`paymentInstructions`:
+
+```json
+"paymentInstructions": [
+  { "accountOrWalletInfo": { "accountType": "SPARK_WALLET",
+                             "address": "spark1...",
+                             "invoice": "spark1..." } },
+  { "accountOrWalletInfo": { "accountType": "EMBEDDED_WALLET",
+                             "payloadToSign": "{...}" } }
+]
+```
+
+These are alternatives — pick one:
+
+- **`EMBEDDED_WALLET` path** (this README): debits the customer's existing
+  on-chain USDB balance. Needs a Turnkey-stamped signature over
+  `payloadToSign`.
+- **`SPARK_WALLET` path**: pay USDB into the `invoice` from any external
+  Spark wallet. No stamp needed; the deposit drives the offramp once
+  detected. Used by `test_token_offramp_e2e` via
+  `spark-cli fulfillsparkinvoice`.
 
 ### 3.5 Stamp the payload
 
@@ -223,7 +253,15 @@ g -X POST -H 'Content-Type: application/json' \
    -H "Grid-Wallet-Signature: $STAMP" \
    -d '{}' \
    "$GRID_BASE_URL/quotes/$QUOTE_ID/execute" | jq '.status'
+```
 
+> **Sandbox tip**: in sandbox mode you can skip the keypair / decrypt /
+> stamp dance entirely. Use the fixed value
+> `Grid-Wallet-Signature: sandbox-valid-signature`; any other value is
+> rejected with the same `INVALID_INPUT` shape a bad real stamp would
+> produce.
+
+```bash
 # Poll — typically 60–180s for the full chain to reach COMPLETED.
 while :; do
   S=$(g "$GRID_BASE_URL/transactions/$TXN_ID" | jq -r .status)

--- a/scripts/embedded-wallet-sign.js
+++ b/scripts/embedded-wallet-sign.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Embedded-wallet signing helpers for the Grid offramp flow.
+ *
+ * Three primitives that aren't expressible in plain curl. Everything else
+ * (create customer, on-ramp quote, register OTP, offramp quote, execute)
+ * is a regular HTTP call — see scripts/README.md for the full walkthrough.
+ *
+ * Subcommands:
+ *
+ *   gen-keypair
+ *       Generate an ephemeral P-256 keypair. Prints JSON with `pubHex` and
+ *       `privHex`. Send `pubHex` as `clientPublicKey` to
+ *       `POST /auth/credentials/{id}/verify`; keep `privHex` to decrypt the
+ *       `encryptedSessionSigningKey` from the response.
+ *
+ *   decrypt-bundle <bundle> <privHex>
+ *       HPKE-open the `encryptedSessionSigningKey` returned by
+ *       `POST /auth/credentials/{id}/verify`. Prints the session API
+ *       private key as hex.
+ *
+ *   stamp <sessionPrivHex> <payload>
+ *       Build a Turnkey API stamp over a `payloadToSign`. Prints the value
+ *       to drop into the `Grid-Wallet-Signature` header on
+ *       `POST /quotes/{id}/execute`.
+ *
+ * For long arguments, pass `-` to read from stdin:
+ *
+ *   cat bundle.txt | embedded-wallet-sign decrypt-bundle - $PRIV_HEX
+ */
+
+"use strict";
+
+const { generateKeyPairSync, createPublicKey } = require("node:crypto");
+const { decryptCredentialBundle } = require("@turnkey/crypto");
+const { ApiKeyStamper } = require("@turnkey/api-key-stamper");
+
+function readArg(value) {
+  if (value !== "-") return value;
+  return require("node:fs").readFileSync(0, "utf8").trim();
+}
+
+function jwkB64ToHex(b64url) {
+  return Buffer.from(b64url, "base64url").toString("hex");
+}
+
+function genKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+  });
+  const privJwk = privateKey.export({ format: "jwk" });
+  const pubJwk = publicKey.export({ format: "jwk" });
+  // Uncompressed SEC1: 0x04 || X || Y
+  const pubHex =
+    "04" + jwkB64ToHex(pubJwk.x) + jwkB64ToHex(pubJwk.y);
+  const privHex = jwkB64ToHex(privJwk.d);
+  return { pubHex, privHex };
+}
+
+function privHexToCompressedPubHex(privHex) {
+  // Build a JWK from the private key, then re-derive the public point in
+  // compressed SEC1 form (the format the Turnkey stamp expects).
+  const dB64 = Buffer.from(privHex, "hex").toString("base64url");
+  // We need x/y to construct a JWK key object, but we only have d.
+  // Use noble curves transitively from @turnkey/crypto.
+  const { p256 } = require("@noble/curves/p256");
+  const compressed = p256.getPublicKey(privHex, true); // Uint8Array
+  return Buffer.from(compressed).toString("hex");
+}
+
+async function main() {
+  const [, , cmd, ...rest] = process.argv;
+  switch (cmd) {
+    case "gen-keypair": {
+      const out = genKeypair();
+      process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+      return;
+    }
+    case "decrypt-bundle": {
+      const [bundleArg, privArg] = rest;
+      if (!bundleArg || !privArg) usage(1);
+      const bundle = readArg(bundleArg);
+      const privHex = readArg(privArg);
+      const sessionPrivHex = await decryptCredentialBundle(bundle, privHex);
+      process.stdout.write(sessionPrivHex + "\n");
+      return;
+    }
+    case "stamp": {
+      const [sessArg, payloadArg] = rest;
+      if (!sessArg || !payloadArg) usage(1);
+      const sessionPrivHex = readArg(sessArg);
+      const payload = readArg(payloadArg);
+      const sessionPubHex = privHexToCompressedPubHex(sessionPrivHex);
+      const stamper = new ApiKeyStamper({
+        apiPublicKey: sessionPubHex,
+        apiPrivateKey: sessionPrivHex,
+      });
+      const { stampHeaderValue } = await stamper.stamp(payload);
+      process.stdout.write(stampHeaderValue + "\n");
+      return;
+    }
+    case "--help":
+    case "-h":
+    case undefined:
+      usage(0);
+      return;
+    default:
+      console.error(`Unknown command: ${cmd}`);
+      usage(1);
+  }
+}
+
+function usage(code) {
+  const msg = [
+    "embedded-wallet-sign — signing helpers for the Grid offramp flow",
+    "",
+    "Subcommands:",
+    "  gen-keypair                                 Generate ephemeral P-256 keypair",
+    "  decrypt-bundle <bundle> <privHex>           HPKE-open the session signing key",
+    "  stamp <sessionPrivHex> <payload>            Build a Grid-Wallet-Signature stamp",
+    "",
+    "Use - in place of any argument to read it from stdin.",
+  ].join("\n");
+  (code === 0 ? process.stdout : process.stderr).write(msg + "\n");
+  process.exit(code);
+}
+
+main().catch((err) => {
+  console.error(err.stack || String(err));
+  process.exit(1);
+});

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,379 @@
+{
+  "name": "@lightspark/grid-api-scripts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lightspark/grid-api-scripts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@turnkey/api-key-stamper": "^0.6.5",
+        "@turnkey/crypto": "^2.8.14"
+      },
+      "bin": {
+        "embedded-wallet-sign": "embedded-wallet-sign.js"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
+      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-csr": "^2.3.13",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-pkcs9": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "pvtsutils": "^1.3.5",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.7.0",
+        "tsyringe": "^4.8.0"
+      }
+    },
+    "node_modules/@turnkey/api-key-stamper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@turnkey/api-key-stamper/-/api-key-stamper-0.6.5.tgz",
+      "integrity": "sha512-dSINHLIzYVw+ZNLwjM1wnEYFkYHPjQDSi43opCUhvow/ws6Fsn6gWkYpzbH+6Ej3rvSJTuaTwsld+dsTG/3HnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@turnkey/crypto": "2.8.14",
+        "@turnkey/encoding": "0.6.0",
+        "sha256-uint8array": "^0.10.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/crypto": {
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@turnkey/crypto/-/crypto-2.8.14.tgz",
+      "integrity": "sha512-UZU+DEwhSUyyMHC9VZbp5av8NY/IJsfJ+g1E4dndQjMSAJd5NPKGS7sItlBy1ifN6wBb9JP5AcvmcfCdCfj9bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.0",
+        "@noble/hashes": "1.8.0",
+        "@peculiar/x509": "1.12.3",
+        "@turnkey/encoding": "0.6.0",
+        "@turnkey/sdk-types": "0.14.0",
+        "borsh": "2.0.0",
+        "cbor-js": "0.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/crypto/node_modules/@noble/curves": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+      "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@turnkey/encoding": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/encoding/-/encoding-0.6.0.tgz",
+      "integrity": "sha512-IC8qXvy36+iGAeiaVIuJvB35uU2Ld/RAWI/DRTKS+ttBej0GXhOn48Ouu5mlca4jt8ZEuwXmDVv74A8uBQclsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bs58": "6.0.0",
+        "bs58check": "4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@turnkey/sdk-types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@turnkey/sdk-types/-/sdk-types-0.14.0.tgz",
+      "integrity": "sha512-FLN4p3Jc3rBMvM17tgFrO4VpqkQN0RgWtLknqcqpLuNgTJ7oqgvzm42YIrzvBlW6DPsnFjVZMzc4yCfaRN7Lmg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/cbor-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
+      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==",
+      "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/sha256-uint8array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
+      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@lightspark/grid-api-scripts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Helper scripts for Grid offramp / embedded-wallet flows",
+  "bin": {
+    "embedded-wallet-sign": "./embedded-wallet-sign.js"
+  },
+  "type": "commonjs",
+  "dependencies": {
+    "@turnkey/api-key-stamper": "^0.6.5",
+    "@turnkey/crypto": "^2.8.14"
+  }
+}


### PR DESCRIPTION
### TL;DR

Adds a `scripts/` directory with a step-by-step offramp guide and a Node.js signing helper for the USDB embedded wallet → USD bank flow, and updates Claude skill/project documentation to reference them.

### What changed?

**`scripts/README.md`** — A complete walkthrough of the USDB embedded wallet offramp flow covering:
- Customer onboarding (create, KYC approval, find internal accounts, bootstrap the embedded wallet via `EMAIL_OTP` credential registration, add a destination bank)
- On-ramp (platform USD → customer USDB quote and execute)
- Off-ramp (ephemeral keypair generation, OTP issuance, OTP verification + HPKE bundle decrypt, offramp quote creation, Turnkey stamp construction, and quote execution with `Grid-Wallet-Signature`)
- A troubleshooting table covering common errors like `to_network INTERNAL_FUNDED_FIAT does not support USDB`, expired OTPs, and insufficient funds

**`scripts/embedded-wallet-sign.js`** — A Node.js CLI with three subcommands that handle the cryptographic operations not expressible in plain curl:
- `gen-keypair` — generates an ephemeral P-256 keypair (pubHex/privHex) to supply as `clientPublicKey` to `/auth/credentials/{id}/verify`
- `decrypt-bundle` — HPKE-opens the `encryptedSessionSigningKey` from the verify response using `@turnkey/crypto`
- `stamp` — builds a Turnkey API stamp over a `payloadToSign` using `@turnkey/api-key-stamper`, producing the value for the `Grid-Wallet-Signature` header

**`scripts/package.json` / `package-lock.json`** — Package manifest with `@turnkey/api-key-stamper` and `@turnkey/crypto` as dependencies.

**`CLAUDE.md` and `.claude/skills/grid-api/SKILL.md`** — Updated to point Claude at `scripts/README.md` whenever tasks involve Turnkey signing, offramp, `Grid-Wallet-Signature`, HPKE bundle decryption, or the `EMAIL_OTP` credential flow. Also documents the bootstrapping gotcha: the Turnkey sub-org and Spark network wallet aren't provisioned until an `EMAIL_OTP` credential is registered, so this must happen before the first on-ramp quote.

### How to test?

1. `cd scripts && npm install`
2. Set `GRID_BASE_URL`, `GRID_CLIENT_ID`, and `GRID_CLIENT_SECRET`
3. Follow `scripts/README.md` end-to-end: create a customer, register an `EMAIL_OTP` credential against the USDB account, run an on-ramp quote, then execute the offramp using the three `embedded-wallet-sign.js` subcommands (`gen-keypair` → `decrypt-bundle` → `stamp`)
4. Confirm the transaction reaches `COMPLETED` and the destination bank receives USD

### Why make this change?

The USDB embedded wallet offramp requires two cryptographic operations (HPKE decryption and Turnkey API stamp construction) that cannot be performed with curl alone. Without tooling and documentation for these steps, integrators have no clear path to complete the flow. The bootstrapping requirement (registering an `EMAIL_OTP` credential before the first quote) is also a non-obvious gotcha that causes confusing failures. This PR provides both the reference documentation and the minimal Node.js tooling needed to drive the full flow end-to-end.