### PR TITLE
Add COP fields needed for Thunes standard-bank payouts

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12498,29 +12498,41 @@ components:
         - accountType
       description: |-
         Required fields depend on the selected paymentRails:
-        - BANK_TRANSFER: accountNumber
+        - BANK_TRANSFER: bankName, accountNumber, bankAccountType
         - MOBILE_MONEY: phoneNumber
       properties:
         accountType:
           type: string
           enum:
             - COP_ACCOUNT
+        bankName:
+          type: string
+          description: The name of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 255
         accountNumber:
           type: string
-          description: The account number of the bank
+          description: The account number of the bank (BANK_TRANSFER only)
           minLength: 1
           maxLength: 34
+        bankAccountType:
+          type: string
+          description: The bank account type (BANK_TRANSFER only)
+          enum:
+            - CHECKING
+            - SAVINGS
         phoneNumber:
           type: string
-          description: The phone number in international format
+          description: The phone number in international format (MOBILE_MONEY only — Nequi, Daviplata)
           example: '+1234567890'
           minLength: 7
           maxLength: 15
           pattern: ^\+[0-9]{6,14}$
       example:
         accountType: COP_ACCOUNT
+        bankName: Bancolombia
         accountNumber: '1234567890'
-        phoneNumber: '+1234567890'
+        bankAccountType: CHECKING
     CopAccountInfo:
       allOf:
         - $ref: '#/components/schemas/CopAccountInfoBase'
@@ -12566,6 +12578,12 @@ components:
           description: The country of residence of the beneficiary
         address:
           $ref: '#/components/schemas/Address'
+        documentType:
+          type: string
+          description: Identity document type — required by most Colombian banks (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT, PP for passport)
+        documentNumber:
+          type: string
+          description: Identity document number — required by most Colombian banks
     CopExternalAccountInfo:
       title: COP Account
       allOf:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12580,10 +12580,18 @@ components:
           $ref: '#/components/schemas/Address'
         documentType:
           type: string
-          description: Identity document type — required by most Colombian banks (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT, PP for passport)
+          description: 'Identity document type — required by most Colombian banks. CC: Cédula de Ciudadanía, CE: Cédula de Extranjería, TI: Tarjeta de Identidad, NIT: Número de Identificación Tributaria, PP: Passport'
+          enum:
+            - CC
+            - CE
+            - TI
+            - NIT
+            - PP
         documentNumber:
           type: string
           description: Identity document number — required by most Colombian banks
+          minLength: 1
+          maxLength: 50
     CopExternalAccountInfo:
       title: COP Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12498,29 +12498,41 @@ components:
         - accountType
       description: |-
         Required fields depend on the selected paymentRails:
-        - BANK_TRANSFER: accountNumber
+        - BANK_TRANSFER: bankName, accountNumber, bankAccountType
         - MOBILE_MONEY: phoneNumber
       properties:
         accountType:
           type: string
           enum:
             - COP_ACCOUNT
+        bankName:
+          type: string
+          description: The name of the bank (BANK_TRANSFER only)
+          minLength: 1
+          maxLength: 255
         accountNumber:
           type: string
-          description: The account number of the bank
+          description: The account number of the bank (BANK_TRANSFER only)
           minLength: 1
           maxLength: 34
+        bankAccountType:
+          type: string
+          description: The bank account type (BANK_TRANSFER only)
+          enum:
+            - CHECKING
+            - SAVINGS
         phoneNumber:
           type: string
-          description: The phone number in international format
+          description: The phone number in international format (MOBILE_MONEY only — Nequi, Daviplata)
           example: '+1234567890'
           minLength: 7
           maxLength: 15
           pattern: ^\+[0-9]{6,14}$
       example:
         accountType: COP_ACCOUNT
+        bankName: Bancolombia
         accountNumber: '1234567890'
-        phoneNumber: '+1234567890'
+        bankAccountType: CHECKING
     CopAccountInfo:
       allOf:
         - $ref: '#/components/schemas/CopAccountInfoBase'
@@ -12566,6 +12578,12 @@ components:
           description: The country of residence of the beneficiary
         address:
           $ref: '#/components/schemas/Address'
+        documentType:
+          type: string
+          description: Identity document type — required by most Colombian banks (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT, PP for passport)
+        documentNumber:
+          type: string
+          description: Identity document number — required by most Colombian banks
     CopExternalAccountInfo:
       title: COP Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12580,10 +12580,18 @@ components:
           $ref: '#/components/schemas/Address'
         documentType:
           type: string
-          description: Identity document type — required by most Colombian banks (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT, PP for passport)
+          description: 'Identity document type — required by most Colombian banks. CC: Cédula de Ciudadanía, CE: Cédula de Extranjería, TI: Tarjeta de Identidad, NIT: Número de Identificación Tributaria, PP: Passport'
+          enum:
+            - CC
+            - CE
+            - TI
+            - NIT
+            - PP
         documentNumber:
           type: string
           description: Identity document number — required by most Colombian banks
+          minLength: 1
+          maxLength: 50
     CopExternalAccountInfo:
       title: COP Account
       allOf:

--- a/openapi/components/schemas/common/CopAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/CopAccountInfoBase.yaml
@@ -3,7 +3,7 @@ required:
 - accountType
 description: 'Required fields depend on the selected paymentRails:
 
