### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 55 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 56 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="55 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="56 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -18,6 +18,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | Country | ISO Code | Payment Rails |
 |---|---|---:|
 | 🇦🇹 Austria | AT | `SEPA` `SEPA Instant` |
+| 🇧🇩 Bangladesh | BD | `Bank Transfer` |
 | 🇧🇪 Belgium | BE | `SEPA` `SEPA Instant` |
 | 🇧🇯 Benin | BJ | `Bank Transfer` |
 | 🇧🇷 Brazil | BR | `PIX` |
@@ -82,7 +83,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="13 countries">
     Primary: Bank Transfer
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="7 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="8 countries">
     Various instant payment systems
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Americas" tag="3 countries">


### PR DESCRIPTION
## Summary

Syncs `mintlify/snippets/country-support.mdx` with the **Grid Switch Corridor List** tab of the country coverage timeline (source of truth).

Rule applied (per the updated task): `Status = Live` → live, `Public Roadmap = Yes` → coming soon.

- **Live country list**: add 🇧🇩 Bangladesh (Live, BD/BDT). All other 55 live countries already match. Bump total from 55 → 56 and Asia-Pacific from 7 → 8 in the summary cards.
- **Coming Soon**: no changes. Canada, China, Hong Kong, and South Korea are the only corridors with `Public Roadmap = Yes`, which already match the existing table.

## Test plan

- [ ] Preview the Supported Countries page in Mintlify and verify Bangladesh appears in alphabetical position with `Bank Transfer` as the rail and the totals show 56 / Asia-Pacific 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)