### PR TITLE
Require clientPubkey in OTP verify flow

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15611,6 +15611,7 @@ components:
       required:
         - type
         - otp
+        - clientPublicKey
       properties:
         type:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15611,6 +15611,7 @@ components:
       required:
         - type
         - otp
+        - clientPublicKey
       properties:
         type:
           type: string

--- a/openapi/components/schemas/auth/EmailOtpCredentialVerifyRequestFields.yaml
+++ b/openapi/components/schemas/auth/EmailOtpCredentialVerifyRequestFields.yaml
@@ -2,6 +2,7 @@ type: object
 required:
   - type
   - otp
+  - clientPublicKey
 properties:
   type:
     type: string


### PR DESCRIPTION
Sparkcore handler explicitly requires `clientPublicKey` for `EMAIL_OTP`'s verify flow and rejects the request without it. The grid api had `clientPublicKey` as optional in the verify flow requst body, this makes it required.