### PR TITLE
Add SLV_ACCOUNT external-account type for El Salvador

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -10558,6 +10558,74 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+    SlvAccountInfoBase:
+      type: object
+      required:
+        - accountType
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - BANK_TRANSFER: bankAccountType, accountNumber
+        - MOBILE_MONEY: phoneNumber
+      properties:
+        accountType:
+          type: string
+          enum:
+            - SLV_ACCOUNT
+        bankName:
+          type: string
+          description: The name of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 255
+        accountNumber:
+          type: string
+          description: The account number of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 34
+        bankAccountType:
+          type: string
+          description: The bank account type (BANK_TRANSFER only)
+          enum:
+            - CHECKING
+            - SAVINGS
+        phoneNumber:
+          type: string
+          description: The phone number in international format (MOBILE_MONEY only — e.g. Tigo Money)
+          example: '+50312345678'
+          minLength: 7
+          maxLength: 15
+          pattern: ^\+[0-9]{6,14}$
+      example:
+        accountType: SLV_ACCOUNT
+        bankName: Banco Cuscatlan
+        accountNumber: '0123456789'
+        bankAccountType: CHECKING
+    SlvAccountInfo:
+      allOf:
+        - $ref: '#/components/schemas/SlvAccountInfoBase'
+        - type: object
+          required:
+            - paymentRails
+          properties:
+            paymentRails:
+              type: array
+              items:
+                type: string
+                enum:
+                  - BANK_TRANSFER
+                  - MOBILE_MONEY
+    PaymentSlvAccountInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BasePaymentAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfo'
+        - type: object
+          required:
+            - reference
+          properties:
+            reference:
+              type: string
+              description: Unique reference code that must be included with the payment to properly credit it
+              example: UMA-Q12345-REF
     PaymentEmbeddedWalletInfo:
       title: Embedded Wallet
       allOf:
@@ -10627,6 +10695,7 @@ components:
             - $ref: '#/components/schemas/PaymentHtgAccountInfo'
             - $ref: '#/components/schemas/PaymentJmdAccountInfo'
             - $ref: '#/components/schemas/PaymentPkrAccountInfo'
+            - $ref: '#/components/schemas/PaymentSlvAccountInfo'
             - $ref: '#/components/schemas/PaymentSparkWalletInfo'
             - $ref: '#/components/schemas/PaymentLightningInvoiceInfo'
             - $ref: '#/components/schemas/PaymentSolanaWalletInfo'
@@ -10681,6 +10750,7 @@ components:
               HTG_ACCOUNT: '#/components/schemas/PaymentHtgAccountInfo'
               JMD_ACCOUNT: '#/components/schemas/PaymentJmdAccountInfo'
               PKR_ACCOUNT: '#/components/schemas/PaymentPkrAccountInfo'
+              SLV_ACCOUNT: '#/components/schemas/PaymentSlvAccountInfo'
               EMBEDDED_WALLET: '#/components/schemas/PaymentEmbeddedWalletInfo'
     InternalAccount:
       type: object
@@ -10833,6 +10903,7 @@ components:
         - HTG_ACCOUNT
         - JMD_ACCOUNT
         - PKR_ACCOUNT
+        - SLV_ACCOUNT
       description: Type of external account or wallet
       example: GBP_ACCOUNT
     BaseExternalAccountInfo:
@@ -12821,6 +12892,57 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PkrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    SlvBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    SlvExternalAccountInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/SlvBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/SlvBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ExternalAccountInfoOneOf:
       oneOf:
         - $ref: '#/components/schemas/BrlExternalAccountInfo'
@@ -12865,6 +12987,7 @@ components:
         - $ref: '#/components/schemas/HtgExternalAccountInfo'
         - $ref: '#/components/schemas/JmdExternalAccountInfo'
         - $ref: '#/components/schemas/PkrExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvExternalAccountInfo'
       discriminator:
         propertyName: accountType
         mapping:
