### PR TITLE
docs: align sandbox-testing curl examples with current OpenAPI schema

### DIFF
--- a/mintlify/global-p2p/platform-tools/sandbox-testing.mdx
+++ b/mintlify/global-p2p/platform-tools/sandbox-testing.mdx
@@ -41,7 +41,7 @@ sequenceDiagram
     participant Test as Test UMA Address
 
     Note over Client, Grid: Testing Outgoing Payments
-    Client->>Grid: GET /receiver/$success.usd@sandbox.uma.money
+    Client->>Grid: GET /receiver/uma/$success.usd@sandbox.uma.money
     Grid-->>Client: Supported currencies and requirements
     Client->>Grid: POST /quotes
     Grid-->>Client: Quote with payment instructions
@@ -59,15 +59,15 @@ sequenceDiagram
 1. Look up a sandbox UMA address:
 
 ```bash
-curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/\$success.usd@sandbox.uma.money" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/uma/\$success.usd@sandbox.uma.money" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 2. Create a quote as normal:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "lookupId": "Lookup:019542f5-b3e7-1d02-0000-000000000009",
@@ -84,16 +84,15 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
   }'
 ```
 
-3. Instead of making a real bank transfer, use the sandbox send endpoint:
+3. Instead of making a real bank transfer, use the sandbox send endpoint with the quote ID:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/send" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "reference": "UMA-Q12345-REF",
-    "currencyCode": "USD",
-    "currencyAmount": 10000
+    "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+    "currencyCode": "USD"
   }'
 ```
 
@@ -105,7 +104,7 @@ To test receiving payments to your platform's users, use the sandbox receive end
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/uma/receive" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "senderUmaAddress": "$success.usd@sandbox.uma.money",
@@ -125,18 +124,18 @@ This will trigger the same webhook flow as a real incoming payment:
 
 Here's a complete example of testing both directions of payments:
 
-1. First, register a test user:
+1. First, register a test customer:
 
 ```bash
-curl -X POST "https://api.lightspark.com/grid/2025-10-13/users" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "umaAddress": "$test.user@your.domain",
-    "platformUserId": "test_123",
-    "userType": "INDIVIDUAL",
+    "platformCustomerId": "test_123",
+    "customerType": "INDIVIDUAL",
     "fullName": "Test User",
     "birthDate": "1990-01-01",
+    "nationality": "US",
     "address": {
       "line1": "123 Test St",
       "city": "Testville",
@@ -147,11 +146,13 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/users" \
   }'
 ```
 
+The response includes the customer's auto-generated `umaAddress`, which you can use as the `receiverUmaAddress` below.
+
 2. Test receiving a payment:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/uma/receive" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "senderUmaAddress": "$success.usd@sandbox.uma.money",
@@ -165,12 +166,12 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/uma/receive" \
 
 ```bash
 # 1. Look up recipient
-curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/\$success.usd@sandbox.uma.money" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/uma/\$success.usd@sandbox.uma.money" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 # 2. Create quote
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "lookupId": "Lookup:019542f5-b3e7-1d02-0000-000000000009",
@@ -188,12 +189,11 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
 
 # 3. Simulate sending payment
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/send" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "reference": "UMA-Q12345-REF",
-    "currencyCode": "USD",
-    "currencyAmount": 10000
+    "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+    "currencyCode": "USD"
   }'
 ```
 
@@ -204,24 +204,24 @@ You can test various error scenarios using the special sandbox UMA addresses:
 1. Test compliance failures:
 
 ```bash
-curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/\$fail.compliance.usd@sandbox.uma.money" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/uma/\$fail.compliance.usd@sandbox.uma.money" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 # ... create quote and attempt payment
 ```
 
 2. Test long-pending payments:
 
 ```bash
-curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/\$pending.long.usd@sandbox.uma.money" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/uma/\$pending.long.usd@sandbox.uma.money" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 # ... create quote and attempt payment
 ```
 
 3. Non-existent UMA address:
 
 ```bash
-curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/\$non.existent.usd@sandbox.uma.money" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+curl -X GET "https://api.lightspark.com/grid/2025-10-13/receiver/uma/\$non.existent.usd@sandbox.uma.money" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 # ... should return 404 Not Found
 ```
 

--- a/mintlify/global-p2p/quickstart.mdx
+++ b/mintlify/global-p2p/quickstart.mdx
@@ -190,9 +190,8 @@ In this guide, the entities map as follows:
     -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d '{
-      "reference": "UMA-Q12345-REF",
-      "currencyCode": "USDC",
-      "currencyAmount": 10000
+      "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+      "currencyCode": "USDC"
     }'
   ```
   

--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -140,8 +140,7 @@ POST /quotes
   },
   "destination": {
     "destinationType": "ACCOUNT",
-    "accountId": "ExternalAccount:...",
-    "currency": "EUR"
+    "accountId": "ExternalAccount:..."
   },
   "lockedCurrencySide": "SENDING",
   "lockedCurrencyAmount": 100000
