### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 58 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 59 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="58 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="59 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -54,6 +54,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇳🇱 Netherlands | NL | `SEPA` `SEPA Instant` |
 | 🇳🇬 Nigeria | NG | `Bank Transfer` |
 | 🇳🇴 Norway | NO | `SEPA` `SEPA Instant` |
+| 🇵🇰 Pakistan | PK | `Bank Transfer` |
 | 🇵🇭 Philippines | PH | `Bank Transfer` |
 | 🇵🇱 Poland | PL | `SEPA` `SEPA Instant` |
 | 🇵🇹 Portugal | PT | `SEPA` `SEPA Instant` |
@@ -85,7 +86,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="13 countries">
     Primary: Bank Transfer
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="8 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="9 countries">
     Various instant payment systems
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Americas" tag="5 countries">


### PR DESCRIPTION
## Summary
- Adds Pakistan (PK, Thunes / `Bank Transfer`) to the Live destinations table.
- Bumps the totals: 58 → 59 countries overall, Asia-Pacific 8 → 9. Europe / MEA / Americas unchanged.
- Coming Soon (Canada, China, Hong Kong, South Korea) unchanged from the source sheet.

Source of truth: [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) — rows with Status=Live are Live; Status≠Live AND Public Roadmap=Yes are Coming Soon.

## Test plan
- [ ] Visual check of `/global-p2p/country-support` in `mint dev` — Pakistan row appears, headline reads "Send payments to 59 countries", Regional Summary cards sum to 59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)