@@ -12911,6 +13034,7 @@ components:
           JMD_ACCOUNT: '#/components/schemas/JmdExternalAccountInfo'
           LIGHTNING_ACCOUNT: '#/components/schemas/LightningExternalAccountInfo'
           PKR_ACCOUNT: '#/components/schemas/PkrExternalAccountInfo'
+          SLV_ACCOUNT: '#/components/schemas/SlvExternalAccountInfo'
     ExternalAccount:
       allOf:
         - type: object
@@ -13672,6 +13796,26 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PkrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    SlvExternalAccountCreateInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfoBase'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/SlvBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/SlvBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ExternalAccountCreateInfoOneOf:
       oneOf:
         - $ref: '#/components/schemas/AedExternalAccountCreateInfo'
@@ -13709,6 +13853,7 @@ components:
         - $ref: '#/components/schemas/HtgExternalAccountCreateInfo'
         - $ref: '#/components/schemas/JmdExternalAccountCreateInfo'
         - $ref: '#/components/schemas/PkrExternalAccountCreateInfo'
+        - $ref: '#/components/schemas/SlvExternalAccountCreateInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
         - $ref: '#/components/schemas/LightningExternalAccountInfo'
         - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
@@ -13754,6 +13899,7 @@ components:
           HTG_ACCOUNT: '#/components/schemas/HtgExternalAccountCreateInfo'
           JMD_ACCOUNT: '#/components/schemas/JmdExternalAccountCreateInfo'
           PKR_ACCOUNT: '#/components/schemas/PkrExternalAccountCreateInfo'
+          SLV_ACCOUNT: '#/components/schemas/SlvExternalAccountCreateInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'
           LIGHTNING: '#/components/schemas/LightningExternalAccountInfo'
           SOLANA_WALLET: '#/components/schemas/SolanaWalletExternalAccountInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10558,6 +10558,74 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+    SlvAccountInfoBase:
+      type: object
+      required:
+        - accountType
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - BANK_TRANSFER: bankAccountType, accountNumber
+        - MOBILE_MONEY: phoneNumber
+      properties:
+        accountType:
+          type: string
+          enum:
+            - SLV_ACCOUNT
+        bankName:
+          type: string
+          description: The name of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 255
+        accountNumber:
+          type: string
+          description: The account number of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 34
+        bankAccountType:
+          type: string
+          description: The bank account type (BANK_TRANSFER only)
+          enum:
+            - CHECKING
+            - SAVINGS
+        phoneNumber:
+          type: string
+          description: The phone number in international format (MOBILE_MONEY only — e.g. Tigo Money)
+          example: '+50312345678'
+          minLength: 7
+          maxLength: 15
+          pattern: ^\+[0-9]{6,14}$
+      example:
+        accountType: SLV_ACCOUNT
+        bankName: Banco Cuscatlan
+        accountNumber: '0123456789'
+        bankAccountType: CHECKING
+    SlvAccountInfo:
+      allOf:
+        - $ref: '#/components/schemas/SlvAccountInfoBase'
+        - type: object
+          required:
+            - paymentRails
+          properties:
+            paymentRails:
+              type: array
+              items:
+                type: string
+                enum:
+                  - BANK_TRANSFER
+                  - MOBILE_MONEY
+    PaymentSlvAccountInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BasePaymentAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfo'
+        - type: object
+          required:
+            - reference
+          properties:
+            reference:
+              type: string
+              description: Unique reference code that must be included with the payment to properly credit it
+              example: UMA-Q12345-REF
     PaymentEmbeddedWalletInfo:
       title: Embedded Wallet
       allOf:
@@ -10627,6 +10695,7 @@ components:
             - $ref: '#/components/schemas/PaymentHtgAccountInfo'
             - $ref: '#/components/schemas/PaymentJmdAccountInfo'
             - $ref: '#/components/schemas/PaymentPkrAccountInfo'
+            - $ref: '#/components/schemas/PaymentSlvAccountInfo'
             - $ref: '#/components/schemas/PaymentSparkWalletInfo'
             - $ref: '#/components/schemas/PaymentLightningInvoiceInfo'
             - $ref: '#/components/schemas/PaymentSolanaWalletInfo'
