### PR TITLE
[grid] Clarify auth challenge rate limit docs

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4190,7 +4190,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error404'
         '429':
-          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the OTP rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
+          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the credential challenge rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
           headers:
             Retry-After:
               description: Number of seconds to wait before retrying the request.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4190,7 +4190,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error404'
         '429':
-          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the OTP rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
+          description: Too many requests. Returned with `RATE_LIMITED` when challenge re-issues are requested more frequently than the credential challenge rate limit allows. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
           headers:
             Retry-After:
               description: Number of seconds to wait before retrying the request.

--- a/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
+++ b/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
@@ -111,8 +111,8 @@ post:
     '429':
       description: >-
         Too many requests. Returned with `RATE_LIMITED` when challenge
-        re-issues are requested more frequently than the OTP rate limit
-        allows. Clients should back off and retry after the interval
+        re-issues are requested more frequently than the credential challenge
+        rate limit allows. Clients should back off and retry after the interval
         indicated by the `Retry-After` response header.
       headers:
         Retry-After:


### PR DESCRIPTION
## Reason

The Grid implementation now rate-limits auth credential challenge reissues for both PASSKEY and EMAIL_OTP credentials. The OpenAPI source still described the `429 RATE_LIMITED` response as tied specifically to the OTP rate limit, which makes the generated SDK/docs contract narrower than the implemented behavior.

- https://lightspark.atlassian.net/browse/AT-5038

## Overview

- Update the source OpenAPI 429 description for `POST /auth/credentials/{id}/challenge` from OTP-only to credential challenge rate limiting.
- Regenerate the bundled `openapi.yaml` and `mintlify/openapi.yaml` outputs from the source spec.
- Keep this docs/source change aligned with the webdev implementation PR: https://github.com/lightsparkdev/webdev/pull/26929

## Test Plan

- `make build`
- `make lint`