### PR TITLE
feat(spec): validate webhookEndpoint format on PATCH /config

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8104,6 +8104,14 @@ components:
           example: mycompany.com
         webhookEndpoint:
           type: string
+          format: uri
+          pattern: ^https://
+          minLength: 9
+          description: |
+            HTTPS URL where Grid will POST webhook events. Must use the `https://` scheme;
+            `http://`, raw hostnames, and empty strings are rejected. Localhost and private
+            hostnames are not supported in production. To clear the webhook endpoint, omit
+            this field from the request rather than sending an empty string.
           example: https://api.mycompany.com/webhooks/uma
         supportedCurrencies:
           type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8104,6 +8104,14 @@ components:
           example: mycompany.com
         webhookEndpoint:
           type: string
+          format: uri
+          pattern: ^https://
+          minLength: 9
+          description: |
+            HTTPS URL where Grid will POST webhook events. Must use the `https://` scheme;
+            `http://`, raw hostnames, and empty strings are rejected. Localhost and private
+            hostnames are not supported in production. To clear the webhook endpoint, omit
+            this field from the request rather than sending an empty string.
           example: https://api.mycompany.com/webhooks/uma
         supportedCurrencies:
           type: array

--- a/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
+++ b/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
@@ -5,6 +5,14 @@ properties:
     example: mycompany.com
   webhookEndpoint:
     type: string
+    format: uri
+    pattern: '^https://'
+    minLength: 9
+    description: |
+      HTTPS URL where Grid will POST webhook events. Must use the `https://` scheme;
+      `http://`, raw hostnames, and empty strings are rejected. Localhost and private
+      hostnames are not supported in production. To clear the webhook endpoint, omit
+      this field from the request rather than sending an empty string.
     example: https://api.mycompany.com/webhooks/uma
   supportedCurrencies:
     type: array


### PR DESCRIPTION
## Summary

Tightens the OpenAPI schema for `webhookEndpoint` on `PATCH /config` so SDK
clients and bundler-level validation reject obvious garbage URLs:

- `format: uri`
- `pattern: ^https://`
- `minLength: 9`
- Description clarifies acceptable values

## Why

The error audit (parent epic AT-5324) found the server currently accepts
`not-a-url`, `http://...`, `https://localhost:...`, and empty string for
`webhookEndpoint` with HTTP 200. Spec-side tightening helps SDKs catch this
early; the server-side validation fix is tracked in AT-5334.

## Test plan

- [x] `make build` clean
- [x] `make lint` clean
- [ ] Reviewer to verify generated bundle in `mintlify/openapi.yaml` and
      confirm the description renders correctly in docs preview.

Refs [AT-5334](https://lightspark.atlassian.net/browse/AT-5334)

[AT-5334]: https://lightspark.atlassian.net/browse/AT-5334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