@@ -10681,6 +10750,7 @@ components:
               HTG_ACCOUNT: '#/components/schemas/PaymentHtgAccountInfo'
               JMD_ACCOUNT: '#/components/schemas/PaymentJmdAccountInfo'
               PKR_ACCOUNT: '#/components/schemas/PaymentPkrAccountInfo'
+              SLV_ACCOUNT: '#/components/schemas/PaymentSlvAccountInfo'
               EMBEDDED_WALLET: '#/components/schemas/PaymentEmbeddedWalletInfo'
     InternalAccount:
       type: object
@@ -10833,6 +10903,7 @@ components:
         - HTG_ACCOUNT
         - JMD_ACCOUNT
         - PKR_ACCOUNT
+        - SLV_ACCOUNT
       description: Type of external account or wallet
       example: GBP_ACCOUNT
     BaseExternalAccountInfo:
@@ -12821,6 +12892,57 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PkrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    SlvBeneficiary:
+      title: Individual Beneficiary
+      type: object
+      required:
+        - beneficiaryType
+        - fullName
+      properties:
+        beneficiaryType:
+          type: string
+          enum:
+            - INDIVIDUAL
+        fullName:
+          type: string
+          description: The full name of the beneficiary
+        birthDate:
+          type: string
+          description: The birth date of the beneficiary
+        nationality:
+          type: string
+          description: The nationality of the beneficiary
+        email:
+          type: string
+          description: The email of the beneficiary
+        phoneNumber:
+          type: string
+          description: The phone number of the beneficiary
+        countryOfResidence:
+          type: string
+          description: The country of residence of the beneficiary
+        address:
+          $ref: '#/components/schemas/Address'
+    SlvExternalAccountInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfo'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/SlvBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/SlvBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ExternalAccountInfoOneOf:
       oneOf:
         - $ref: '#/components/schemas/BrlExternalAccountInfo'
@@ -12865,6 +12987,7 @@ components:
         - $ref: '#/components/schemas/HtgExternalAccountInfo'
         - $ref: '#/components/schemas/JmdExternalAccountInfo'
         - $ref: '#/components/schemas/PkrExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvExternalAccountInfo'
       discriminator:
         propertyName: accountType
         mapping:
@@ -12911,6 +13034,7 @@ components:
           JMD_ACCOUNT: '#/components/schemas/JmdExternalAccountInfo'
           LIGHTNING_ACCOUNT: '#/components/schemas/LightningExternalAccountInfo'
           PKR_ACCOUNT: '#/components/schemas/PkrExternalAccountInfo'
+          SLV_ACCOUNT: '#/components/schemas/SlvExternalAccountInfo'
     ExternalAccount:
       allOf:
         - type: object
@@ -13672,6 +13796,26 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/PkrBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    SlvExternalAccountCreateInfo:
+      title: SLV Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/SlvAccountInfoBase'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/SlvBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/SlvBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     ExternalAccountCreateInfoOneOf:
       oneOf:
         - $ref: '#/components/schemas/AedExternalAccountCreateInfo'
@@ -13709,6 +13853,7 @@ components:
         - $ref: '#/components/schemas/HtgExternalAccountCreateInfo'
         - $ref: '#/components/schemas/JmdExternalAccountCreateInfo'
         - $ref: '#/components/schemas/PkrExternalAccountCreateInfo'
+        - $ref: '#/components/schemas/SlvExternalAccountCreateInfo'
         - $ref: '#/components/schemas/SparkWalletExternalAccountInfo'
         - $ref: '#/components/schemas/LightningExternalAccountInfo'
         - $ref: '#/components/schemas/SolanaWalletExternalAccountInfo'
