### PR TITLE
Revert "[kyb] add issuing authority to IDs"

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8103,10 +8103,6 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
-        issuingAuthority:
-          type: string
-          description: Name of the government agency or organization that issued the identification
-          example: U.S. Department of State
     BeneficialOwner:
       type: object
       required:
@@ -14339,10 +14335,6 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
-        issuingAuthority:
-          type: string
-          description: Name of the government agency or organization that issued the identification
-          example: U.S. Department of State
     BeneficialOwnerUpdateRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8103,10 +8103,6 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
-        issuingAuthority:
-          type: string
-          description: Name of the government agency or organization that issued the identification
-          example: U.S. Department of State
     BeneficialOwner:
       type: object
       required:
@@ -14339,10 +14335,6 @@ components:
           type: string
           description: Country that issued the identification (ISO 3166-1 alpha-2)
           example: US
-        issuingAuthority:
-          type: string
-          description: Name of the government agency or organization that issued the identification
-          example: U.S. Department of State
     BeneficialOwnerUpdateRequest:
       type: object
       properties:

--- a/openapi/components/schemas/customers/BeneficialOwnerPersonalInfo.yaml
+++ b/openapi/components/schemas/customers/BeneficialOwnerPersonalInfo.yaml
@@ -51,7 +51,3 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
-  issuingAuthority:
-    type: string
-    description: Name of the government agency or organization that issued the identification
-    example: U.S. Department of State

--- a/openapi/components/schemas/customers/BeneficialOwnerPersonalInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BeneficialOwnerPersonalInfoUpdate.yaml
@@ -44,7 +44,3 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
-  issuingAuthority:
-    type: string
-    description: Name of the government agency or organization that issued the identification
-    example: U.S. Department of State

--- a/openapi/components/schemas/customers/PersonalIdentification.yaml
+++ b/openapi/components/schemas/customers/PersonalIdentification.yaml
@@ -13,7 +13,3 @@ properties:
     type: string
     description: Country that issued the identification (ISO 3166-1 alpha-2)
     example: US
-  issuingAuthority:
-    type: string
-    description: Name of the government agency or organization that issued the identification
-    example: U.S. Department of State


### PR DESCRIPTION
Reverts lightsparkdev/grid-api#480

oops. realized we want this on the document object, not on the beneficial owner