### PR TITLE
Expose transaction receipt fields

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15807,8 +15807,12 @@ components:
       properties:
         reference:
           type: string
-          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
+          description: Unique reference code to include with the payment to match it with the correct incoming transaction, when available.
           example: UMA-Q12345-REF
+        transactionHash:
+          type: string
+          description: Transaction hash for the crypto transfer that delivered funds to the transaction destination, when available.
+          example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingRateDetails:
       description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
@@ -15872,6 +15876,12 @@ components:
             receivedAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount received in the recipient's currency
+            fees:
+              type: integer
+              format: int64
+              description: The total fees available from the receive quote in the smallest unit of the receiving currency (eg. cents).
+              minimum: 0
+              example: 10
             reconciliationInstructions:
               $ref: '#/components/schemas/ReconciliationInstructions'
               description: Included for all transactions except those with "CREATED" status
@@ -16027,6 +16037,9 @@ components:
               description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
               minimum: 0
               example: 10
+            reconciliationInstructions:
+              $ref: '#/components/schemas/ReconciliationInstructions'
+              description: Reconciliation details for this transaction, including crypto transaction hash when available.
             quoteId:
               type: string
               description: The ID of the quote that was used to trigger this payment

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15802,8 +15802,7 @@ components:
           REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     ReconciliationInstructions:
       type: object
-      required:
-        - reference
+      minProperties: 1
       properties:
         reference:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15807,8 +15807,12 @@ components:
       properties:
         reference:
           type: string
-          description: Unique reference code that must be included with the payment to match it with the correct incoming transaction
+          description: Unique reference code to include with the payment to match it with the correct incoming transaction, when available.
           example: UMA-Q12345-REF
+        transactionHash:
+          type: string
+          description: Transaction hash for the crypto transfer that delivered funds to the transaction destination, when available.
+          example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingRateDetails:
       description: 'Details about the rate and fees for an incoming transaction. Note: `gridApiFixedFee` is denominated in the receiving currency, so its equivalent value in the sending currency fluctuates with the FX rate. As a result, the total fee on a subsequent quote for the same transfer may differ even if the underlying fee structure is unchanged.'
       type: object
@@ -15872,6 +15876,12 @@ components:
             receivedAmount:
               $ref: '#/components/schemas/CurrencyAmount'
               description: Amount received in the recipient's currency
+            fees:
+              type: integer
+              format: int64
+              description: The total fees available from the receive quote in the smallest unit of the receiving currency (eg. cents).
+              minimum: 0
+              example: 10
             reconciliationInstructions:
               $ref: '#/components/schemas/ReconciliationInstructions'
               description: Included for all transactions except those with "CREATED" status
@@ -16027,6 +16037,9 @@ components:
               description: The fees associated with the quote in the smallest unit of the sending currency (eg. cents).
               minimum: 0
               example: 10
+            reconciliationInstructions:
+              $ref: '#/components/schemas/ReconciliationInstructions'
+              description: Reconciliation details for this transaction, including crypto transaction hash when available.
             quoteId:
               type: string
               description: The ID of the quote that was used to trigger this payment

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15802,8 +15802,7 @@ components:
           REALTIME_FUNDING: '#/components/schemas/RealtimeFundingTransactionSource'
     ReconciliationInstructions:
       type: object
-      required:
-        - reference
+      minProperties: 1
       properties:
         reference:
           type: string

--- a/openapi/components/schemas/common/ReconciliationInstructions.yaml
+++ b/openapi/components/schemas/common/ReconciliationInstructions.yaml
@@ -5,6 +5,12 @@ properties:
   reference:
     type: string
     description: >-
-      Unique reference code that must be included with the payment to match it
-      with the correct incoming transaction
+      Unique reference code to include with the payment to match it with the
+      correct incoming transaction, when available.
     example: UMA-Q12345-REF
+  transactionHash:
+    type: string
+    description: >-
+      Transaction hash for the crypto transfer that delivered funds to the
+      transaction destination, when available.
+    example: "0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566"

--- a/openapi/components/schemas/common/ReconciliationInstructions.yaml
+++ b/openapi/components/schemas/common/ReconciliationInstructions.yaml
@@ -1,6 +1,5 @@
 type: object
-required:
-  - reference
+minProperties: 1
 properties:
   reference:
     type: string

--- a/openapi/components/schemas/transactions/IncomingTransaction.yaml
+++ b/openapi/components/schemas/transactions/IncomingTransaction.yaml
@@ -15,6 +15,14 @@ allOf:
       receivedAmount:
         $ref: ../common/CurrencyAmount.yaml
         description: Amount received in the recipient's currency
+      fees:
+        type: integer
+        format: int64
+        description: >-
+          The total fees available from the receive quote in the smallest unit
+          of the receiving currency (eg. cents).
+        minimum: 0
+        example: 10
       reconciliationInstructions:
         $ref: ../common/ReconciliationInstructions.yaml
         description: Included for all transactions except those with "CREATED" status

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -34,6 +34,11 @@ allOf:
           currency (eg. cents).
         minimum: 0
         example: 10
+      reconciliationInstructions:
+        $ref: ../common/ReconciliationInstructions.yaml
+        description: >-
+          Reconciliation details for this transaction, including crypto
+          transaction hash when available.
       quoteId:
         type: string
         description: The ID of the quote that was used to trigger this payment


### PR DESCRIPTION
## Summary

- Add optional `transactionHash` to `reconciliationInstructions` for destination-side crypto settlement receipt data.
- Make `reference` optional so reconciliation instructions can contain only a transaction hash when no payment reference exists.
- Add optional `fees` to incoming transactions, denominated in the receiving currency's smallest unit.
- Rebuild bundled OpenAPI specs for `openapi.yaml` and `mintlify/openapi.yaml`.

## Implementation Note

The public API stays storage-agnostic. In webdev, `transactionHash` is populated from hash-bearing Grid settlement references, including the existing `USDC_SOLANA` settlement reference type and the new generic `CRYPTO` type.

## Testing

- `make build`
- `make lint`