### PR TITLE
Align auth session request-id contract

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4025,7 +4025,7 @@ paths:
       description: |
         Complete the verification step for a previously created authentication credential and issue a session signing key.
 
-        For `EMAIL_OTP` credentials, supply the one-time password that was emailed to the user along with a client-generated public key. For `OAUTH` credentials, supply a fresh OIDC token (`iat` must be less than 60 seconds before the request) along with the client-generated public key; this is also the reauthentication path after a prior session expired. For `PASSKEY` credentials, the client completes a WebAuthn assertion (`navigator.credentials.get()`) against the Grid-issued `challenge` returned from either `POST /auth/credentials` (first authentication) or `POST /auth/credentials/{id}/challenge` (reauthentication), and submits the resulting `assertion` along with the client-generated public key. The `requestId` that accompanied the challenge must be echoed in the `Request-Id` header so Grid can correlate the assertion with the pending challenge; Grid verifies the WebAuthn signature against the stored credential before issuing the session.
+        For `EMAIL_OTP` credentials, supply the one-time password that was emailed to the user along with a client-generated public key. For `OAUTH` credentials, supply a fresh OIDC token (`iat` must be less than 60 seconds before the request) along with the client-generated public key; this is also the reauthentication path after a prior session expired. For `PASSKEY` credentials, the client completes a WebAuthn assertion (`navigator.credentials.get()`) against the Grid-issued `challenge` returned from `POST /auth/credentials/{id}/challenge`, and submits the resulting `assertion` with the `Request-Id` header. The `clientPublicKey` for `PASSKEY` credentials is supplied on the challenge call, where it is bound into the pending session-creation request.
 
         On success, the response contains an `encryptedSessionSigningKey` that is encrypted to the supplied `clientPublicKey`, along with an `expiresAt` timestamp marking when the session expires. The `clientPublicKey` is ephemeral and one-time-use per verification request.
       operationId: verifyAuthCredential
@@ -4043,7 +4043,7 @@ paths:
         - name: Request-Id
           in: header
           required: false
-          description: The `requestId` returned alongside the Grid-issued `challenge` from `POST /auth/credentials` or `POST /auth/credentials/{id}/challenge`, echoed back here so Grid can correlate the assertion with the pending challenge. Required when `type` is `PASSKEY`; ignored for `EMAIL_OTP` and `OAUTH`.
+          description: The `requestId` returned alongside the Grid-issued `challenge` from `POST /auth/credentials/{id}/challenge`, echoed back here so Grid can correlate the assertion with the pending challenge.
           schema:
             type: string
           example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4025,7 +4025,7 @@ paths:
       description: |
         Complete the verification step for a previously created authentication credential and issue a session signing key.
 
-        For `EMAIL_OTP` credentials, supply the one-time password that was emailed to the user along with a client-generated public key. For `OAUTH` credentials, supply a fresh OIDC token (`iat` must be less than 60 seconds before the request) along with the client-generated public key; this is also the reauthentication path after a prior session expired. For `PASSKEY` credentials, the client completes a WebAuthn assertion (`navigator.credentials.get()`) against the Grid-issued `challenge` returned from either `POST /auth/credentials` (first authentication) or `POST /auth/credentials/{id}/challenge` (reauthentication), and submits the resulting `assertion` along with the client-generated public key. The `requestId` that accompanied the challenge must be echoed in the `Request-Id` header so Grid can correlate the assertion with the pending challenge; Grid verifies the WebAuthn signature against the stored credential before issuing the session.
+        For `EMAIL_OTP` credentials, supply the one-time password that was emailed to the user along with a client-generated public key. For `OAUTH` credentials, supply a fresh OIDC token (`iat` must be less than 60 seconds before the request) along with the client-generated public key; this is also the reauthentication path after a prior session expired. For `PASSKEY` credentials, the client completes a WebAuthn assertion (`navigator.credentials.get()`) against the Grid-issued `challenge` returned from `POST /auth/credentials/{id}/challenge`, and submits the resulting `assertion` with the `Request-Id` header. The `clientPublicKey` for `PASSKEY` credentials is supplied on the challenge call, where it is bound into the pending session-creation request.
 
         On success, the response contains an `encryptedSessionSigningKey` that is encrypted to the supplied `clientPublicKey`, along with an `expiresAt` timestamp marking when the session expires. The `clientPublicKey` is ephemeral and one-time-use per verification request.
       operationId: verifyAuthCredential
@@ -4043,7 +4043,7 @@ paths:
         - name: Request-Id
           in: header
           required: false
-          description: The `requestId` returned alongside the Grid-issued `challenge` from `POST /auth/credentials` or `POST /auth/credentials/{id}/challenge`, echoed back here so Grid can correlate the assertion with the pending challenge. Required when `type` is `PASSKEY`; ignored for `EMAIL_OTP` and `OAUTH`.
+          description: The `requestId` returned alongside the Grid-issued `challenge` from `POST /auth/credentials/{id}/challenge`, echoed back here so Grid can correlate the assertion with the pending challenge.
           schema:
             type: string
           example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21

--- a/openapi/paths/auth/auth_credentials_{id}_verify.yaml
+++ b/openapi/paths/auth/auth_credentials_{id}_verify.yaml
@@ -12,14 +12,11 @@ post:
     public key; this is also the reauthentication path after a prior
     session expired. For `PASSKEY` credentials, the client completes a
     WebAuthn assertion (`navigator.credentials.get()`) against the
-    Grid-issued `challenge` returned from either `POST /auth/credentials`
-    (first authentication) or `POST /auth/credentials/{id}/challenge`
-    (reauthentication), and submits the resulting `assertion` along with
-    the client-generated public key. The `requestId` that accompanied
-    the challenge must be echoed in the `Request-Id` header so Grid can
-    correlate the assertion with the pending challenge; Grid verifies
-    the WebAuthn signature against the stored credential before issuing
-    the session.
+    Grid-issued `challenge` returned from
+    `POST /auth/credentials/{id}/challenge`, and submits the resulting
+    `assertion` with the `Request-Id` header. The `clientPublicKey`
+    for `PASSKEY` credentials is supplied on the challenge call, where
+    it is bound into the pending session-creation request.
 
 
     On success, the response contains an `encryptedSessionSigningKey`
@@ -46,10 +43,8 @@ post:
       required: false
       description: >-
         The `requestId` returned alongside the Grid-issued `challenge` from
-        `POST /auth/credentials` or `POST /auth/credentials/{id}/challenge`,
-        echoed back here so Grid can correlate the assertion with the
-        pending challenge. Required when `type` is `PASSKEY`; ignored for
-        `EMAIL_OTP` and `OAUTH`.
+        `POST /auth/credentials/{id}/challenge`, echoed back here so Grid
+        can correlate the assertion with the pending challenge.
       schema:
         type: string
       example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21


### PR DESCRIPTION
- Fix some description to be more accurate for new API endpoints. POST /auth/credentials no longer emis a challenge