### PR TITLE
[kyb] add issuing authority to IDs

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8103,6 +8103,10 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
+        issuingAuthority:
+          type: string
+          description: Name of the government agency or organization that issued the identification
+          example: U.S. Department of State
     BeneficialOwner:
       type: object
       required:
@@ -14335,6 +14339,10 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
+        issuingAuthority:
+          type: string
+          description: Name of the government agency or organization that issued the identification
+          example: U.S. Department of State
     BeneficialOwnerUpdateRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8103,6 +8103,10 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
+        issuingAuthority:
+          type: string
+          description: Name of the government agency or organization that issued the identification
+          example: U.S. Department of State
     BeneficialOwner:
       type: object
       required:
@@ -14335,6 +14339,10 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
+        issuingAuthority:
+          type: string
+          description: Name of the government agency or organization that issued the identification
+          example: U.S. Department of State
     BeneficialOwnerUpdateRequest:
       type: object
       properties:

--- a/openapi/components/schemas/customers/BeneficialOwnerPersonalInfo.yaml
+++ b/openapi/components/schemas/customers/BeneficialOwnerPersonalInfo.yaml
@@ -51,3 +51,7 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
+  issuingAuthority:
+    type: string
+    description: Name of the government agency or organization that issued the identification
+    example: U.S. Department of State

--- a/openapi/components/schemas/customers/BeneficialOwnerPersonalInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BeneficialOwnerPersonalInfoUpdate.yaml
@@ -44,3 +44,7 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
+  issuingAuthority:
+    type: string
+    description: Name of the government agency or organization that issued the identification
+    example: U.S. Department of State

--- a/openapi/components/schemas/customers/PersonalIdentification.yaml
+++ b/openapi/components/schemas/customers/PersonalIdentification.yaml
@@ -13,3 +13,7 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
+  issuingAuthority:
+    type: string
+    description: Name of the government agency or organization that issued the identification
+    example: U.S. Department of State


### PR DESCRIPTION
As part of our bank's customer onboarding, we need to provide the issuing authority on all customer IDs -- these changes add that field to the API so we can begin dashboard work on collecting it. Future changes will make it a required field

closes https://lightspark.atlassian.net/browse/AT-4816