-  - BANK_TRANSFER: accountNumber
+  - BANK_TRANSFER: bankName, accountNumber, bankAccountType
 
   - MOBILE_MONEY: phoneNumber'
 properties:
@@ -11,19 +11,32 @@ properties:
     type: string
     enum:
     - COP_ACCOUNT
+  bankName:
+    type: string
+    description: The name of the bank (BANK_TRANSFER only)
+    minLength: 1
+    maxLength: 255
   accountNumber:
     type: string
-    description: The account number of the bank
+    description: The account number of the bank (BANK_TRANSFER only)
     minLength: 1
     maxLength: 34
+  bankAccountType:
+    type: string
+    description: The bank account type (BANK_TRANSFER only)
+    enum:
+    - CHECKING
+    - SAVINGS
   phoneNumber:
     type: string
-    description: The phone number in international format
+    description: The phone number in international format (MOBILE_MONEY only —
+      Nequi, Daviplata)
     example: '+1234567890'
     minLength: 7
     maxLength: 15
     pattern: ^\+[0-9]{6,14}$
 example:
   accountType: COP_ACCOUNT
+  bankName: Bancolombia
   accountNumber: '1234567890'
-  phoneNumber: '+1234567890'
+  bankAccountType: CHECKING

--- a/openapi/components/schemas/common/CopBeneficiary.yaml
+++ b/openapi/components/schemas/common/CopBeneficiary.yaml
@@ -28,3 +28,11 @@ properties:
     description: The country of residence of the beneficiary
   address:
     $ref: ./Address.yaml
+  documentType:
+    type: string
+    description: Identity document type — required by most Colombian banks
+      (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT,
+      PP for passport)
+  documentNumber:
+    type: string
+    description: Identity document number — required by most Colombian banks

--- a/openapi/components/schemas/common/CopBeneficiary.yaml
+++ b/openapi/components/schemas/common/CopBeneficiary.yaml
@@ -30,9 +30,17 @@ properties:
     $ref: ./Address.yaml
   documentType:
     type: string
-    description: Identity document type — required by most Colombian banks
-      (e.g. CC for Cédula de Ciudadanía, CE for Cédula de Extranjería, NIT,
-      PP for passport)
+    description: 'Identity document type — required by most Colombian banks.
+      CC: Cédula de Ciudadanía, CE: Cédula de Extranjería, TI: Tarjeta de
+      Identidad, NIT: Número de Identificación Tributaria, PP: Passport'
+    enum:
+    - CC
+    - CE
+    - TI
+    - NIT
+    - PP
   documentNumber:
     type: string
     description: Identity document number — required by most Colombian banks
+    minLength: 1
+    maxLength: 50


### PR DESCRIPTION
## Summary
Thunes' Colombia bank corridor requires four fields beyond what the current \`CopAccountInfo\` / \`CopBeneficiary\` schemas expose. Without these, standard-bank COP payouts fail at the Thunes payer-match step:

| Field | Purpose | Per Thunes audit |
|---|---|---|
| \`bankName\` (account) | Disambiguate which COP bank | Standard for bank rail |
| \`bankAccountType\` (account) | Part of credit-party identifier (\`account_type + bank_account_number\`) for std banks | Required for 47 of 51 COP payers |
| \`documentType\` (beneficiary) | Maps to Thunes \`id_type\` (CC / CE / NIT / PP) | Required for KYC match on most std banks |
| \`documentNumber\` (beneficiary) | Maps to Thunes \`id_number\` | Required for KYC match on most std banks |

All four added as **optional** so existing consumers aren't broken. The runtime decides which subset is required based on the chosen \`paymentRails\`:
- \`BANK_TRANSFER\` → \`bankName + accountNumber + bankAccountType + documentType + documentNumber\`
- \`MOBILE_MONEY\` (Nequi / Daviplata) → \`phoneNumber\`

That rail-conditional enforcement lands in sparkcore alongside the receiver-field updates.

## Why optional, not required
We've been bitten by the union-validation pattern before (PKR's \`iban required\` regression, SLV's bank-vs-mobile rails). The grid-api schema describes the union of all possible fields; the runtime enforces which subset is needed for the selected rail. This keeps the schema permissive and the validation in one place.

## Test plan
- [x] \`npm run lint:openapi\` passes
- [x] Bundled \`openapi.yaml\` regenerated
- [ ] Sparkcore wiring PR (follow-up): runtime field requirements per rail, response builder, \`CURRENCY_PAYEE_FIELD_MAPPINGS\` update, union-shape extraction for COP
- [ ] Live test: Bancolombia std bank payout (47-payer baseline) once both PRs land

## Out of scope (followup)
- **Davivienda-specific fields** (\`address\` + \`city\` + \`country_iso_code\` + \`msisdn\` on receiver). Already representable via existing optional beneficiary fields; the runtime will pass them when present.
- **Bre-B optional \`account_type\`**: Bre-B-routed banks don't require it. Acceptable to over-ask in v1.
- **Per-payer field variance** within COP: deferred to a future refactor of \`ThunesFieldsProvider\` that's payer-aware rather than corridor-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)