### PR TITLE
ci: detect OpenAPI breaking changes on PRs

### DIFF
--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -1,0 +1,109 @@
+name: OpenAPI Breaking Changes
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'openapi.yaml'
+      - 'openapi/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  detect:
+    name: Detect breaking changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base spec
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Checkout head spec
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+
+      - name: Install oasdiff
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
+
+      - name: Run oasdiff breaking
+        id: oasdiff
+        run: |
+          set +e
+          oasdiff breaking \
+            base/openapi.yaml head/openapi.yaml \
+            --format markdown \
+            --fail-on ERR > breaking.md
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ] && [ -s breaking.md ]; then
+            echo "has_breaking=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_breaking=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build comment body
+        id: body
+        if: steps.oasdiff.outputs.has_breaking == 'true'
+        run: |
+          {
+            echo 'body<<COMMENT_EOF'
+            echo '## :warning: Breaking OpenAPI changes detected'
+            echo ''
+            echo 'This PR introduces breaking changes to `openapi.yaml`:'
+            echo ''
+            cat breaking.md
+            echo ''
+            echo '---'
+            echo '_Detected by [oasdiff](https://github.com/oasdiff/oasdiff). This PR will need approval from an API reviewer before merge._'
+            echo 'COMMENT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure breaking-change label exists
+        if: steps.oasdiff.outputs.has_breaking == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create "breaking-change" \
+            --color B60205 \
+            --description "Introduces a breaking change to the OpenAPI spec" \
+            2>/dev/null || true
+
+      - name: Add breaking-change label
+        if: steps.oasdiff.outputs.has_breaking == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "breaking-change"
+
+      - name: Remove breaking-change label if previously set
+        if: steps.oasdiff.outputs.has_breaking == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --remove-label "breaking-change" || true
+
+      - name: Upsert PR comment (breaking)
+        if: steps.oasdiff.outputs.has_breaking == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: oasdiff-breaking-changes
+          message: ${{ steps.body.outputs.body }}
+
+      - name: Clear PR comment (no breaking)
+        if: steps.oasdiff.outputs.has_breaking == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: oasdiff-breaking-changes
+          delete: true


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that detects breaking changes to the OpenAPI spec on every PR and surfaces them to reviewers.

On PRs touching `openapi.yaml` or `openapi/**`:
- Runs `oasdiff breaking` between the PR's base and head bundled spec.
- If breaking changes are detected (oasdiff `ERR` severity), adds a `breaking-change` label and posts a sticky comment with the markdown report.
- If a previous run flagged the PR but the breaking change has since been removed, the label and comment are cleared automatically.

## Validation

Ran the same `oasdiff breaking` logic locally against recent merged PRs:

- **#509** (required `taxId` / `incorporatedOn` on business customers) — exit 1, correctly flagged as breaking (4 changes across `POST /customers` and `customer-update` webhook).
- **#512** (added `SWIFT` payment rail enum value) — exit 0, treated as non-breaking. New enum values in responses are classified as `WARN`, below the `ERR` gate. Open question: SDKs with closed-enum codegen may still break; we may want to revisit the threshold.

## Follow-up (separate PR)

Step 2 of this effort: a required status check that gates merge on approval from a designated reviewer when the `breaking-change` label is present. This PR only handles detection + notification.

## Notes

- The workflow doesn't run on its own PR (no `openapi/**` changes) — it activates on the next spec-touching PR.
- Uses `marocchino/sticky-pull-request-comment@v2` for upsert comment behavior. Happy to swap for `gh pr comment` if you'd rather avoid the third-party action.