@@ -13754,6 +13899,7 @@ components:
           HTG_ACCOUNT: '#/components/schemas/HtgExternalAccountCreateInfo'
           JMD_ACCOUNT: '#/components/schemas/JmdExternalAccountCreateInfo'
           PKR_ACCOUNT: '#/components/schemas/PkrExternalAccountCreateInfo'
+          SLV_ACCOUNT: '#/components/schemas/SlvExternalAccountCreateInfo'
           SPARK_WALLET: '#/components/schemas/SparkWalletExternalAccountInfo'
           LIGHTNING: '#/components/schemas/LightningExternalAccountInfo'
           SOLANA_WALLET: '#/components/schemas/SolanaWalletExternalAccountInfo'

--- a/openapi/components/schemas/common/PaymentInstructions.yaml
+++ b/openapi/components/schemas/common/PaymentInstructions.yaml
@@ -50,6 +50,7 @@ properties:
     - $ref: ../common/PaymentHtgAccountInfo.yaml
     - $ref: ../common/PaymentJmdAccountInfo.yaml
     - $ref: ../common/PaymentPkrAccountInfo.yaml
+    - $ref: ../common/PaymentSlvAccountInfo.yaml
     - $ref: ../common/PaymentSparkWalletInfo.yaml
     - $ref: ../common/PaymentLightningInvoiceInfo.yaml
     - $ref: ../common/PaymentSolanaWalletInfo.yaml
@@ -104,4 +105,5 @@ properties:
         HTG_ACCOUNT: ../common/PaymentHtgAccountInfo.yaml
         JMD_ACCOUNT: ../common/PaymentJmdAccountInfo.yaml
         PKR_ACCOUNT: ../common/PaymentPkrAccountInfo.yaml
+        SLV_ACCOUNT: ../common/PaymentSlvAccountInfo.yaml
         EMBEDDED_WALLET: ../common/PaymentEmbeddedWalletInfo.yaml

--- a/openapi/components/schemas/common/PaymentSlvAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentSlvAccountInfo.yaml
@@ -1,0 +1,13 @@
+title: SLV Account
+allOf:
+- $ref: ./BasePaymentAccountInfo.yaml
+- $ref: ./SlvAccountInfo.yaml
+- type: object
+  required:
+  - reference
+  properties:
+    reference:
+      type: string
+      description: Unique reference code that must be included with the payment to
+        properly credit it
+      example: UMA-Q12345-REF

--- a/openapi/components/schemas/common/SlvAccountInfo.yaml
+++ b/openapi/components/schemas/common/SlvAccountInfo.yaml
@@ -1,0 +1,13 @@
+allOf:
+- $ref: ./SlvAccountInfoBase.yaml
+- type: object
+  required:
+  - paymentRails
+  properties:
+    paymentRails:
+      type: array
+      items:
+        type: string
+        enum:
+        - BANK_TRANSFER
+        - MOBILE_MONEY

--- a/openapi/components/schemas/common/SlvAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/SlvAccountInfoBase.yaml
@@ -1,0 +1,42 @@
+type: object
+required:
+- accountType
+description: 'Required fields depend on the selected paymentRails:
+
+  - BANK_TRANSFER: bankAccountType, accountNumber
+
+  - MOBILE_MONEY: phoneNumber'
+properties:
+  accountType:
+    type: string
+    enum:
+    - SLV_ACCOUNT
+  bankName:
+    type: string
+    description: The name of the bank (BANK_TRANSFER only)
+    minLength: 1
+    maxLength: 255
+  accountNumber:
+    type: string
+    description: The account number of the bank (BANK_TRANSFER only)
+    minLength: 1
+    maxLength: 34
+  bankAccountType:
+    type: string
+    description: The bank account type (BANK_TRANSFER only)
+    enum:
+    - CHECKING
+    - SAVINGS
+  phoneNumber:
+    type: string
+    description: The phone number in international format (MOBILE_MONEY only — e.g.
+      Tigo Money)
+    example: '+50312345678'
+    minLength: 7
+    maxLength: 15
+    pattern: ^\+[0-9]{6,14}$
+example:
+  accountType: SLV_ACCOUNT
+  bankName: Banco Cuscatlan
+  accountNumber: '0123456789'
+  bankAccountType: CHECKING

