### PR TITLE
fix(stainless): rename simulate.return → simulate.refund to avoid Kotlin keyword

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -353,7 +353,7 @@ resources:
             methods:
               authorization: post /sandbox/cards/{id}/simulate/authorization
               clearing: post /sandbox/cards/{id}/simulate/clearing
-              return: post /sandbox/cards/{id}/simulate/return
+              refund: post /sandbox/cards/{id}/simulate/return
             models:
               card_merchant: "#/components/schemas/CardMerchant"
               card_pull_summary: "#/components/schemas/CardPullSummary"


### PR DESCRIPTION
## Summary

Renames the Stainless method `sandbox.cards.simulate.return` → `sandbox.cards.simulate.refund` to avoid the Kotlin reserved keyword `return`.

## Why

After #518, Stainless codegen emits a warning:

> Encountered name `return` that conflicts with a Kotlin keyword. Renamed to `return_`.

That gives consumers awkward call sites like `grid.sandbox.cards.simulate.return_(...)` in Kotlin. The endpoint creates a `CardRefund` (per the `POST /sandbox/cards/{id}/simulate/return` description: _"Simulate a merchant-initiated RETURN against an existing settled card transaction... Creates a CardRefund..."_), so `refund` is both semantically accurate and reads cleanly across all SDK targets.

## Changes

- `.stainless/stainless.yml`: rename the method key in `sandbox.subresources.cards.subresources.simulate.methods` from `return` → `refund`. The underlying OpenAPI path is unchanged (`/sandbox/cards/{id}/simulate/return`); only the SDK identifier changes.

## SDK call site impact

| Language | Before | After |
|---|---|---|
| Kotlin | `simulate.return_(...)` | `simulate.refund(...)` |
| TypeScript | `simulate.return(...)` | `simulate.refund(...)` |
| Python | `simulate.return_(...)` (reserved) | `simulate.refund(...)` |

Method has not shipped in any GA SDK yet, so no compatibility shim is needed.

## Test plan
- [ ] Stainless regen succeeds without the keyword-conflict warning
- [ ] Kotlin SDK compiles