### PR TITLE
docs: annotate cards/intro snippet to trigger Mintlify redeploy

### DIFF
--- a/mintlify/snippets/cards/intro.mdx
+++ b/mintlify/snippets/cards/intro.mdx
@@ -1,3 +1,6 @@
+{/* Shared Cards intro snippet — included from /cards/index.mdx and any
+    use-case tab that surfaces card issuance. */}
+
 import { topLevelProductName } from '/snippets/variables.mdx';
 import { FeatureCard, FeatureCardGrid } from '/snippets/feature-card.mdx';
 


### PR DESCRIPTION
## Summary
Tiny snippet annotation to force a Mintlify redeploy. PR #490 only touched `openapi/openapi.yaml` (outside `mintlify/`), so Mintlify's GitHub integration skipped the deploy on that merge and the production API reference is still missing the Cards group.

Touching a file under `mintlify/` here triggers an actual Mintlify deploy, which re-fetches Stainless's now-updated `openapi.documented.yml` (already serves Cards endpoints) and bakes it into the production build.

## Test plan
- [ ] Mintlify Deployment check passes (not skipped) on merge
- [ ] grid.lightspark.com/api-reference shows the Cards tag group after the deploy completes