--- a/openapi/components/schemas/common/SlvBeneficiary.yaml
+++ b/openapi/components/schemas/common/SlvBeneficiary.yaml
@@ -1,0 +1,30 @@
+title: Individual Beneficiary
+type: object
+required:
+- beneficiaryType
+- fullName
+properties:
+  beneficiaryType:
+    type: string
+    enum:
+    - INDIVIDUAL
+  fullName:
+    type: string
+    description: The full name of the beneficiary
+  birthDate:
+    type: string
+    description: The birth date of the beneficiary
+  nationality:
+    type: string
+    description: The nationality of the beneficiary
+  email:
+    type: string
+    description: The email of the beneficiary
+  phoneNumber:
+    type: string
+    description: The phone number of the beneficiary
+  countryOfResidence:
+    type: string
+    description: The country of residence of the beneficiary
+  address:
+    $ref: ./Address.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountCreateInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountCreateInfoOneOf.yaml
@@ -34,6 +34,7 @@ oneOf:
 - $ref: ./HtgExternalAccountCreateInfo.yaml
 - $ref: ./JmdExternalAccountCreateInfo.yaml
 - $ref: ./PkrExternalAccountCreateInfo.yaml
+- $ref: ./SlvExternalAccountCreateInfo.yaml
 - $ref: ./SparkWalletExternalAccountInfo.yaml
 - $ref: ./LightningExternalAccountInfo.yaml
 - $ref: ./SolanaWalletExternalAccountInfo.yaml
@@ -79,6 +80,7 @@ discriminator:
     HTG_ACCOUNT: ./HtgExternalAccountCreateInfo.yaml
     JMD_ACCOUNT: ./JmdExternalAccountCreateInfo.yaml
     PKR_ACCOUNT: ./PkrExternalAccountCreateInfo.yaml
+    SLV_ACCOUNT: ./SlvExternalAccountCreateInfo.yaml
     SPARK_WALLET: ./SparkWalletExternalAccountInfo.yaml
     LIGHTNING: ./LightningExternalAccountInfo.yaml
     SOLANA_WALLET: ./SolanaWalletExternalAccountInfo.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountInfoOneOf.yaml
@@ -41,6 +41,7 @@ oneOf:
 - $ref: ./HtgExternalAccountInfo.yaml
 - $ref: ./JmdExternalAccountInfo.yaml
 - $ref: ./PkrExternalAccountInfo.yaml
+- $ref: ./SlvExternalAccountInfo.yaml
 discriminator:
   propertyName: accountType
   mapping:
@@ -87,3 +88,4 @@ discriminator:
     JMD_ACCOUNT: ./JmdExternalAccountInfo.yaml
     LIGHTNING_ACCOUNT: ./LightningExternalAccountInfo.yaml
     PKR_ACCOUNT: ./PkrExternalAccountInfo.yaml
+    SLV_ACCOUNT: ./SlvExternalAccountInfo.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountType.yaml
@@ -42,5 +42,6 @@ enum:
 - HTG_ACCOUNT
 - JMD_ACCOUNT
 - PKR_ACCOUNT
+- SLV_ACCOUNT
 description: Type of external account or wallet
 example: GBP_ACCOUNT

--- a/openapi/components/schemas/external_accounts/SlvExternalAccountCreateInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SlvExternalAccountCreateInfo.yaml
@@ -1,0 +1,19 @@
+title: SLV Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/SlvAccountInfoBase.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - title: Individual Beneficiary
+        $ref: ../common/SlvBeneficiary.yaml
+      - title: Business Beneficiary
+        $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/SlvBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/SlvExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/SlvExternalAccountInfo.yaml
@@ -1,0 +1,19 @@
+title: SLV Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/SlvAccountInfo.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - title: Individual Beneficiary
+        $ref: ../common/SlvBeneficiary.yaml
+      - title: Business Beneficiary
+        $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/SlvBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml


