### PR TITLE
Add passkey credentialId to auth challenge response

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -453,12 +453,10 @@ resources:
           auth_credential_verify_request_one_of: '#/components/schemas/AuthCredentialVerifyRequestOneOf'
           auth_signed_request_challenge: '#/components/schemas/AuthSignedRequestChallenge'
           email_otp_credential_create_request: '#/components/schemas/EmailOtpCredentialCreateRequest'
-          email_otp_credential_verify_request: '#/components/schemas/EmailOtpCredentialVerifyRequest'
           email_otp_credential_create_request_fields: '#/components/schemas/EmailOtpCredentialCreateRequestFields'
           email_otp_credential_verify_request_fields: '#/components/schemas/EmailOtpCredentialVerifyRequestFields'
           oauth_credential_create_request: '#/components/schemas/OauthCredentialCreateRequest'
           oauth_credential_create_request_fields: '#/components/schemas/OauthCredentialCreateRequestFields'
-          oauth_credential_verify_request: '#/components/schemas/OauthCredentialVerifyRequest'
           oauth_credential_verify_request_fields: '#/components/schemas/OauthCredentialVerifyRequestFields'
           passkey_attestation: '#/components/schemas/PasskeyAttestation'
           passkey_assertion: '#/components/schemas/PasskeyAssertion'
@@ -467,7 +465,6 @@ resources:
           passkey_auth_challenge: '#/components/schemas/PasskeyAuthChallenge'
           auth_method_response: '#/components/schemas/AuthMethodResponse'
           auth_credential_response_one_of: '#/components/schemas/AuthCredentialResponseOneOf'
-          passkey_credential_verify_request: '#/components/schemas/PasskeyCredentialVerifyRequest'
           passkey_credential_verify_request_fields: '#/components/schemas/PasskeyCredentialVerifyRequestFields'
           signed_request_challenge: "#/components/schemas/SignedRequestChallenge"
       sessions:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4123,7 +4123,7 @@ paths:
 
         `OAUTH` credentials do not have a challenge step. To authenticate or reauthenticate an OAuth credential, call `POST /auth/credentials/{id}/verify` with a fresh OIDC token and a `clientPublicKey`.
 
-        For `PASSKEY` credentials, this issues a fresh Grid-generated WebAuthn challenge for reauthentication. The request body must carry the client's ephemeral `clientPublicKey` so Grid can bake it into the Turnkey session-creation payload the returned challenge is computed from — this seals the resulting session signing key to the client. The response is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the new `challenge`, `requestId`, and `expiresAt`. The client passes the `challenge` into `navigator.credentials.get()` and submits the resulting assertion to `POST /auth/credentials/{id}/verify` with `Request-Id: <requestId>` to receive a session.
+        For `PASSKEY` credentials, this issues a fresh Grid-generated WebAuthn challenge for reauthentication. The request body must carry the client's ephemeral `clientPublicKey` so Grid can bake it into the Turnkey session-creation payload the returned challenge is computed from — this seals the resulting session signing key to the client. The response is a `PasskeyAuthChallenge` — the passkey auth method fields plus the WebAuthn `credentialId`, new `challenge`, `requestId`, and `expiresAt`. The client passes `credentialId` as `allowCredentials[].id` and `challenge` as the WebAuthn challenge in `navigator.credentials.get()`, then submits the resulting assertion to `POST /auth/credentials/{id}/verify` with `Request-Id: <requestId>` to receive a session.
       operationId: challengeAuthCredential
       tags:
         - Embedded Wallet Auth
@@ -4153,7 +4153,7 @@ paths:
                 value: {}
       responses:
         '200':
-          description: Challenge re-issued for the authentication credential. For `EMAIL_OTP` the body is a plain `AuthMethod` and a new OTP email has been sent. For `PASSKEY` the body is a `PasskeyAuthChallenge` carrying the freshly issued `challenge`, `requestId`, and `expiresAt` required to complete reauthentication via `POST /auth/credentials/{id}/verify`.
+          description: Challenge re-issued for the authentication credential. For `EMAIL_OTP` the body is a plain `AuthMethod` and a new OTP email has been sent. For `PASSKEY` the body is a `PasskeyAuthChallenge` carrying the passkey `credentialId`, freshly issued `challenge`, `requestId`, and `expiresAt` required to complete reauthentication via `POST /auth/credentials/{id}/verify`.
           content:
             application/json:
               schema:
@@ -4174,6 +4174,7 @@ paths:
                     id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
                     accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     type: PASSKEY
