### PR TITLE
docs(spec): clarify customerType is immutable on PATCH /customers

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9073,7 +9073,15 @@ components:
         - customerType
       properties:
         customerType:
-          $ref: '#/components/schemas/CustomerType'
+          allOf:
+            - $ref: '#/components/schemas/CustomerType'
+          description: |
+            Must equal the existing customer's `customerType`. This field is required
+            on PATCH because it discriminates the request body shape (INDIVIDUAL vs
+            BUSINESS); it is not the way to change customer type. Requests that
+            submit a different `customerType` than the existing record will be
+            rejected with `INVALID_INPUT`. To change the legal classification of a
+            customer, create a new customer and migrate its accounts.
         currencies:
           type: array
           items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9073,7 +9073,15 @@ components:
         - customerType
       properties:
         customerType:
-          $ref: '#/components/schemas/CustomerType'
+          allOf:
+            - $ref: '#/components/schemas/CustomerType'
+          description: |
+            Must equal the existing customer's `customerType`. This field is required
+            on PATCH because it discriminates the request body shape (INDIVIDUAL vs
+            BUSINESS); it is not the way to change customer type. Requests that
+            submit a different `customerType` than the existing record will be
+            rejected with `INVALID_INPUT`. To change the legal classification of a
+            customer, create a new customer and migrate its accounts.
         currencies:
           type: array
           items:

--- a/openapi/components/schemas/customers/CustomerUpdateRequest.yaml
+++ b/openapi/components/schemas/customers/CustomerUpdateRequest.yaml
@@ -9,7 +9,15 @@ required:
   - customerType
 properties:
   customerType:
-    $ref: ./CustomerType.yaml
+    allOf:
+      - $ref: ./CustomerType.yaml
+    description: |
+      Must equal the existing customer's `customerType`. This field is required
+      on PATCH because it discriminates the request body shape (INDIVIDUAL vs
+      BUSINESS); it is not the way to change customer type. Requests that
+      submit a different `customerType` than the existing record will be
+      rejected with `INVALID_INPUT`. To change the legal classification of a
+      customer, create a new customer and migrate its accounts.
   currencies:
     type: array
     items:


### PR DESCRIPTION
## Summary

Adds a `description` to the `customerType` property on the customer-update
request schemas clarifying that this field is the request-body
discriminator and must equal the existing customer's type. Type changes
require a new customer.

## Why

The error audit (parent epic AT-5324) found callers can submit a
different `customerType` on PATCH than the existing customer's, silently
converting INDIVIDUAL → BUSINESS (or vice versa) and losing required
fields. The server-side rejection fix is tracked under the same ticket;
this PR tightens the spec so the contract is unambiguous.

## Test plan

- [x] `make build` clean
- [x] `make lint` clean
- [ ] Reviewer to confirm the rendered docs show the new description on the
      customer-update schemas.

Refs [AT-5336](https://lightspark.atlassian.net/browse/AT-5336)

[AT-5336]: https://lightspark.atlassian.net/browse/AT-5336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