### PR TITLE
docs(spec): document REQUEST_ID_MISSING error code (401)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8110,6 +8110,7 @@ components:
             | WALLET_SIGNATURE_MALFORMED | The `Grid-Wallet-Signature` header could not be parsed (bad encoding, structure, or fields) |
             | WALLET_SIGNATURE_BODY_MISMATCH | The `Grid-Wallet-Signature` was computed over a different request body than the one received |
             | WALLET_SIGNATURE_INVALID | The `Grid-Wallet-Signature` failed cryptographic verification against the registered credential |
+            | REQUEST_ID_MISSING | The `Request-Id` header is required on the signed retry but was not supplied (paired with `Grid-Wallet-Signature`) |
           enum:
             - UNAUTHORIZED
             - INVALID_SIGNATURE
@@ -8117,6 +8118,7 @@ components:
             - WALLET_SIGNATURE_MALFORMED
             - WALLET_SIGNATURE_BODY_MISMATCH
             - WALLET_SIGNATURE_INVALID
+            - REQUEST_ID_MISSING
         message:
           type: string
           description: Error message

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8110,6 +8110,7 @@ components:
             | WALLET_SIGNATURE_MALFORMED | The `Grid-Wallet-Signature` header could not be parsed (bad encoding, structure, or fields) |
             | WALLET_SIGNATURE_BODY_MISMATCH | The `Grid-Wallet-Signature` was computed over a different request body than the one received |
             | WALLET_SIGNATURE_INVALID | The `Grid-Wallet-Signature` failed cryptographic verification against the registered credential |
+            | REQUEST_ID_MISSING | The `Request-Id` header is required on the signed retry but was not supplied (paired with `Grid-Wallet-Signature`) |
           enum:
             - UNAUTHORIZED
             - INVALID_SIGNATURE
@@ -8117,6 +8118,7 @@ components:
             - WALLET_SIGNATURE_MALFORMED
             - WALLET_SIGNATURE_BODY_MISMATCH
             - WALLET_SIGNATURE_INVALID
+            - REQUEST_ID_MISSING
         message:
           type: string
           description: Error message

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -20,6 +20,7 @@ properties:
       | WALLET_SIGNATURE_MALFORMED | The `Grid-Wallet-Signature` header could not be parsed (bad encoding, structure, or fields) |
       | WALLET_SIGNATURE_BODY_MISMATCH | The `Grid-Wallet-Signature` was computed over a different request body than the one received |
       | WALLET_SIGNATURE_INVALID | The `Grid-Wallet-Signature` failed cryptographic verification against the registered credential |
+      | REQUEST_ID_MISSING | The `Request-Id` header is required on the signed retry but was not supplied (paired with `Grid-Wallet-Signature`) |
     enum:
       - UNAUTHORIZED
       - INVALID_SIGNATURE
@@ -27,6 +28,7 @@ properties:
       - WALLET_SIGNATURE_MALFORMED
       - WALLET_SIGNATURE_BODY_MISMATCH
       - WALLET_SIGNATURE_INVALID
+      - REQUEST_ID_MISSING
   message:
     type: string
     description: Error message


### PR DESCRIPTION
## Summary

Follow-up to grid-api #500 (merged). webdev PR #27767 (AT-5342) added a new \`REQUEST_ID_MISSING\` ErrorCode (401) on the server so that signed-retry endpoints can distinguish two failure modes that were previously lumped under \`WALLET_SIGNATURE_MISSING\`:

- **WALLET_SIGNATURE_MISSING** — caller sent \`Request-Id\` but forgot \`Grid-Wallet-Signature\`
- **REQUEST_ID_MISSING** — caller sent \`Grid-Wallet-Signature\` but forgot \`Request-Id\`

Kevin's review on the server PR pointed out that lumping these under one code defeats the point of having specific subcodes. The server change is in; this PR brings the spec into sync so the SDKs can learn the new code.

## Files

- \`openapi/components/schemas/errors/Error401.yaml\` — add \`REQUEST_ID_MISSING\` to the enum + description table
- \`openapi.yaml\`, \`mintlify/openapi.yaml\` — re-bundled

## Test plan

- [x] \`make build\` clean
- [x] \`npx @redocly/cli lint openapi.yaml\` clean (no errors; 33 pre-existing warnings)
- [x] Bundle contains \`REQUEST_ID_MISSING\`

Refs [AT-5342](https://lightspark.atlassian.net/browse/AT-5342) under epic [AT-5324](https://lightspark.atlassian.net/browse/AT-5324)

[AT-5342]: https://lightspark.atlassian.net/browse/AT-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