+                    credentialId: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
                     nickname: iPhone Face-ID
                     createdAt: '2026-04-08T15:30:01Z'
                     updatedAt: '2026-04-08T15:35:00Z'
@@ -15766,15 +15767,20 @@ components:
           example: 04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2
     PasskeyAuthChallenge:
       title: Passkey Auth Challenge
-      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials` (first-authentication case) and `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a Grid-issued `challenge`, the corresponding `requestId`, and the challenge's `expiresAt` to the base `AuthMethod` fields. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
+      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials/{id}/challenge`. Includes the WebAuthn `credentialId` needed to target the passkey, plus the Grid-issued `challenge`, corresponding `requestId`, and challenge `expiresAt`. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
       allOf:
         - $ref: '#/components/schemas/AuthMethod'
         - type: object
           required:
+            - credentialId
             - challenge
             - requestId
             - expiresAt
           properties:
+            credentialId:
+              type: string
+              description: Base64url-encoded WebAuthn credential identifier for this passkey. Corresponds to `PublicKeyCredential.rawId`; pass this value as `allowCredentials[].id` when requesting a passkey assertion for this auth method.
+              example: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
             challenge:
               type: string
               description: Base64url-encoded challenge issued by Grid for the pending passkey authentication. The client passes it into `navigator.credentials.get()` as the WebAuthn challenge; the resulting assertion is submitted to `POST /auth/credentials/{id}/verify`. Single-use; a new challenge is issued on the next call to `POST /auth/credentials/{id}/challenge`.
@@ -15790,7 +15796,7 @@ components:
               example: '2026-04-08T15:35:00Z'
     AuthCredentialResponseOneOf:
       title: Auth Credential Response
-      description: Discriminated response shape returned from `POST /auth/credentials/{id}/challenge`. For `EMAIL_OTP` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion. OAuth credentials do not use the challenge endpoint. Registration responses from `POST /auth/credentials` use the simpler `AuthMethodResponse` shape directly for all three credential types.
+      description: Discriminated response shape returned from `POST /auth/credentials/{id}/challenge`. For `EMAIL_OTP` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the passkey auth method fields plus the WebAuthn `credentialId`, Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion. OAuth credentials do not use the challenge endpoint. Registration responses from `POST /auth/credentials` use the simpler `AuthMethodResponse` shape directly for all three credential types.
       oneOf:
         - $ref: '#/components/schemas/AuthMethodResponse'
         - $ref: '#/components/schemas/PasskeyAuthChallenge'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4123,7 +4123,7 @@ paths:
 
         `OAUTH` credentials do not have a challenge step. To authenticate or reauthenticate an OAuth credential, call `POST /auth/credentials/{id}/verify` with a fresh OIDC token and a `clientPublicKey`.
 
-        For `PASSKEY` credentials, this issues a fresh Grid-generated WebAuthn challenge for reauthentication. The request body must carry the client's ephemeral `clientPublicKey` so Grid can bake it into the Turnkey session-creation payload the returned challenge is computed from — this seals the resulting session signing key to the client. The response is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the new `challenge`, `requestId`, and `expiresAt`. The client passes the `challenge` into `navigator.credentials.get()` and submits the resulting assertion to `POST /auth/credentials/{id}/verify` with `Request-Id: <requestId>` to receive a session.
+        For `PASSKEY` credentials, this issues a fresh Grid-generated WebAuthn challenge for reauthentication. The request body must carry the client's ephemeral `clientPublicKey` so Grid can bake it into the Turnkey session-creation payload the returned challenge is computed from — this seals the resulting session signing key to the client. The response is a `PasskeyAuthChallenge` — the passkey auth method fields plus the WebAuthn `credentialId`, new `challenge`, `requestId`, and `expiresAt`. The client passes `credentialId` as `allowCredentials[].id` and `challenge` as the WebAuthn challenge in `navigator.credentials.get()`, then submits the resulting assertion to `POST /auth/credentials/{id}/verify` with `Request-Id: <requestId>` to receive a session.
       operationId: challengeAuthCredential
       tags:
         - Embedded Wallet Auth
@@ -4153,7 +4153,7 @@ paths:
                 value: {}
       responses:
         '200':
-          description: Challenge re-issued for the authentication credential. For `EMAIL_OTP` the body is a plain `AuthMethod` and a new OTP email has been sent. For `PASSKEY` the body is a `PasskeyAuthChallenge` carrying the freshly issued `challenge`, `requestId`, and `expiresAt` required to complete reauthentication via `POST /auth/credentials/{id}/verify`.
+          description: Challenge re-issued for the authentication credential. For `EMAIL_OTP` the body is a plain `AuthMethod` and a new OTP email has been sent. For `PASSKEY` the body is a `PasskeyAuthChallenge` carrying the passkey `credentialId`, freshly issued `challenge`, `requestId`, and `expiresAt` required to complete reauthentication via `POST /auth/credentials/{id}/verify`.
           content:
             application/json:
               schema:
@@ -4174,6 +4174,7 @@ paths:
                     id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
                     accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     type: PASSKEY
+                    credentialId: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
                     nickname: iPhone Face-ID
                     createdAt: '2026-04-08T15:30:01Z'
                     updatedAt: '2026-04-08T15:35:00Z'
@@ -15766,15 +15767,20 @@ components:
           example: 04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2
     PasskeyAuthChallenge:
       title: Passkey Auth Challenge
-      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials` (first-authentication case) and `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a Grid-issued `challenge`, the corresponding `requestId`, and the challenge's `expiresAt` to the base `AuthMethod` fields. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
+      description: Extended `AuthMethod` shape returned for `PASSKEY` credentials from `POST /auth/credentials/{id}/challenge`. Includes the WebAuthn `credentialId` needed to target the passkey, plus the Grid-issued `challenge`, corresponding `requestId`, and challenge `expiresAt`. The client signs the challenge with the passkey to produce the assertion submitted to `POST /auth/credentials/{id}/verify`.
       allOf:
         - $ref: '#/components/schemas/AuthMethod'
         - type: object
           required:
+            - credentialId
             - challenge
             - requestId
             - expiresAt
           properties:
+            credentialId:
+              type: string
+              description: Base64url-encoded WebAuthn credential identifier for this passkey. Corresponds to `PublicKeyCredential.rawId`; pass this value as `allowCredentials[].id` when requesting a passkey assertion for this auth method.
+              example: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
             challenge:
               type: string
               description: Base64url-encoded challenge issued by Grid for the pending passkey authentication. The client passes it into `navigator.credentials.get()` as the WebAuthn challenge; the resulting assertion is submitted to `POST /auth/credentials/{id}/verify`. Single-use; a new challenge is issued on the next call to `POST /auth/credentials/{id}/challenge`.
@@ -15790,7 +15796,7 @@ components:
               example: '2026-04-08T15:35:00Z'
     AuthCredentialResponseOneOf:
       title: Auth Credential Response
-      description: Discriminated response shape returned from `POST /auth/credentials/{id}/challenge`. For `EMAIL_OTP` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion. OAuth credentials do not use the challenge endpoint. Registration responses from `POST /auth/credentials` use the simpler `AuthMethodResponse` shape directly for all three credential types.
+      description: Discriminated response shape returned from `POST /auth/credentials/{id}/challenge`. For `EMAIL_OTP` credentials the body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to disambiguate the oneOf). For `PASSKEY` credentials the body is a `PasskeyAuthChallenge` — the passkey auth method fields plus the WebAuthn `credentialId`, Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the subsequent assertion. OAuth credentials do not use the challenge endpoint. Registration responses from `POST /auth/credentials` use the simpler `AuthMethodResponse` shape directly for all three credential types.
       oneOf:
         - $ref: '#/components/schemas/AuthMethodResponse'
         - $ref: '#/components/schemas/PasskeyAuthChallenge'

--- a/openapi/components/schemas/auth/AuthCredentialResponseOneOf.yaml
+++ b/openapi/components/schemas/auth/AuthCredentialResponseOneOf.yaml
@@ -4,9 +4,10 @@ description: >-
   `POST /auth/credentials/{id}/challenge`. For `EMAIL_OTP` credentials the
   body is a plain `AuthMethod` (wrapped as `AuthMethodResponse` to
   disambiguate the oneOf). For `PASSKEY` credentials the body is a
-  `PasskeyAuthChallenge` — the base `AuthMethod` fields plus the
-  Grid-issued `challenge`, `requestId`, and `expiresAt` that drive the
-  subsequent assertion. OAuth credentials do not use the challenge endpoint.
+  `PasskeyAuthChallenge` — the passkey auth method fields plus the
+  WebAuthn `credentialId`, Grid-issued `challenge`, `requestId`, and
+  `expiresAt` that drive the subsequent assertion. OAuth credentials do not
+  use the challenge endpoint.
   Registration responses from `POST /auth/credentials` use the simpler
   `AuthMethodResponse` shape directly for all three credential types.
 oneOf:

--- a/openapi/components/schemas/auth/PasskeyAuthChallenge.yaml
+++ b/openapi/components/schemas/auth/PasskeyAuthChallenge.yaml
@@ -1,20 +1,28 @@
 title: Passkey Auth Challenge
 description: >-
   Extended `AuthMethod` shape returned for `PASSKEY` credentials from
-  `POST /auth/credentials` (first-authentication case) and
-  `POST /auth/credentials/{id}/challenge` (reauthentication case). Adds a
-  Grid-issued `challenge`, the corresponding `requestId`, and the
-  challenge's `expiresAt` to the base `AuthMethod` fields. The client signs
-  the challenge with the passkey to produce the assertion submitted to
-  `POST /auth/credentials/{id}/verify`.
+  `POST /auth/credentials/{id}/challenge`. Includes the WebAuthn
+  `credentialId` needed to target the passkey, plus the Grid-issued
+  `challenge`, corresponding `requestId`, and challenge `expiresAt`. The
+  client signs the challenge with the passkey to produce the assertion
+  submitted to `POST /auth/credentials/{id}/verify`.
 allOf:
   - $ref: ./AuthMethod.yaml
   - type: object
     required:
+      - credentialId
       - challenge
       - requestId
       - expiresAt
     properties:
+      credentialId:
+        type: string
+        description: >-
+          Base64url-encoded WebAuthn credential identifier for this passkey.
+          Corresponds to `PublicKeyCredential.rawId`; pass this value as
+          `allowCredentials[].id` when requesting a passkey assertion for this
+          auth method.
+        example: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
       challenge:
         type: string
         description: >-

--- a/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
+++ b/openapi/paths/auth/auth_credentials_{id}_challenge.yaml
@@ -23,11 +23,13 @@ post:
     client's ephemeral `clientPublicKey` so Grid can bake it into the
     Turnkey session-creation payload the returned challenge is computed
     from — this seals the resulting session signing key to the client.
-    The response is a `PasskeyAuthChallenge` — the base `AuthMethod`
-    fields plus the new `challenge`, `requestId`, and `expiresAt`. The
-    client passes the `challenge` into `navigator.credentials.get()` and
-    submits the resulting assertion to `POST /auth/credentials/{id}/verify`
-    with `Request-Id: <requestId>` to receive a session.
+    The response is a `PasskeyAuthChallenge` — the passkey auth method
+    fields plus the WebAuthn `credentialId`, new `challenge`, `requestId`,
+    and `expiresAt`. The client passes `credentialId` as
+    `allowCredentials[].id` and `challenge` as the WebAuthn challenge in
+    `navigator.credentials.get()`, then submits the resulting assertion to
+    `POST /auth/credentials/{id}/verify` with `Request-Id: <requestId>` to
+    receive a session.
   operationId: challengeAuthCredential
   tags:
     - Embedded Wallet Auth
@@ -67,9 +69,9 @@ post:
         Challenge re-issued for the authentication credential. For
         `EMAIL_OTP` the body is a plain `AuthMethod` and a new OTP email
         has been sent. For `PASSKEY` the body is a `PasskeyAuthChallenge`
-        carrying the freshly issued `challenge`, `requestId`, and
-        `expiresAt` required to complete reauthentication via
-        `POST /auth/credentials/{id}/verify`.
+        carrying the passkey `credentialId`, freshly issued `challenge`,
+        `requestId`, and `expiresAt` required to complete reauthentication
+        via `POST /auth/credentials/{id}/verify`.
       content:
         application/json:
           schema:
@@ -90,6 +92,7 @@ post:
                 id: AuthMethod:019542f5-b3e7-1d02-0000-000000000001
                 accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 type: PASSKEY
+                credentialId: KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew
                 nickname: iPhone Face-ID
                 createdAt: '2026-04-08T15:30:01Z'
                 updatedAt: '2026-04-08T15:35:00Z'


### PR DESCRIPTION
Summary:

- Make PasskeyAuthChallenge extend the passkey auth method shape so challenge responses include credentialId.
- Document using credentialId as allowCredentials[].id when calling navigator.credentials.get().
- Update the passkey challenge response example.

![Screenshot 2026-05-07 at 4.38.03 PM.png](https://app.graphite.com/user-attachments/assets/570af4cc-046c-4d48-a164-09b989fae65d.png)

https://docs.google.com/document/d/18f3pLcXbLein9McsXxiPzVJMmXhBFGWQ-6Gys5WILLk/edit?tab=t.zg1lhkeq1hek

Test:

- npm run lint:openapi