### PR TITLE
docs(mcp): document API execution tool and multi-language SDK doc search

### DIFF
--- a/mintlify/platform-overview/building-with-ai.mdx
+++ b/mintlify/platform-overview/building-with-ai.mdx
@@ -107,7 +107,7 @@ Start in the sandbox environment to experiment safely. The Skill is great at gen
 
 ## MCP server
 
-Grid provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives AI agents access to Grid's documentation, so your agentic workflows have full context of the Grid API during implementation.
+Grid provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that lets AI agents search Grid's SDK documentation **and** execute Grid API operations directly. Your agentic workflows get full context of the Grid API during implementation and can run quotes, transfers, customer onboarding, and other operations end-to-end.
 
 ```text
 https://mcp.grid.lightspark.com/
@@ -115,16 +115,16 @@ https://mcp.grid.lightspark.com/
 
 The MCP server exposes two tools:
 
-- **`search_grid_api_documentation`** — Search the Grid docs for relevant guides, code examples, and API references
-- **`get_page_grid_api_documentation`** — Retrieve the full content of a specific documentation page
+- **`search_docs`** — Search Grid SDK documentation for methods, parameters, and usage examples across HTTP, TypeScript, JavaScript, Python, Go, Java, Kotlin, Ruby, and Terraform
+- **`execute`** — Interact with the Grid API to create customers, manage accounts, generate and execute quotes, send transfers, look up receivers, and call any other Grid API operation
 
-<Info>
-The MCP server provides documentation access to support agentic implementation workflows. It does not yet support interacting with the Grid API directly — use the [Grid API agent skill](#install-the-grid-api-agent-skill) or direct API calls for that.
-</Info>
+<Warning>
+Because `execute` calls the live Grid API with your credentials, scope your API token carefully. Use a **read-only token in sandbox** while experimenting; only issue a write-capable or production-scoped token when you understand the operations the agent will run.
+</Warning>
 
 ### Create an API token
 
-The MCP server requires Grid API credentials. In the [Grid dashboard](https://app.lightspark.com), create a **read-only scoped API token** and copy the client ID and client secret. You'll plug these into the `x-grid-client-id` and `x-grid-client-secret` headers in the configurations below.
+The MCP server requires Grid API credentials. In the [Grid dashboard](https://app.lightspark.com), create a scoped API token — a **read-only sandbox token** is recommended for first-time setup — and copy the client ID and client secret. You'll plug these into the `x-grid-client-id` and `x-grid-client-secret` headers in the configurations below.
 
 ### Configure your client
 


### PR DESCRIPTION
## Summary

The Building with AI page describes the MCP server as documentation-only with tool names `search_grid_api_documentation` / `get_page_grid_api_documentation`. The actual server at `https://mcp.grid.lightspark.com/` exposes:

- **`search_docs`** — searches SDK documentation across HTTP, TypeScript, JavaScript, Python, Go, Java, Kotlin, Ruby, and Terraform
- **`execute`** — runs JS/TS code against an initialized Grid SDK client, giving agents the ability to call any Grid API operation (quotes, customers, transfers, etc.)

This PR updates the MCP section to:

- Reframe the intro to mention both doc search and live API execution
- Correct the tool names and descriptions
- Replace the outdated "does not yet support interacting with the Grid API directly" callout with a security warning about token scoping, since `execute` runs against the live API with the user's credentials
- Soften the API-token guidance to recommend a read-only sandbox token for first-time setup (the previous wording mandated read-only, which would block agents from actually calling `execute` for write operations)

## Test plan

- [ ] `make lint` passes
- [ ] Local `make mint` renders the MCP section correctly
- [ ] Spot-check the Warning callout rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)