### PR TITLE
fix(spectral): catch oneOf without discriminator at all schema depths

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -61,12 +61,15 @@ rules:
   # Discriminators and Polymorphism (README: OpenAPI Best Practices)
   # ============================================================
 
-  # oneOf must include a discriminator
+  # oneOf must include a discriminator (anywhere it appears — top-level
+  # schemas, properties, request/response bodies). oneOf implies a tagged
+  # union; for nullable values use anyOf instead.
   oneOf-must-have-discriminator:
     description: oneOf schemas must include a discriminator
-    message: "oneOf without a discriminator. See openapi/README.md#discriminators-and-polymorphism"
-    severity: warn
-    given: "$.components.schemas[?(@.oneOf)]"
+    message: "oneOf without a discriminator. Use anyOf for non-tagged unions (e.g. nullable values). See openapi/README.md#discriminators-and-polymorphism"
+    severity: error
+    resolved: false
+    given: "$..*[?(@ && @.oneOf)]"
     then:
       field: discriminator
       function: truthy


### PR DESCRIPTION
## Summary

Two changes that together close a hole in our spec hygiene: a Spectral rule that catches every `oneOf` missing a discriminator (not just top-level schemas), and the one existing violation (`Card.stateReason`).

## Why

Stainless's Java codegen emitted the diagnostic:

> `Java/SchemaUnionDiscriminatorMissing` — Union has object variants but no discriminator. Deserialization may be inefficient or ambiguous without a discriminator because each object variant must be tried in sequence.

Tracking it down found a single offender: `Card.stateReason`, which used `oneOf: [$ref CardStateReason, type: 'null']`. `oneOf` implies a tagged union — meaningful only with a discriminator — whereas this is really just a nullable enum. The idiomatic primitive for that is `anyOf`.

The existing spectral rule (`oneOf-must-have-discriminator`) didn't catch it for two reasons:
1. **Scope**: it only inspected `$.components.schemas[?(@.oneOf)]` — i.e. top-level schemas. Nested `oneOf` (inside `properties`, `allOf`, etc.) was invisible.
2. **Severity**: it was set to `warn`, so wouldn't have failed CI even if it had matched.

## Changes

### `openapi/components/schemas/cards/Card.yaml`
Change `stateReason` from `oneOf` → `anyOf`. No semantic change for consumers; just signals to codegen that this is a nullable value, not a tagged union.

```diff
 stateReason:
-  oneOf:
+  anyOf:
     - $ref: ./CardStateReason.yaml
     - type: 'null'
```

### `.spectral.yaml`
Broaden `oneOf-must-have-discriminator`:
- **Given path**: `$.components.schemas[?(@.oneOf)]` → `$..*[?(@ && @.oneOf)]`. Recursive descent with a null-safe filter so it catches `oneOf` at any depth (nested properties, allOf members, array items, etc.) without crashing on JSON null literals (`type: 'null'` etc.).
- **Severity**: `warn` → `error`. The only existing violation is fixed in this PR, so this won't regress CI.
- **Message**: updated to point devs at `anyOf` for nullable-value cases.

## Validation

- `make lint` exits 0 with the fix applied.
- Temporarily regressing `Card.yaml` back to `oneOf` makes spectral fail with:
  ```
  error  oneOf-must-have-discriminator
  components.schemas.Card.properties.stateReason
  ```

## Stack

Stacked on top of #520.