### PR TITLE
ci: pin oasdiff to v1.16.0

### DIFF
--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -31,8 +31,17 @@ jobs:
           path: head
 
       - name: Install oasdiff
+        env:
+          OASDIFF_VERSION: 1.16.0
+          OASDIFF_SHA256: 2f424431c441a85e2d73ff884609f55c98c283ca2ce3d88537a7a029379dd521
         run: |
-          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
+          curl -fsSL \
+            "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/oasdiff.tgz
+          echo "${OASDIFF_SHA256}  /tmp/oasdiff.tgz" | sha256sum -c -
+          tar -xzf /tmp/oasdiff.tgz -C /tmp oasdiff
+          sudo mv /tmp/oasdiff /usr/local/bin/oasdiff
+          oasdiff --version
 
       - name: Run oasdiff breaking
         id: oasdiff


### PR DESCRIPTION
## Summary

Pins oasdiff to v1.16.0 in the breaking-changes workflow and verifies the downloaded tarball against a hardcoded SHA-256, instead of running the upstream install script.

The previous `install.sh | sh` approach grabs whatever release is current at build time, with no integrity check:
- Behavior of the breaking-change gate could shift silently across CI runs.
- A buggy or backwards-incompatible oasdiff release could either miss real breaking changes or flag spurious ones.
- A compromised release artifact would be executed unconditionally.

Now we download a fixed release tarball and verify it against a hardcoded SHA-256 (`2f424431c4…dd521`, from the upstream `checksums.txt` for v1.16.0 linux_amd64). The SHA is hardcoded rather than fetched, so a tampered `checksums.txt` can't slip a bad binary through. Bumping the version is a two-line change (`OASDIFF_VERSION` + `OASDIFF_SHA256`).

## Test plan
- [ ] Workflow runs successfully on a spec-touching PR (any subsequent PR will exercise it).