### PR DESCRIPTION
## Summary
Adds the OpenAPI schemas for \`SLV_ACCOUNT\`, the external-account type for El Salvador Thunes payouts. The sparkcore destination resolver at [thunes_destination_resolver.py:30](https://github.com/lightsparkdev/webdev/blob/main/sparkcore/sparkcore/grid/destination_resolution/thunes_destination_resolver.py#L30) already maps \`SLV_ACCOUNT → \$grid.slv\`, but until now there was no schema for clients to create such accounts. This is the foundation needed before we can wire SLV in sparkcore and finally turn the corridor on for testing.

## Design notes

El Salvador uses USD as its currency, which Lightspark also uses for the US bank corridor. To avoid touching the existing US flow, \`SLV_ACCOUNT\` is modeled as a **separate \`accountType\` under the same \`USD\` currency**. The dispatch on accountType is what distinguishes routes:
- \`USD_ACCOUNT\` → Lightspark Payments (existing US ACH/wire flow, untouched)
- \`SLV_ACCOUNT\` → Thunes via \$grid.slv (new)

No new \`CurrencyUnit\` is introduced, no schema for US bank flow is modified.

## Schema layout

Mirrors the recent GHS/BDT refactor (per-rail conditional fields):

| File | Purpose |
|---|---|
| \`common/SlvAccountInfoBase.yaml\` | Multi-rail base: \`bankName\`/\`accountNumber\`/\`bankAccountType\` for BANK_TRANSFER, \`phoneNumber\` for MOBILE_MONEY (Tigo Money) |
| \`common/SlvAccountInfo.yaml\` | Adds \`paymentRails\` array for response shape |
| \`common/SlvBeneficiary.yaml\` | Individual beneficiary, mirrors GHS/BDT/HTG |
| \`common/PaymentSlvAccountInfo.yaml\` | Payment-instruction variant (with \`reference\`) |
| \`external_accounts/SlvExternalAccountCreateInfo.yaml\` | POST create body |
| \`external_accounts/SlvExternalAccountInfo.yaml\` | Account response |
| \`ExternalAccountType.yaml\` | + \`SLV_ACCOUNT\` enum value |
| \`ExternalAccountCreateInfoOneOf.yaml\` | + \`SLV_ACCOUNT\` discriminator mapping |
| \`ExternalAccountInfoOneOf.yaml\` | + \`SLV_ACCOUNT\` discriminator mapping |
| \`PaymentInstructions.yaml\` | + \`SLV_ACCOUNT\` discriminator mapping |

Bundled \`openapi.yaml\` regenerated via \`npm run build:openapi\`; mintlify copy updated.

## Test plan
- [x] \`npm run lint:openapi\` passes (no errors, 16 unrelated warnings, 1 ignored)
- [x] Bundled spec contains all SLV refs and discriminator mappings
- [ ] Regenerate the sparkcore Python SDK (\`grid-api/grid_api/models/\`) before the follow-up sparkcore PR can land

## Follow-up
Sparkcore PR will:
1. Add \`SlvExternalAccountInfo\`/\`SlvExternalAccountCreateInfo\` import + tuple to \`CURRENCY_TO_ACCOUNT_TYPE[CurrencyUnit.USD]\` so the dispatcher accepts both US and SLV account shapes under USD
2. Add SLV branch to \`thunes_fields_provider._bank_receiver_fields\` and \`_mobile_receiver_fields\` (keyed on \`CurrencyUnit.USD\` — safe since \`ThunesFieldsProvider\` is only consumed by Thunes flows, not by LSP USD)
3. Flip \`THUNES_CORRIDOR_RAILS[\"\$grid.slv\"] = [RailType.BANK, RailType.MOBILE_MONEY]\`
4. Account-creation plumbing in \`grid/utils/account.py\` to build \`SlvExternalAccountInfo\` responses
5. Add USD entry to \`CURRENCY_PAYEE_FIELD_MAPPINGS\` for SLV's CPI fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)