### PR TITLE
fix(agents): correct auth scheme, stale paths, and phantom COMPLETED status

### DIFF
--- a/mintlify/global-accounts/agents/approvals-and-audit.mdx
+++ b/mintlify/global-accounts/agents/approvals-and-audit.mdx
@@ -26,7 +26,7 @@ When an agent submits an action that is not eligible for automatic execution, Gr
 5. Your app shows the customer the requested amount, accounts, and reason.
 6. The customer approves or rejects from that trusted surface.
 7. Your backend calls `POST /agents/{agentId}/actions/{actionId}/approve` or `.../reject`.
-8. Grid executes the action and the `AgentAction` transitions to `APPROVED`, then `COMPLETED` — or `REJECTED` if declined.
+8. Grid executes the action and the `AgentAction` transitions to `APPROVED` — or `REJECTED` if declined.
 
 ## Approval outcomes
 

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15,6 +15,7 @@ servers:
     description: Production server
 security:
   - BasicAuth: []
+  - AgentAuth: []
 tags:
   - name: Platform Configuration
     description: Platform configuration endpoints for managing global settings. You can also configure these settings in the Grid dashboard.
@@ -5288,7 +5289,7 @@ paths:
       summary: Execute a quote
       description: |
         Execute a quote created by the authenticated agent. Requires the EXECUTE_QUOTES permission in the agent's policy.
-        If the agent's policy requires approval for this amount (based on execution mode or approval thresholds), the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount (based on execution mode or approval thresholds), the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
         Once executed, the quote cannot be cancelled.
       operationId: agentExecuteQuote
       tags:
@@ -5452,7 +5453,7 @@ paths:
       summary: Create a transfer-in
       description: |
         Transfer funds from an external account to an internal account for the authenticated agent's customer. Accounts must belong to the agent's customer. Requires the CREATE_TRANSFERS permission in the agent's policy.
-        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
         This endpoint should only be used for external account sources with pull functionality (e.g. ACH Pull). Otherwise, use the payment instructions on the internal account to deposit funds.
       operationId: agentCreateTransferIn
       tags:
@@ -5525,7 +5526,7 @@ paths:
       summary: Create a transfer-out
       description: |
         Transfer funds from an internal account to an external account for the authenticated agent's customer. Accounts must belong to the agent's customer. Requires the CREATE_TRANSFERS permission in the agent's policy.
-        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
       operationId: agentCreateTransferOut
       tags:
         - Agent Operations

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,6 +15,7 @@ servers:
     description: Production server
 security:
   - BasicAuth: []
+  - AgentAuth: []
 tags:
   - name: Platform Configuration
     description: Platform configuration endpoints for managing global settings. You can also configure these settings in the Grid dashboard.
@@ -5288,7 +5289,7 @@ paths:
       summary: Execute a quote
       description: |
         Execute a quote created by the authenticated agent. Requires the EXECUTE_QUOTES permission in the agent's policy.
-        If the agent's policy requires approval for this amount (based on execution mode or approval thresholds), the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount (based on execution mode or approval thresholds), the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
         Once executed, the quote cannot be cancelled.
       operationId: agentExecuteQuote
       tags:
@@ -5452,7 +5453,7 @@ paths:
       summary: Create a transfer-in
       description: |
         Transfer funds from an external account to an internal account for the authenticated agent's customer. Accounts must belong to the agent's customer. Requires the CREATE_TRANSFERS permission in the agent's policy.
-        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
         This endpoint should only be used for external account sources with pull functionality (e.g. ACH Pull). Otherwise, use the payment instructions on the internal account to deposit funds.
       operationId: agentCreateTransferIn
       tags:
@@ -5525,7 +5526,7 @@ paths:
       summary: Create a transfer-out
       description: |
         Transfer funds from an internal account to an external account for the authenticated agent's customer. Accounts must belong to the agent's customer. Requires the CREATE_TRANSFERS permission in the agent's policy.
-        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+        If the agent's policy requires approval for this amount, the transaction will be created in a pending state and must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
       operationId: agentCreateTransferOut
       tags:
         - Agent Operations

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -279,3 +279,4 @@ webhooks:
     $ref: webhooks/verification-update.yaml
 security:
   - BasicAuth: []
+  - AgentAuth: []

--- a/openapi/paths/agents/agents_me_quotes_{quoteId}_execute.yaml
+++ b/openapi/paths/agents/agents_me_quotes_{quoteId}_execute.yaml
@@ -14,7 +14,7 @@ post:
 
     If the agent's policy requires approval for this amount (based on execution mode
     or approval thresholds), the transaction will be created in a pending state and
-    must be approved by the platform via `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+    must be approved by the platform via `POST /agents/{agentId}/actions/{actionId}/approve`.
 
     Once executed, the quote cannot be cancelled.
   operationId: agentExecuteQuote

--- a/openapi/paths/agents/agents_me_transfer-in.yaml
+++ b/openapi/paths/agents/agents_me_transfer-in.yaml
@@ -7,7 +7,7 @@ post:
 
     If the agent's policy requires approval for this amount, the transaction will be
     created in a pending state and must be approved by the platform via
-    `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+    `POST /agents/{agentId}/actions/{actionId}/approve`.
 
     This endpoint should only be used for external account sources with pull functionality
     (e.g. ACH Pull). Otherwise, use the payment instructions on the internal account to

--- a/openapi/paths/agents/agents_me_transfer-out.yaml
+++ b/openapi/paths/agents/agents_me_transfer-out.yaml
@@ -7,7 +7,7 @@ post:
 
     If the agent's policy requires approval for this amount, the transaction will be
     created in a pending state and must be approved by the platform via
-    `POST /agents/{agentId}/transactions/{transactionId}/approve`.
+    `POST /agents/{agentId}/actions/{actionId}/approve`.
   operationId: agentCreateTransferOut
   tags:
     - Agent Operations


### PR DESCRIPTION
## Summary

- **Auth scheme**: Added `AgentAuth` to the global `security` array in `openapi/openapi.yaml`. Per Stainless docs, the top-level security array determines which schemes the SDK client supports — without it, the Stainless `merge` step was failing, which is why the published docs at grid.lightspark.com never reflected the agents endpoints after #430 merged.
- **Stale paths**: Three agent endpoint descriptions still referenced the old `POST /agents/{agentId}/transactions/{transactionId}/approve` path. Updated to `POST /agents/{agentId}/actions/{actionId}/approve`.
- **Phantom status**: `approvals-and-audit.mdx` step 8 documented a `COMPLETED` terminal state that does not exist in `AgentActionStatus`. `APPROVED` is the terminal success state. Removed to prevent integrators from polling for a state that never arrives.

## Test plan

- [ ] Stainless `merge` check passes (unblocks published docs update)
- [ ] Verify agent endpoints appear in published sidebar after merge