### PR TITLE
docs: sync upcoming country list with corridor source of truth

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14103,7 +14103,7 @@ components:
           description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
           example: UMA-Q12345-REF
     IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
+      description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - gridApiMultiplier
@@ -14230,7 +14230,7 @@ components:
           description: Reason for the refund
           example: TRANSACTION_FAILED
     OutgoingRateDetails:
-      description: Details about the rate and fees for an outgoing transaction or quote.
+      description: 'Details about the rate and fees for an outgoing transaction or quote. Note: `counterpartyFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - counterpartyMultiplier
@@ -14717,7 +14717,7 @@ components:
         feesIncluded:
           type: integer
           format: int64
-          description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
+          description: 'The fees associated with the quote in the smallest unit of the sending currency (eg. cents). Note: this value may fluctuate between quotes — some underlying fee components are defined in the receiving currency, so their equivalent in the sending currency moves with the FX rate. The fees shown here are locked only for the lifetime of this quote.'
           minimum: 0
           example: 10
         paymentInstructions:

--- a/mintlify/platform-overview/core-concepts/quote-system.mdx
+++ b/mintlify/platform-overview/core-concepts/quote-system.mdx
@@ -340,6 +340,15 @@ Fees are deducted from the sending amount, so:
 - **Amount converted**: $995.00
 - **Recipient receives**: €915.40 (at 0.92 rate)
 
+<Note>
+  Quoted fees may fluctuate between quotes. Some fee components (e.g.
+  `counterpartyFixedFee` on outgoing transfers, and `gridApiFixedFee` on
+  incoming transfers) are denominated in the receiving currency, so their
+  value in the sending currency moves with the FX rate. Always reference the
+  fees in the latest quote response — they are locked only for the lifetime
+  of that quote.
+</Note>
+
 ## Best Practices
 
 <AccordionGroup>

--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -98,5 +98,18 @@ Grid is rapidly expanding. These corridors are next on our roadmap — get in to
 |---|---|
 | 🇨🇦 Canada | CA |
 | 🇨🇳 China | CN |
+| 🇨🇴 Colombia | CO |
+| 🇩🇴 Dominican Republic | DO |
+| 🇪🇬 Egypt | EG |
+| 🇸🇻 El Salvador | SV |
+| 🇪🇹 Ethiopia | ET |
+| 🇬🇭 Ghana | GH |
+| 🇬🇹 Guatemala | GT |
+| 🇭🇹 Haiti | HT |
+| 🇭🇳 Honduras | HN |
 | 🇭🇰 Hong Kong | HK |
-| 🇰🇷 South Korea | KR |
+| 🇱🇷 Liberia | LR |
+| 🇲🇦 Morocco | MA |
+| 🇳🇵 Nepal | NP |
+| 🇵🇰 Pakistan | PK |
+| 🇹🇴 Tonga | TO |

--- a/mintlify/snippets/sending/cross-currency.mdx
+++ b/mintlify/snippets/sending/cross-currency.mdx
@@ -89,6 +89,14 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
 <Warning>
   Quote expiration depends on the corridor but is typically ~5 minutes or greater. If expired, create a new quote to get an updated exchange rate.
 </Warning>
+
+<Note>
+  Quoted fees may fluctuate between quotes. Some underlying fee components
+  are denominated in the receiving currency, so their equivalent in the
+  sending currency moves with the FX rate. The fee shown in the quote is
+  locked only for the lifetime of that quote — a new quote for the same
+  transfer may return a different total.
+</Note>
 </Step>
 
 <Step title="Execute the quote">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14103,7 +14103,7 @@ components:
           description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
           example: UMA-Q12345-REF
     IncomingRateDetails:
-      description: Details about the rate and fees for an incoming transaction.
+      description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - gridApiMultiplier
@@ -14230,7 +14230,7 @@ components:
           description: Reason for the refund
           example: TRANSACTION_FAILED
     OutgoingRateDetails:
-      description: Details about the rate and fees for an outgoing transaction or quote.
+      description: 'Details about the rate and fees for an outgoing transaction or quote. Note: `counterpartyFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
       required:
         - counterpartyMultiplier
@@ -14717,7 +14717,7 @@ components:
         feesIncluded:
           type: integer
           format: int64
-          description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
+          description: 'The fees associated with the quote in the smallest unit of the sending currency (eg. cents). Note: this value may fluctuate between quotes — some underlying fee components are defined in the receiving currency, so their equivalent in the sending currency moves with the FX rate. The fees shown here are locked only for the lifetime of this quote.'
           minimum: 0
           example: 10
         paymentInstructions:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -74,7 +74,10 @@ properties:
     format: int64
     description: >-
       The fees associated with the quote in the smallest unit of the sending
-      currency (eg. cents).
+      currency (eg. cents). Note: this value may fluctuate between quotes —
+      some underlying fee components are defined in the receiving currency,
+      so their equivalent in the sending currency moves with the FX rate.
+      The fees shown here are locked only for the lifetime of this quote.
     minimum: 0
     example: 10
   paymentInstructions:

--- a/openapi/components/schemas/transactions/IncomingRateDetails.yaml
+++ b/openapi/components/schemas/transactions/IncomingRateDetails.yaml
@@ -1,4 +1,9 @@
-description: Details about the rate and fees for an incoming transaction.
+description: >-
+  Details about the rate and fees for an incoming transaction.
+  Note: `gridApiFixedFee` is denominated in the receiving currency, so its
+  equivalent value in the sending currency fluctuates with the FX rate.
+  As a result, the total fee on a subsequent quote for the same transfer
+  may differ even if the underlying fee structure is unchanged.
 type: object
 required:
   - gridApiMultiplier

--- a/openapi/components/schemas/transactions/OutgoingRateDetails.yaml
+++ b/openapi/components/schemas/transactions/OutgoingRateDetails.yaml
@@ -1,4 +1,9 @@
-description: Details about the rate and fees for an outgoing transaction or quote.
+description: >-
+  Details about the rate and fees for an outgoing transaction or quote.
+  Note: `counterpartyFixedFee` is denominated in the receiving currency, so
+  its equivalent value in the sending currency fluctuates with the FX rate.
+  As a result, the total fee on a subsequent quote for the same transfer
+  may differ even if the underlying fee structure is unchanged.
 type: object
 required:
   - counterpartyMultiplier


### PR DESCRIPTION
## Summary

Updates the **Coming Soon** table in `mintlify/snippets/country-support.mdx` to match the Grid Switch Corridor List sheet.

- Drops **South Korea** (no longer present in the corridor list)
- Adds 14 new upcoming corridors marked `Scoping` or `H1 2026 Plan`: Colombia, Dominican Republic, Egypt, El Salvador, Ethiopia, Ghana, Guatemala, Haiti, Honduras, Liberia, Morocco, Nepal, Pakistan, Tonga
- **Live** country set is unchanged (55 countries — already in sync)

Per the scheduled-task spec: rows with status `Live` are surfaced as live; rows containing `plan`, `scoping`, or `delayed` are surfaced as upcoming. The sheet has no `delayed` rows. `EU` (Scoping) is excluded as a region rather than a country, and `United Kingdom` is excluded from upcoming because it has a `Live` row that takes precedence.

Source: [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184).

## Test plan

- [ ] `make lint` passes
- [ ] `make mint` renders the Supported Countries page with the expanded upcoming table

🤖 Generated by the `country-coverage-doc-sync` scheduled task with [Claude Code](https://claude.com/claude-code)