@@ -159,17 +158,18 @@ For quotes from an external account source, execute as in production via `/quote
 3. Update transaction statuses immediately (no waiting for bank processing)
 4. Trigger webhooks for state changes
 
-For quotes with payment instructions (no source account), use the existing `/sandbox/send` endpoint to simulate payment:
+For quotes with real-time funding (no source account), use the `/sandbox/send` endpoint to simulate the inbound payment. Reference the quote by ID and specify the funding currency:
 
 ```bash
 POST /sandbox/send
 
 {
-  "reference": "UMA-Q12345-REF",  // From quote payment instructions
-  "currencyCode": "USD",
-  "currencyAmount": 100000
+  "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+  "currencyCode": "USD"
 }
 ```
+
+`currencyCode` must match the quote's funding-source currency. `currencyAmount` is optional — when omitted, the amount is derived from the quote.
 
 ## Testing Webhooks
 

--- a/mintlify/payouts-and-b2b/quickstart.mdx
+++ b/mintlify/payouts-and-b2b/quickstart.mdx
@@ -185,9 +185,7 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/internal-accoun
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "currencyCode": "USD",
-    "currencyAmount": 100000,
-    "reference": "FUND-ABC123"
+    "amount": 100000
   }'
 ```
 

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -111,6 +111,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
+      "sourceType": "REALTIME_FUNDING",
       "customerId": "Customer:sandbox001",
       "currency": "USD"
     },
@@ -124,26 +125,26 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
   }'
 ```
 
-The quote response includes payment instructions with a reference code.
+The quote response includes payment instructions for the fiat funding step.
 
 ### Step 4: Simulate funding
 
-Use the sandbox endpoint to simulate receiving the fiat payment:
+Use the sandbox endpoint to simulate receiving the fiat payment. Reference the quote by ID and specify the funding currency:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/sandbox/send' \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
-    "reference": "RAMP-ABC123",
-    "currencyCode": "USD",
-    "currencyAmount": 10000
+    "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+    "currencyCode": "USD"
   }'
 ```
 
 <Note>
-  The reference code must match the one provided in the quote's payment
-  instructions.
+  `currencyCode` must match the funding-source currency on the quote.
+  `currencyAmount` is optional — when omitted, the amount is derived from the
+  quote.
 </Note>
 
 ### Step 5: Verify completion
@@ -238,11 +239,12 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
+      "sourceType": "ACCOUNT",
       "accountId": "InternalAccount:sandbox_btc001"
     },
     "destination": {
-      "accountId": "ExternalAccount:sandbox_bank001",
-      "currency": "USD"
+      "destinationType": "ACCOUNT",
+      "accountId": "ExternalAccount:sandbox_bank001"
     },
     "lockedCurrencySide": "SENDING",
     "lockedCurrencyAmount": 5000000,

--- a/mintlify/ramps/quickstart.mdx
+++ b/mintlify/ramps/quickstart.mdx
@@ -104,10 +104,11 @@ Create a quote to convert USD to Bitcoin and deliver it to the Spark wallet. The
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {
+      "sourceType": "REALTIME_FUNDING",
       "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
       "currency": "USD"
     },
@@ -203,12 +204,11 @@ In Sandbox, you can simulate funding using the `/sandbox/send` endpoint:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/send" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "reference": "RAMP-ABC123",
-    "currencyCode": "USD",
-    "currencyAmount": 10000
+    "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+    "currencyCode": "USD"
   }'
 ```
 

--- a/mintlify/rewards/platform-tools/sandbox-testing.mdx
+++ b/mintlify/rewards/platform-tools/sandbox-testing.mdx
@@ -79,6 +79,7 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {
+      "sourceType": "ACCOUNT",
       "accountId": "InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965"
     },
     "destination": {
@@ -134,6 +135,7 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {
+      "sourceType": "ACCOUNT",
       "accountId": "InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965"
     },
     "destination": {
@@ -187,6 +189,7 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {
+      "sourceType": "ACCOUNT",
       "accountId": "InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965"
     },
     "destination": {


### PR DESCRIPTION
Align sandbox-testing and adjacent quickstart curl examples with the current OpenAPI schema.

- /sandbox/send body: replace stale {reference, currencyCode, currencyAmount}
  with {quoteId, currencyCode} per SandboxSendRequest schema
- /sandbox/internal-accounts/{id}/fund body: drop currencyCode/currencyAmount/
  reference, use {amount} per SandboxFundRequest schema
- /quotes bodies: add required sourceType on quote sources, remove invalid
  currency field from AccountDestination
- replace deprecated POST /users with POST /customers and correct fields
- fix /receiver/<addr> → /receiver/uma/<addr> path
- swap broken 'Authorization: Basic $ID:$SECRET' header for curl -u form