### PR TITLE
docs(accounts/auth/cards): sync examples with schema

### DIFF
--- a/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
+++ b/mintlify/payouts-and-b2b/platform-tools/sandbox-testing.mdx
@@ -121,7 +121,7 @@ POST /customers/external-accounts
   "customerId": "Customer:123",
   "currency": "EUR",
   "accountInfo": {
-    "accountType": "IBAN_ACCOUNT",
+    "accountType": "EUR_ACCOUNT",
     "iban": "DE89370400440532013003",
     "beneficiary": {
       "beneficiaryType": "INDIVIDUAL",
@@ -183,7 +183,7 @@ All webhook events fire normally in sandbox. To test your webhook endpoint:
 You can also manually trigger a test webhook:
 
 ```bash
-POST /webhooks/test
+POST /sandbox/webhooks/test
 
 {
   "url": "https://your-app.com/webhooks"

--- a/mintlify/platform-overview/core-concepts/account-model.mdx
+++ b/mintlify/platform-overview/core-concepts/account-model.mdx
@@ -31,11 +31,11 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
   <Tab title="US Bank Accounts">
     ```json
     {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
       "currency": "USD",
       "accountNumber": "1234567890",
       "routingNumber": "110000000",
-      "accountCategory": "CHECKING",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Alice Johnson",
@@ -54,10 +54,10 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
   <Tab title="IBAN (Europe)">
     ```json
     {
-      "accountType": "IBAN",
+      "accountType": "EUR_ACCOUNT",
       "currency": "EUR",
       "iban": "DE89370400440532013000",
-      "swiftBic": "DEUTDEFF",
+      "swiftCode": "DEUTDEFF",
       "bankName": "Deutsche Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -70,7 +70,7 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
   <Tab title="PIX (Brazil)">
     ```json
     {
-      "accountType": "PIX",
+      "accountType": "BRL_ACCOUNT",
       "currency": "BRL",
       "pixKey": "user@example.com",
       "pixKeyType": "EMAIL",
@@ -87,7 +87,7 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
   <Tab title="CLABE (Mexico)">
     ```json
     {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
       "clabeNumber": "012345678901234567",
       "bankName": "BBVA Mexico",
       "beneficiary": {
@@ -101,7 +101,7 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
   <Tab title="UPI (India)">
     ```json
     {
-      "accountType": "UPI",
+      "accountType": "INR_ACCOUNT",
       "currency": "INR",
       "vpa": "user@paytm",
       "beneficiary": {
@@ -164,10 +164,10 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/customers/external-accou
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
     "currency": "USD",
     "accountInfo": {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
       "accountNumber": "9876543210",
       "routingNumber": "110000000",
-      "accountCategory": "CHECKING",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Alice Johnson",
@@ -192,7 +192,7 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/customers/external-accou
   "currency": "USD",
   "status": "PENDING",
   "accountInfo": {
-    "accountType": "US_ACCOUNT",
+    "accountType": "USD_ACCOUNT",
     "accountNumber": "****3210",
     "routingNumber": "110000000"
   }
@@ -210,7 +210,7 @@ PENDING → ACTIVE
 - **PENDING**: Created, undergoing verification/screening
 - **ACTIVE**: Verified, ready for transactions
 - **INACTIVE**: Disabled (can be reactivated)
-- **REJECTED**: Failed verification
+- **UNDER_REVIEW**: Additional review required
 
 You'll receive `INTERNAL_ACCOUNT.BALANCE_UPDATED` webhooks as balance changes, and `INTERNAL_ACCOUNT.STATUS_UPDATED` webhooks when account status changes (e.g., ACTIVE to FROZEN).
 

--- a/mintlify/ramps/accounts/external-accounts.mdx
+++ b/mintlify/ramps/accounts/external-accounts.mdx
@@ -130,10 +130,10 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "USD",
     "platformAccountId": "user_bank_usd_001",
     "accountInfo": {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
       "accountNumber": "123456789",
       "routingNumber": "021000021",
-      "accountCategory": "CHECKING",
+      "bankAccountType": "CHECKING",
       "bankName": "Chase Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -168,23 +168,16 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accou
   -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
 ```
 
-### Filter by account type
-
-```bash
-curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001&accountType=SPARK_WALLET' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
-```
-
 ## Account status and verification
 
 External accounts move through verification states:
 
 | Status     | Description              | Can Use for Conversions |
 | ---------- | ------------------------ | ----------------------- |
-| `PENDING`  | Verification in progress | ❌                      |
-| `ACTIVE`   | Verified and ready       | ✅                      |
-| `FAILED`   | Verification failed      | ❌                      |
-| `DISABLED` | Manually disabled        | ❌                      |
+| `PENDING`       | Verification in progress    | ❌                      |
+| `ACTIVE`        | Verified and ready          | ✅                      |
+| `UNDER_REVIEW`  | Additional review required  | ❌                      |
+| `INACTIVE`      | Manually disabled           | ❌                      |
 
 <Info>
   Spark wallet accounts are immediately `ACTIVE`. Bank accounts may require

--- a/mintlify/ramps/conversion-flows/self-custody-wallets.mdx
+++ b/mintlify/ramps/conversion-flows/self-custody-wallets.mdx
@@ -72,11 +72,6 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
     "currency": "BTC",
-    "beneficiary": {
-      "counterPartyType": "INDIVIDUAL",
-      "fullName": "John Doe",
-      "email": "john@example.com"
-    },
     "accountInfo": {
       "accountType": "SPARK_WALLET",
       "address": "spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu"
@@ -96,11 +91,6 @@ const externalAccount = await fetch(
     body: JSON.stringify({
       customerId: "Customer:019542f5-b3e7-1d02-0000-000000000001",
       currency: "BTC",
-      beneficiary: {
-        counterPartyType: "INDIVIDUAL",
-        fullName: "John Doe",
-        email: "john@example.com",
-      },
       accountInfo: {
         accountType: "SPARK_WALLET",
         address: sparkAddress,
@@ -129,11 +119,6 @@ response = requests.post(
     json={
         'customerId': 'Customer:019542f5-b3e7-1d02-0000-000000000001',
         'currency': 'BTC',
-        'beneficiary': {
-            'counterPartyType': 'INDIVIDUAL',
-            'fullName': 'John Doe',
-            'email': 'john@example.com'
-        },
         'accountInfo': {
             'accountType': 'SPARK_WALLET',
             'address': spark_address

--- a/mintlify/snippets/cards/cardholder-setup.mdx
+++ b/mintlify/snippets/cards/cardholder-setup.mdx
@@ -4,7 +4,7 @@ covers the requirements and the order they must be satisfied in.
 
 ## KYC must be APPROVED
 
-`POST /cards` is rejected with `409 CARDHOLDER_KYC_NOT_APPROVED` if the
+`POST /cards` is rejected with `400 CARDHOLDER_KYC_NOT_APPROVED` if the
 cardholder's `kycStatus` is anything other than `APPROVED`. There is no
 "issue and verify later" path.
 
@@ -26,7 +26,7 @@ time. The account must:
 
 - Belong to the cardholder (no cross-customer funding in v1).
 - Be denominated in a card-eligible currency. In v1 this is USDB; the
-  request is rejected with `409 FUNDING_SOURCE_INELIGIBLE` otherwise.
+  request is rejected with `400 FUNDING_SOURCE_INELIGIBLE` otherwise.
 
 If the cardholder doesn't have an internal account yet, internal
 accounts are created automatically when the customer is created based

--- a/mintlify/snippets/cards/funding-sources.mdx
+++ b/mintlify/snippets/cards/funding-sources.mdx
@@ -29,7 +29,7 @@ Each source must:
   one currency.
 
 If any source fails these checks, the request is rejected with
-`409 FUNDING_SOURCE_INELIGIBLE`.
+`400 FUNDING_SOURCE_INELIGIBLE`.
 
 ## Replacing the binding
 
@@ -62,7 +62,7 @@ post-change `Card` resource.
 
 | Status | Code | What it means |
 |--------|------|---------------|
-| 409 | `FUNDING_SOURCE_INELIGIBLE` | A supplied account doesn't belong to the cardholder or isn't denominated in the card's currency. |
+| 400 | `FUNDING_SOURCE_INELIGIBLE` | A supplied account doesn't belong to the cardholder or isn't denominated in the card's currency. |
 | 409 | `CARD_NOT_MUTABLE` | The card is `CLOSED`. |
 | 400 | `INVALID_INPUT` | The `fundingSources` array is empty (a card must have at least one source). |
 

--- a/mintlify/snippets/cards/implementation-overview.mdx
+++ b/mintlify/snippets/cards/implementation-overview.mdx
@@ -27,7 +27,7 @@ Grid. You'll only need to:
 A card can only be issued to a `Customer` with `kycStatus: APPROVED`.
 This is the same gate you use for Grid's other features. If the
 cardholder hasn't completed KYC, `POST /cards` returns
-`409 CARDHOLDER_KYC_NOT_APPROVED` — see
+`400 CARDHOLDER_KYC_NOT_APPROVED` — see
 [Cardholder setup](/cards/onboarding/cardholder-setup) for how to drive
 KYC to completion before issuing.
 

--- a/mintlify/snippets/cards/issuing-cards.mdx
+++ b/mintlify/snippets/cards/issuing-cards.mdx
@@ -71,8 +71,8 @@ cross your servers.
 
 | Status | Code | What it means |
 |--------|------|---------------|
-| 409 | `CARDHOLDER_KYC_NOT_APPROVED` | Cardholder is not `kycStatus: APPROVED`. Drive KYC to completion before retrying. |
-| 409 | `FUNDING_SOURCE_INELIGIBLE` | The supplied internal account doesn't belong to the cardholder or isn't denominated in a card-eligible currency. |
+| 400 | `CARDHOLDER_KYC_NOT_APPROVED` | Cardholder is not `kycStatus: APPROVED`. Drive KYC to completion before retrying. |
+| 400 | `FUNDING_SOURCE_INELIGIBLE` | The supplied internal account doesn't belong to the cardholder or isn't denominated in a card-eligible currency. |
 | 400 | `INVALID_INPUT` | Validation failure on the request body. |
 
 ## Changing funding sources later

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -54,10 +54,10 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "USD",
     "platformAccountId": "user_123_primary_bank",
     "accountInfo": {
-      "accountType": "US_ACCOUNT",
+      "accountType": "USD_ACCOUNT",
       "accountNumber": "123456789",
       "routingNumber": "021000021",
-      "accountCategory": "CHECKING",
+      "bankAccountType": "CHECKING",
       "bankName": "Chase Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -92,7 +92,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "MXN",
     "platformAccountId": "mx_beneficiary_001",
     "accountInfo": {
-      "accountType": "CLABE",
+      "accountType": "MXN_ACCOUNT",
       "clabeNumber": "123456789012345678",
       "bankName": "BBVA Mexico",
       "beneficiary": {
@@ -125,10 +125,11 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "BRL",
     "platformAccountId": "br_pix_001",
     "accountInfo": {
-      "accountType": "PIX",
+      "accountType": "BRL_ACCOUNT",
       "pixKey": "user@email.com",
       "pixKeyType": "EMAIL",
       "bankName": "Nubank",
+      "taxId": "12345678900",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "João Silva",
@@ -304,9 +305,9 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "EUR",
     "platformAccountId": "eu_iban_001",
     "accountInfo": {
-      "accountType": "IBAN",
+      "accountType": "EUR_ACCOUNT",
       "iban": "DE89370400440532013000",
-      "swiftBic": "DEUTDEFF",
+      "swiftCode": "DEUTDEFF",
       "bankName": "Deutsche Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -409,7 +410,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "currency": "INR",
     "platformAccountId": "in_upi_001",
     "accountInfo": {
-      "accountType": "UPI",
+      "accountType": "INR_ACCOUNT",
       "vpa": "user@okbank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -821,10 +822,10 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
   "currency": "USD",
   "platformAccountId": "user_123_primary_bank",
   "accountInfo": {
-    "accountType": "US_ACCOUNT",
+    "accountType": "USD_ACCOUNT",
     "accountNumber": "123456789",
     "routingNumber": "021000021",
-    "accountCategory": "CHECKING",
+    "bankAccountType": "CHECKING",
     "bankName": "Chase Bank",
     "beneficiary": {
       "beneficiaryType": "INDIVIDUAL",
@@ -853,10 +854,10 @@ For business accounts, include business information:
   "platformAccountId": "acme_corp_account",
   "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
   "accountInfo": {
-    "accountType": "US_ACCOUNT",
+    "accountType": "USD_ACCOUNT",
     "accountNumber": "987654321",
     "routingNumber": "021000021",
-    "accountCategory": "CHECKING",
+    "bankAccountType": "CHECKING",
     "bankName": "Chase Bank",
     "beneficiary": {
       "beneficiaryType": "BUSINESS",

--- a/mintlify/snippets/global-accounts/authentication.mdx
+++ b/mintlify/snippets/global-accounts/authentication.mdx
@@ -420,7 +420,7 @@ The lowest-friction credential type — works on any device with email access an
 
 ### Email OTP registration
 
-Creating the credential triggers an OTP email to the address you pass. The user reads the code off the email and submits it through your UI.
+Creating the credential triggers an OTP email to the email address on the customer profile that owns this internal account. The user reads the code off the email and submits it through your UI.
 
 ```mermaid
 sequenceDiagram

--- a/mintlify/snippets/global-accounts/authentication.mdx
+++ b/mintlify/snippets/global-accounts/authentication.mdx
@@ -429,9 +429,9 @@ sequenceDiagram
   participant G as Grid
   participant E as Email
 
-  C->>IB: POST /my-backend/otp/register { email }
+  C->>IB: POST /my-backend/otp/register
   IB->>G: POST /auth/credentials { type: EMAIL_OTP, accountId }
-  G->>E: deliver OTP email
+  G->>E: deliver OTP email (to customer profile address)
   G-->>IB: 201 AuthMethod
   IB-->>C: { credentialId }
   E-->>C: OTP code

--- a/mintlify/snippets/global-accounts/authentication.mdx
+++ b/mintlify/snippets/global-accounts/authentication.mdx
@@ -452,6 +452,10 @@ curl -X POST "$GRID_BASE_URL/auth/credentials" \
   }'
 ```
 
+<Note>
+The request body carries only `type` and `accountId` — there is no `email` field. Grid sends the OTP to the email address on the customer profile that owns this internal account (the `email` field from `POST /customers`). That same address is returned as `nickname` on the response.
+</Note>
+
 **Response (201):**
 
 ```json

--- a/mintlify/snippets/global-accounts/authentication.mdx
+++ b/mintlify/snippets/global-accounts/authentication.mdx
@@ -392,7 +392,7 @@ curl -X POST "$GRID_BASE_URL/auth/credentials" \
   -H "Content-Type: application/json" \
   -d '{
     "type": "OAUTH",
-    "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002",
+    "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002",
     "oidcToken": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9..."
   }'
 ```
@@ -448,7 +448,7 @@ curl -X POST "$GRID_BASE_URL/auth/credentials" \
   -H "Content-Type: application/json" \
   -d '{
     "type": "EMAIL_OTP",
-    "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002"
+    "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
   }'
 ```
 
@@ -457,7 +457,7 @@ curl -X POST "$GRID_BASE_URL/auth/credentials" \
 ```json
 {
   "id": "AuthMethod:019542f5-b3e7-1d02-0000-000000000004",
-  "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002",
+  "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002",
   "type": "EMAIL_OTP",
   "nickname": "jane@example.com",
   "createdAt": "2026-04-19T12:00:00Z",
@@ -506,7 +506,7 @@ Every Global Account starts with a single credential — the one used in the <a 
 ### List credentials
 
 ```bash
-curl -X GET "$GRID_BASE_URL/auth/credentials?accountId=EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002" \
+curl -X GET "$GRID_BASE_URL/auth/credentials?accountId=InternalAccount:019542f5-b3e7-1d02-0000-000000000002" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
@@ -517,7 +517,7 @@ curl -X GET "$GRID_BASE_URL/auth/credentials?accountId=EmbeddedWallet:019542f5-b
   "data": [
     {
       "id": "AuthMethod:019542f5-b3e7-1d02-0000-000000000001",
-      "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002",
+      "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002",
       "type": "PASSKEY",
       "credentialId": "KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew",
       "nickname": "iPhone Face-ID",
@@ -526,7 +526,7 @@ curl -X GET "$GRID_BASE_URL/auth/credentials?accountId=EmbeddedWallet:019542f5-b
     },
     {
       "id": "AuthMethod:019542f5-b3e7-1d02-0000-000000000004",
-      "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002",
+      "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002",
       "type": "EMAIL_OTP",
       "nickname": "jane@example.com",
       "createdAt": "2026-04-09T10:15:00Z",
@@ -577,7 +577,7 @@ Requires an active session on an *existing* credential on the same account. The 
       -H "Content-Type: application/json" \
       -d '{
         "type": "EMAIL_OTP",
-        "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002"
+        "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
       }'
     ```
 
@@ -586,8 +586,8 @@ Requires an active session on an *existing* credential on the same account. The 
     ```json
     {
       "type": "EMAIL_OTP",
-      "payloadToSign": "{\"requestId\":\"7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21\",\"type\":\"EMAIL_OTP\",\"accountId\":\"EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002\",\"expiresAt\":\"2026-04-08T15:35:00Z\"}",
-      "requestId": "7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21",
+      "payloadToSign": "{\"requestId\":\"Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21\",\"type\":\"EMAIL_OTP\",\"accountId\":\"InternalAccount:019542f5-b3e7-1d02-0000-000000000002\",\"expiresAt\":\"2026-04-08T15:35:00Z\"}",
+      "requestId": "Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21",
       "expiresAt": "2026-04-08T15:35:00Z"
     }
     ```
@@ -603,10 +603,10 @@ Requires an active session on an *existing* credential on the same account. The 
       -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Content-Type: application/json" \
       -H "Grid-Wallet-Signature: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=" \
-      -H "Request-Id: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
+      -H "Request-Id: Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
       -d '{
         "type": "EMAIL_OTP",
-        "accountId": "EmbeddedWallet:019542f5-b3e7-1d02-0000-000000000002"
+        "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
       }'
     ```
 
@@ -638,7 +638,7 @@ A credential is revoked by signing with a session from **a different credential 
     {
       "type": "PASSKEY",
       "payloadToSign": "Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==",
-      "requestId": "9f7a2c10-5e88-4fb1-bd0e-1c3a8e7b2d45",
+      "requestId": "Request:9f7a2c10-5e88-4fb1-bd0e-1c3a8e7b2d45",
       "expiresAt": "2026-04-08T15:35:00Z"
     }
     ```
@@ -651,7 +651,7 @@ A credential is revoked by signing with a session from **a different credential 
     curl -X DELETE "$GRID_BASE_URL/auth/credentials/AuthMethod:019542f5-b3e7-1d02-0000-000000000001" \
       -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Grid-Wallet-Signature: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=" \
-      -H "Request-Id: 9f7a2c10-5e88-4fb1-bd0e-1c3a8e7b2d45"
+      -H "Request-Id: Request:9f7a2c10-5e88-4fb1-bd0e-1c3a8e7b2d45"
     ```
 
     **Response:** `204 No Content`. All active sessions issued by the revoked credential are also revoked.

--- a/mintlify/snippets/global-accounts/exporting-wallet.mdx
+++ b/mintlify/snippets/global-accounts/exporting-wallet.mdx
@@ -25,7 +25,7 @@ sequenceDiagram
   <Step title="First call — receive the challenge">
     ```bash
     curl -X POST "$GRID_BASE_URL/internal-accounts/InternalAccount:019542f5-b3e7-1d02-0000-000000000002/export" \
-      -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+      -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Content-Type: application/json" \
       -d '{
         "clientPublicKey": "04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2"
@@ -37,7 +37,7 @@ sequenceDiagram
     ```json
     {
       "payloadToSign": "Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==",
-      "requestId": "c3f8a614-47e2-4a19-9f5d-2b0a91d47e08",
+      "requestId": "Request:c3f8a614-47e2-4a19-9f5d-2b0a91d47e08",
       "expiresAt": "2026-04-19T12:10:00Z"
     }
     ```
@@ -51,7 +51,7 @@ sequenceDiagram
       -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Content-Type: application/json" \
       -H "Grid-Wallet-Signature: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=" \
-      -H "Request-Id: c3f8a614-47e2-4a19-9f5d-2b0a91d47e08" \
+      -H "Request-Id: Request:c3f8a614-47e2-4a19-9f5d-2b0a91d47e08" \
       -d '{
         "clientPublicKey": "04f45f2a22c908b9ce09a7150e514afd24627c401c38a4afc164e1ea783adaaa31d4245acfb88c2ebd42b47628d63ecabf345484f0a9f665b63c54c897d5578be2"
       }'

--- a/mintlify/snippets/global-accounts/managing-sessions.mdx
+++ b/mintlify/snippets/global-accounts/managing-sessions.mdx
@@ -53,7 +53,7 @@ Session revocation uses the same <a href="authentication#the-signed-retry-patter
     {
       "type": "PASSKEY",
       "payloadToSign": "Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==",
-      "requestId": "2b1e5a08-9c44-4e91-ae7f-6d0b3f8c1e22",
+      "requestId": "Request:2b1e5a08-9c44-4e91-ae7f-6d0b3f8c1e22",
       "expiresAt": "2026-04-19T12:10:00Z"
     }
     ```
@@ -66,7 +66,7 @@ Session revocation uses the same <a href="authentication#the-signed-retry-patter
     curl -X DELETE "$GRID_BASE_URL/auth/sessions/Session:019542f5-b3e7-1d02-0000-000000000003" \
       -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Grid-Wallet-Signature: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=" \
-      -H "Request-Id: 2b1e5a08-9c44-4e91-ae7f-6d0b3f8c1e22"
+      -H "Request-Id: Request:2b1e5a08-9c44-4e91-ae7f-6d0b3f8c1e22"
     ```
 
     **Response:** `204 No Content`.

--- a/mintlify/snippets/global-accounts/walkthrough.mdx
+++ b/mintlify/snippets/global-accounts/walkthrough.mdx
@@ -262,7 +262,7 @@ The customer has an outstanding quote with a `payloadToSign`. Now we need a sess
       "createdAt": "2026-04-19T12:00:01Z",
       "updatedAt": "2026-04-19T12:05:00Z",
       "challenge": "VjZ6o8KfE9V3q3LkR2nH5eZ6dM8yA1xW",
-      "requestId": "7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21",
+      "requestId": "Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21",
       "expiresAt": "2026-04-19T12:10:00Z"
     }
     ```
@@ -295,7 +295,7 @@ The customer has an outstanding quote with a `payloadToSign`. Now we need a sess
     curl -X POST "$GRID_BASE_URL/auth/credentials/AuthMethod:019542f5-b3e7-1d02-0000-000000000001/verify" \
       -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       -H "Content-Type: application/json" \
-      -H "Request-Id: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
+      -H "Request-Id: Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
       -d '{
         "type": "PASSKEY",
         "assertion": {

--- a/mintlify/snippets/internal-accounts.mdx
+++ b/mintlify/snippets/internal-accounts.mdx
@@ -147,10 +147,10 @@ Each internal account includes `fundingPaymentInstructions` that tell your custo
     {
       "instructionsNotes": "Include reference in SEPA transfer description",
       "accountOrWalletInfo": {
-        "accountType": "IBAN",
+        "accountType": "EUR_ACCOUNT",
         "reference": "FUND-EUR789",
         "iban": "DE89370400440532013000",
-        "swiftBic": "DEUTDEFF",
+        "swiftCode": "DEUTDEFF",
         "accountHolderName": "Lightspark Payments FBO Maria Garcia",
         "bankName": "Banco de México"
       }

--- a/mintlify/snippets/internal-accounts.mdx
+++ b/mintlify/snippets/internal-accounts.mdx
@@ -63,7 +63,7 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/internal-accou
           "instructionsNotes": "Include the reference code in your ACH transfer memo",
           "accountOrWalletInfo": {
             "reference": "FUND-ABC123",
-            "accountType": "US_ACCOUNT",
+            "accountType": "USD_ACCOUNT",
             "accountNumber": "9876543210",
             "routingNumber": "021000021",
             "accountHolderName": "Lightspark Payments FBO John Doe",
@@ -123,7 +123,7 @@ Each internal account includes `fundingPaymentInstructions` that tell your custo
     {
       "instructionsNotes": "Include the reference code in your ACH transfer memo",
       "accountOrWalletInfo": {
-        "accountType": "US_ACCOUNT",
+        "accountType": "USD_ACCOUNT",
         "reference": "FUND-ABC123",
         "accountNumber": "9876543210",
         "routingNumber": "021000021",
@@ -241,28 +241,32 @@ The internal account balance reflects all deposits and withdrawals. The balance 
 ### Example balance check
 
 ```bash Fetch the balance of an internal account
-curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/internal-accounts/InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
+curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/internal-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001&currency=USD' \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Accordion title="Response">
 ```json
 {
-  "data": {
-    "id": "InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965",
-    "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
-    "type": "INTERNAL_FIAT",
-    "status": "ACTIVE",
-    "balance": {
-      "amount": 50000,
-      "currency": {
-        "code": "USD",
-        "name": "United States Dollar",
-        "symbol": "$",
-        "decimals": 2
+  "data": [
+    {
+      "id": "InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965",
+      "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
+      "type": "INTERNAL_FIAT",
+      "status": "ACTIVE",
+      "balance": {
+        "amount": 50000,
+        "currency": {
+          "code": "USD",
+          "name": "United States Dollar",
+          "symbol": "$",
+          "decimals": 2
+        }
       }
     }
-  }
+  ],
+  "hasMore": false,
+  "totalCount": 1
 }
 ```
 </Accordion>

--- a/mintlify/snippets/platform-config-currency-api-webhooks.mdx
+++ b/mintlify/snippets/platform-config-currency-api-webhooks.mdx
@@ -39,7 +39,7 @@ You can trigger a test delivery from the API to validate your endpoint setup. Th
 Use the webhook test endpoint to send a synthetic event to your configured endpoint.
 
 ```bash
-curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/webhooks/test" \
+curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/sandbox/webhooks/test" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 

--- a/mintlify/snippets/platform-configuration-non-uma.mdx
+++ b/mintlify/snippets/platform-configuration-non-uma.mdx
@@ -20,7 +20,8 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/config' \
       "currencyCode": "USD",
       "minAmount": 100,
       "maxAmount": 1000000,
-      "enabledTransactionTypes": ["OUTGOING", "INCOMING"]
+      "enabledTransactionTypes": ["OUTGOING", "INCOMING"],
+      "requiredCounterpartyFields": []
     }
   ],
   "createdAt": "2023-06-15T12:30:45Z",
@@ -49,6 +50,7 @@ curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
         "minAmount": 100,
         "maxAmount": 1000000,
         "enabledTransactionTypes": ["OUTGOING", "INCOMING"],
+        "requiredCounterpartyFields": []
       }
     ]
   }'
@@ -63,7 +65,8 @@ curl -X PATCH 'https://api.lightspark.com/grid/2025-10-13/config' \
       "currencyCode": "USD",
       "minAmount": 100,
       "maxAmount": 1000000,
-      "enabledTransactionTypes": ["OUTGOING", "INCOMING"]
+      "enabledTransactionTypes": ["OUTGOING", "INCOMING"],
+      "requiredCounterpartyFields": []
     }
   ],
   "createdAt": "2023-06-15T12:30:45Z",
@@ -96,9 +99,10 @@ The `supportedCurrencies` array allows you to define settings for each currency 
 - `minAmount`: (Integer, required) Minimum transaction amount in the smallest unit of the currency.
 - `maxAmount`: (Integer, required) Maximum transaction amount in the smallest unit of the currency.
 - `enabledTransactionTypes`: (Array, optional) Specifies which transaction types are allowed (e.g., `["OUTGOING", "INCOMING"]`).
+- `requiredCounterpartyFields`: (Array, required) Counterparty PII fields required for transactions in this currency. For non-UMA platforms with no PII requirements, send an empty array (`[]`).
 
 <Note>
-For payouts payments, you do not need UMA-specific fields like `providerRequiredCustomerFields` or `providerRequiredCounterpartyCustomerFields`. The configuration is simpler and focuses on basic currency requirements.
+For payouts payments, you do not need UMA-specific fields like `providerRequiredCustomerFields` or `providerRequiredCounterpartyCustomerFields`. `requiredCounterpartyFields` itself is structurally required — send `[]` when you don't need to collect counterparty PII.
 </Note>
 
 ## Verify Configuration


### PR DESCRIPTION
Comprehensive sync of accounts / auth / cards documentation examples with the current OpenAPI schema.

## Changes

**Account IDs and headers:**
- `accountId` for internal accounts uses `InternalAccount:` prefix (was `EmbeddedWallet:`).
- `requestId` values and `Request-Id` headers use `Request:` prefix.
- `/auth/credentials` register response no longer falsely claims a challenge is returned (it returns `AuthMethod` only — call `/challenge` separately).
- Removed `email` field from `EMAIL_OTP` credential create body (not in schema).

**External / internal account types and fields:**
- Account types: `USD_ACCOUNT`, `EUR_ACCOUNT`, `BRL_ACCOUNT`, `MXN_ACCOUNT`, `INR_ACCOUNT`, etc. (no `US_ACCOUNT` / `IBAN` / `IBAN_ACCOUNT` / `PIX` / `CLABE` / `UPI` aliases).
- `ExternalAccountStatus`: `PENDING | ACTIVE | UNDER_REVIEW | INACTIVE` (no `REJECTED` / `FAILED` / `DISABLED`).
- Field renames: `bankAccountType` (was `accountCategory`), `swiftCode` (was `swiftBic`), `beneficiaryType` (was `counterPartyType`).
- Spark wallet creation: removed unsupported top-level `beneficiary` block.
- Removed fabricated `GET /customers/internal-accounts/{id}` endpoint example.

**Platform config:**
- `supportedCurrencies` entries require `requiredCounterpartyFields`.
- Sandbox webhook test endpoint is `/sandbox/webhooks/test` (not `/webhooks/test`).

**Cards:**
- `CARDHOLDER_KYC_NOT_APPROVED` and `FUNDING_SOURCE_INELIGIBLE` are `400` (not `409`).

## Sibling PRs

Split from a larger sync effort. Two companion draft PRs cover onboarding (#502) and payments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)