### PR TITLE
fix: remove mobile nav label padding override

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -852,11 +852,6 @@ div#mobile-nav div#navigation-items > div:first-child {
   margin-bottom: 0 !important;
 }
 
-div#mobile-nav div#navigation-items .flex.flex-wrap {
-  padding-bottom: 20px !important;
-  margin-bottom: 0 !important;
-}
-
 /* Mobile nav - sidebar group list: adjust spacing */
 div#mobile-nav ul.sidebar-group,
 div#mobile-nav ul#sidebar-group,


### PR DESCRIPTION
## Summary
- Remove an overbroad mobile nav selector that applied bottom padding to nested `.flex.flex-wrap` elements.
- Fix mobile sidebar nav item alignment by preventing label wrappers from receiving extra bottom spacing.

## Test plan
- Verified in local Mintlify preview at `http://localhost:3001` by inspecting the mobile nav in responsive mode.


Made with [Cursor](https://cursor.com)