### PR TITLE
docs(spec): clarify quote expiresAt window and rail dependence

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5792,8 +5792,15 @@ components:
         expiresAt:
           type: string
           format: date-time
-          description: When this quote expires (typically 1-5 minutes after creation)
-          example: '2025-10-03T12:05:00Z'
+          description: |
+            Absolute UTC timestamp when the rate locked in this quote becomes invalid
+            and the quote can no longer be executed. The window is set by Grid based
+            on the rail and corridor: real-time / instant rails (Lightning, Spark,
+            USDC on Solana/Base/Polygon, SEPA Instant, RTP) typically expire in 1-5
+            minutes; rails with longer settlement guarantees may have longer windows.
+            Always rely on `expiresAt` rather than assuming a fixed window — re-fetch
+            the quote or create a new one when the timestamp is close.
+          example: '2026-05-22T22:05:00Z'
         source:
           $ref: '#/components/schemas/QuoteSource'
         destination:

--- a/mintlify/snippets/terminology.mdx
+++ b/mintlify/snippets/terminology.mdx
@@ -62,7 +62,7 @@ for on-ramping or off-ramping funds. Each external account:
 **Quotes** provide locked-in exchange rates and payment instructions for transfers. A quote:
 
 - Specifies a source (internal account, customer ID, or UMA address) and destination (internal/external account or UMA address)
-- Locks an exchange rate for a short period (typically 1-5 minutes) or can be immediately executed with the `immediatelyExecute` flag
+- Locks an exchange rate until the `expiresAt` timestamp returned with the quote (the window depends on the rail and corridor; real-time rails typically expire in 1-5 minutes), or can be immediately executed with the `immediatelyExecute` flag
 - Calculates total fees and amounts for currency conversion
 - Provides payment instructions for funding the transfer if needed
 - Must be executed before it expires

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5792,8 +5792,15 @@ components:
         expiresAt:
           type: string
           format: date-time
-          description: When this quote expires (typically 1-5 minutes after creation)
-          example: '2025-10-03T12:05:00Z'
+          description: |
+            Absolute UTC timestamp when the rate locked in this quote becomes invalid
+            and the quote can no longer be executed. The window is set by Grid based
+            on the rail and corridor: real-time / instant rails (Lightning, Spark,
+            USDC on Solana/Base/Polygon, SEPA Instant, RTP) typically expire in 1-5
+            minutes; rails with longer settlement guarantees may have longer windows.
+            Always rely on `expiresAt` rather than assuming a fixed window — re-fetch
+            the quote or create a new one when the timestamp is close.
+          example: '2026-05-22T22:05:00Z'
         source:
           $ref: '#/components/schemas/QuoteSource'
         destination:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -36,8 +36,15 @@ properties:
   expiresAt:
     type: string
     format: date-time
-    description: When this quote expires (typically 1-5 minutes after creation)
-    example: '2025-10-03T12:05:00Z'
+    description: |
+      Absolute UTC timestamp when the rate locked in this quote becomes invalid
+      and the quote can no longer be executed. The window is set by Grid based
+      on the rail and corridor: real-time / instant rails (Lightning, Spark,
+      USDC on Solana/Base/Polygon, SEPA Instant, RTP) typically expire in 1-5
+      minutes; rails with longer settlement guarantees may have longer windows.
+      Always rely on `expiresAt` rather than assuming a fixed window — re-fetch
+      the quote or create a new one when the timestamp is close.
+    example: "2026-05-22T22:05:00Z"
   # Transfer details
   source:
     $ref: ./QuoteSource.yaml


### PR DESCRIPTION
## Summary

Clarifies the documented `expiresAt` window on the `Quote` schema. The
previous "typically 1-5 minutes" wording is misleading — the actual
window depends on the rail and corridor, and integrators should always
rely on the timestamp rather than assuming a fixed window.

## Why

The error audit (parent epic AT-5324) found integrators were observing
`expiresAt` values 2+ days out on some corridors in the dev environment,
which contradicted the documented "1-5 minutes" claim. Even if the
dev-side value is a bug, the spec wording should not promise a fixed
window across all corridors.

## Test plan

- [x] `make build` clean
- [x] `make lint` clean
- [ ] Reviewer to confirm wording matches existing guides in Mintlify

Refs [AT-5347](https://lightspark.atlassian.net/browse/AT-5347)

[AT-5347]: https://lightspark.atlassian.net/browse/AT-5347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