### PR TITLE
docs: note that fees may fluctuate with FX rates

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14103,7 +14103,7 @@ components:
           description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
           example: UMA-Q12345-REF
     IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
+      description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - gridApiMultiplier
@@ -14230,7 +14230,7 @@ components:
           description: Reason for the refund
           example: TRANSACTION_FAILED
     OutgoingRateDetails:
-      description: Details about the rate and fees for an outgoing transaction or quote.
+      description: 'Details about the rate and fees for an outgoing transaction or quote. Note: `counterpartyFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - counterpartyMultiplier
@@ -14717,7 +14717,7 @@ components:
         feesIncluded:
           type: integer
           format: int64
-          description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
+          description: 'The fees associated with the quote in the smallest unit of the sending currency (eg. cents). Note: this value may fluctuate between quotes — some underlying fee components are defined in the receiving currency, so their equivalent in the sending currency moves with the FX rate. The fees shown here are locked only for the lifetime of this quote.'
           minimum: 0
           example: 10
         paymentInstructions:

--- a/mintlify/platform-overview/core-concepts/quote-system.mdx
+++ b/mintlify/platform-overview/core-concepts/quote-system.mdx
@@ -340,6 +340,15 @@ Fees are deducted from the sending amount, so:
 - **Amount converted**: $995.00
 - **Recipient receives**: €915.40 (at 0.92 rate)
 
+<Note>
+  Quoted fees may fluctuate between quotes. Some fee components (e.g.
+  `counterpartyFixedFee` on outgoing transfers, and `gridApiFixedFee` on
+  incoming transfers) are denominated in the receiving currency, so their
+  value in the sending currency moves with the FX rate. Always reference the
+  fees in the latest quote response — they are locked only for the lifetime
+  of that quote.
+</Note>
+
 ## Best Practices
 
 <AccordionGroup>

--- a/mintlify/snippets/sending/cross-currency.mdx
+++ b/mintlify/snippets/sending/cross-currency.mdx
@@ -89,6 +89,14 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
 <Warning>
   Quote expiration depends on the corridor but is typically ~5 minutes or greater. If expired, create a new quote to get an updated exchange rate.
 </Warning>
+
+<Note>
+  Quoted fees may fluctuate between quotes. Some underlying fee components
+  are denominated in the receiving currency, so their equivalent in the
+  sending currency moves with the FX rate. The fee shown in the quote is
+  locked only for the lifetime of that quote — a new quote for the same
+  transfer may return a different total.
+</Note>
 </Step>
 
 <Step title="Execute the quote">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14103,7 +14103,7 @@ components:
           description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
           example: UMA-Q12345-REF
     IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
+      description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - gridApiMultiplier
@@ -14230,7 +14230,7 @@ components:
           description: Reason for the refund
           example: TRANSACTION_FAILED
     OutgoingRateDetails:
-      description: Details about the rate and fees for an outgoing transaction or quote.
+      description: 'Details about the rate and fees for an outgoing transaction or quote. Note: `counterpartyFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - counterpartyMultiplier
@@ -14717,7 +14717,7 @@ components:
         feesIncluded:
           type: integer
           format: int64
-          description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
+          description: 'The fees associated with the quote in the smallest unit of the sending currency (eg. cents). Note: this value may fluctuate between quotes — some underlying fee components are defined in the receiving currency, so their equivalent in the sending currency moves with the FX rate. The fees shown here are locked only for the lifetime of this quote.'
           minimum: 0
           example: 10
         paymentInstructions:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -74,7 +74,10 @@ properties:
     format: int64
     description: >-
       The fees associated with the quote in the smallest unit of the sending
-      currency (eg. cents).
+      currency (eg. cents). Note: this value may fluctuate between quotes —
+      some underlying fee components are defined in the receiving currency,
+      so their equivalent in the sending currency moves with the FX rate.
+      The fees shown here are locked only for the lifetime of this quote.
     minimum: 0
     example: 10
   paymentInstructions:

--- a/openapi/components/schemas/transactions/IncomingRateDetails.yaml
+++ b/openapi/components/schemas/transactions/IncomingRateDetails.yaml
@@ -1,4 +1,9 @@
-description: Details about the rate and fees for an incoming transaction.
+description: >-
+  Details about the rate and fees for an incoming transaction.
+  Note: `gridApiFixedFee` is denominated in the receiving currency, so its
+  equivalent value in the sending currency fluctuates with the FX rate.
+  As a result, the total fee on a subsequent quote for the same transfer
+  may differ even if the underlying fee structure is unchanged.
 type: object
 required:
   - gridApiMultiplier

--- a/openapi/components/schemas/transactions/OutgoingRateDetails.yaml
+++ b/openapi/components/schemas/transactions/OutgoingRateDetails.yaml
@@ -1,4 +1,9 @@
-description: Details about the rate and fees for an outgoing transaction or quote.
+description: >-
+  Details about the rate and fees for an outgoing transaction or quote.
+  Note: `counterpartyFixedFee` is denominated in the receiving currency, so
+  its equivalent value in the sending currency fluctuates with the FX rate.
+  As a result, the total fee on a subsequent quote for the same transfer
+  may differ even if the underlying fee structure is unchanged.
 type: object
 required:
   - counterpartyMultiplier


### PR DESCRIPTION
Some fee components are denominated in the receiving currency, so their
equivalent value in the sending currency moves with the FX rate between
quotes. Add a callout in the cross-currency send snippet and the Quote
System guide, and extend the OpenAPI descriptions on `feesIncluded`,
`OutgoingRateDetails`, and `IncomingRateDetails` so the same note shows
up in the API reference.