### PR TITLE
Sync country-support Coming Soon list with corridor source of truth

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -96,7 +96,22 @@ Grid is rapidly expanding. These corridors are next on our roadmap — get in to
 
 | Country | ISO Code |
 |---|---|
+| 🇧🇩 Bangladesh | BD |
 | 🇨🇦 Canada | CA |
 | 🇨🇳 China | CN |
+| 🇨🇴 Colombia | CO |
+| 🇩🇴 Dominican Republic | DO |
+| 🇪🇬 Egypt | EG |
+| 🇸🇻 El Salvador | SV |
+| 🇪🇹 Ethiopia | ET |
+| 🇬🇭 Ghana | GH |
+| 🇬🇹 Guatemala | GT |
+| 🇭🇹 Haiti | HT |
+| 🇭🇳 Honduras | HN |
 | 🇭🇰 Hong Kong | HK |
+| 🇱🇷 Liberia | LR |
+| 🇲🇦 Morocco | MA |
+| 🇳🇵 Nepal | NP |
+| 🇵🇰 Pakistan | PK |
 | 🇰🇷 South Korea | KR |
+| 🇹🇴 Tonga | TO |


### PR DESCRIPTION
## Summary

- Expanded the **Coming Soon** table in `mintlify/snippets/country-support.mdx` from **4 → 19 countries**, based on the [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) spreadsheet.
- Includes every destination whose status is `H1 2026 Plan` or `Scoping` and that is not already Live.
- The **Live** list (55 countries) already matches the source of truth — no changes there.

### Newly added to Coming Soon
Bangladesh, Colombia, Dominican Republic, Egypt, El Salvador, Ethiopia, Ghana, Guatemala, Haiti, Honduras, Liberia, Morocco, Nepal, Pakistan, Tonga (Canada, China, Hong Kong, South Korea were already listed).

### Excluded
Destinations with status `Blocked` or `Deprecating` are intentionally omitted (Botswana, Burkina Faso, Congo Brazzaville, DR Congo, Gabon, Jamaica, Mali, Togo, Ukraine, plus the deprecating Brazil → US Zero Hash route).

## Test plan
- [ ] Render `mintlify/global-p2p/country-support.mdx` locally with `make mint` and confirm the Coming Soon table shows all 19 countries with correct flags/ISO codes.

🤖 Generated by an automated [country-coverage-doc-sync](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184) scheduled task.