### PR TITLE
fix(spectral): broaden no-inline-schema rules to all content types

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -81,7 +81,7 @@ rules:
     message: "Use $ref for request body schema instead of inline definition. See openapi/README.md#avoid-inline-schemas-in-request-and-response-definitions"
     severity: error
     resolved: false
-    given: "$.paths[*][get,post,put,patch,delete].requestBody.content[application/json].schema"
+    given: "$.paths[*][get,post,put,patch,delete].requestBody.content.*.schema"
     then:
       field: "$ref"
       function: truthy
@@ -92,7 +92,7 @@ rules:
     message: "Use $ref for response schema instead of inline definition. See openapi/README.md#avoid-inline-schemas-in-request-and-response-definitions"
     severity: error
     resolved: false
-    given: "$.paths[*][get,post,put,patch,delete].responses[*].content[application/json].schema"
+    given: "$.paths[*][get,post,put,patch,delete].responses[*].content.*.schema"
     then:
       field: "$ref"
       function: truthy

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3002,14 +3002,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              type: object
-              required:
-                - file
-              properties:
-                file:
-                  type: string
-                  format: binary
-                  description: CSV file containing customer information
+              $ref: '#/components/schemas/BulkCustomerImportRequest'
       responses:
         '202':
           description: CSV upload accepted for processing
@@ -16699,6 +16692,15 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    BulkCustomerImportRequest:
+      type: object
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+          description: CSV file containing customer information
     BulkCustomerImportJobAccepted:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3002,14 +3002,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              type: object
-              required:
-                - file
-              properties:
-                file:
-                  type: string
-                  format: binary
-                  description: CSV file containing customer information
+              $ref: '#/components/schemas/BulkCustomerImportRequest'
       responses:
         '202':
           description: CSV upload accepted for processing
@@ -16699,6 +16692,15 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    BulkCustomerImportRequest:
+      type: object
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+          description: CSV file containing customer information
     BulkCustomerImportJobAccepted:
       type: object
       required:

--- a/openapi/components/schemas/customers/BulkCustomerImportRequest.yaml
+++ b/openapi/components/schemas/customers/BulkCustomerImportRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - file
+properties:
+  file:
+    type: string
+    format: binary
+    description: CSV file containing customer information

--- a/openapi/paths/customers/customers_bulk_csv.yaml
+++ b/openapi/paths/customers/customers_bulk_csv.yaml
@@ -104,14 +104,7 @@ post:
     content:
       multipart/form-data:
         schema:
-          type: object
-          required:
-            - file
-          properties:
-            file:
-              type: string
-              format: binary
-              description: CSV file containing customer information
+          $ref: ../../components/schemas/customers/BulkCustomerImportRequest.yaml
   responses:
     '202':
       description: CSV upload accepted for processing


### PR DESCRIPTION
## Summary

Broadens the `no-inline-request-schema` and `no-inline-response-schema` Spectral rules from hardcoded `application/json` content to all content types. Also extracts the previously-missed inline schema on `POST /customers/bulk/csv` (which uses `multipart/form-data`) into a new `BulkCustomerImportRequest` component.

## Why

When extracting the document `requestBody`s in #517, I noticed the existing rule wouldn't have caught inline schemas under `multipart/form-data` — the JSONPath was scoped to `content[application/json].schema`. That left a hole in the lint that masked the inline file-upload schema on the bulk CSV endpoint.

Before:
```yaml
given: "$.paths[*][...].requestBody.content[application/json].schema"
```

After:
```yaml
given: "$.paths[*][...].requestBody.content.*.schema"
```

Same change applied to the response rule.

## Changes

- `.spectral.yaml`: widen JSONPath on both `no-inline-request-schema` and `no-inline-response-schema` to match all content types.
- `openapi/components/schemas/customers/BulkCustomerImportRequest.yaml`: new component for the bulk CSV upload body (`file: binary`).
- `openapi/paths/customers/customers_bulk_csv.yaml`: replace inline schema with `$ref`.
- Rebundled `openapi.yaml` / `mintlify/openapi.yaml`.

## Test plan
- [x] `make build` succeeds
- [x] `make lint` exits 0

## Stack

Stacked on top of #518 / #517.