### PR TITLE
feat(customers): split BusinessInfo response schema (taxId/incorporatedOn optional)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8724,13 +8724,14 @@ components:
           $ref: '#/components/schemas/Address'
         businessInfo:
           $ref: '#/components/schemas/BusinessInfoUpdate'
-    BusinessInfo:
+    BusinessInfoResponse:
       type: object
-      description: Additional information required for business entities
+      description: |
+        Business information returned on a customer. `taxId` and `incorporatedOn` are
+        required on creation but may be absent on legacy customers that pre-date the
+        requirement, so both are optional in responses.
       required:
         - legalName
-        - taxId
-        - incorporatedOn
       properties:
         legalName:
           type: string
@@ -8930,7 +8931,7 @@ components:
         - type: object
           properties:
             businessInfo:
-              $ref: '#/components/schemas/BusinessInfo'
+              $ref: '#/components/schemas/BusinessInfoResponse'
             beneficialOwners:
               type: array
               items:
@@ -9028,6 +9029,83 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
+    BusinessInfo:
+      type: object
+      description: Additional information required for business entities
+      required:
+        - legalName
+        - taxId
+        - incorporatedOn
+      properties:
+        legalName:
+          type: string
+          description: Legal name of the business
+          example: Acme Corporation, Inc.
+        doingBusinessAs:
+          type: string
+          description: Trade name or DBA name of the business, if different from the legal name
+          example: Acme
+        country:
+          type: string
+          description: Country of incorporation or registration (ISO 3166-1 alpha-2)
+          example: US
+        registrationNumber:
+          type: string
+          description: Business registration number
+          example: '5523041'
+        incorporatedOn:
+          type: string
+          format: date
+          description: Date of incorporation in ISO 8601 format (YYYY-MM-DD)
+          example: '2018-03-14'
+        entityType:
+          $ref: '#/components/schemas/EntityType'
+        taxId:
+          type: string
+          description: Tax identification number
+          example: 47-1234567
+        countriesOfOperation:
+          type: array
+          items:
+            type: string
+          description: List of countries where the business operates (ISO 3166-1 alpha-2)
+          example:
+            - US
+        businessType:
+          $ref: '#/components/schemas/BusinessType'
+        purposeOfAccount:
+          $ref: '#/components/schemas/PurposeOfAccount'
+        sourceOfFunds:
+          type: string
+          description: The primary source of funds for the business
+          example: Funds derived from customer payments for software services
+        expectedMonthlyTransactionCount:
+          type: string
+          enum:
+            - COUNT_UNDER_10
+            - COUNT_10_TO_100
+            - COUNT_100_TO_500
+            - COUNT_500_TO_1000
+            - COUNT_OVER_1000
+          description: Expected number of transactions per month
+          example: COUNT_100_TO_500
+        expectedMonthlyTransactionVolume:
+          type: string
+          enum:
+            - VOLUME_UNDER_10K
+            - VOLUME_10K_TO_100K
+            - VOLUME_100K_TO_1M
+            - VOLUME_1M_TO_10M
+            - VOLUME_OVER_10M
+          description: Expected total transaction volume per month in USD equivalent
+          example: VOLUME_100K_TO_1M
+        expectedRecipientJurisdictions:
+          type: array
+          items:
+            type: string
+          description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
     BusinessCustomerCreateRequest:
       title: Business Customer Create Request
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8724,13 +8724,14 @@ components:
           $ref: '#/components/schemas/Address'
         businessInfo:
           $ref: '#/components/schemas/BusinessInfoUpdate'
-    BusinessInfo:
+    BusinessInfoResponse:
       type: object
-      description: Additional information required for business entities
+      description: |
+        Business information returned on a customer. `taxId` and `incorporatedOn` are
+        required on creation but may be absent on legacy customers that pre-date the
+        requirement, so both are optional in responses.
       required:
         - legalName
-        - taxId
-        - incorporatedOn
       properties:
         legalName:
           type: string
@@ -8930,7 +8931,7 @@ components:
         - type: object
           properties:
             businessInfo:
-              $ref: '#/components/schemas/BusinessInfo'
+              $ref: '#/components/schemas/BusinessInfoResponse'
             beneficialOwners:
               type: array
               items:
@@ -9028,6 +9029,83 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
+    BusinessInfo:
+      type: object
+      description: Additional information required for business entities
+      required:
+        - legalName
+        - taxId
+        - incorporatedOn
+      properties:
+        legalName:
+          type: string
+          description: Legal name of the business
+          example: Acme Corporation, Inc.
+        doingBusinessAs:
+          type: string
+          description: Trade name or DBA name of the business, if different from the legal name
+          example: Acme
+        country:
+          type: string
+          description: Country of incorporation or registration (ISO 3166-1 alpha-2)
+          example: US
+        registrationNumber:
+          type: string
+          description: Business registration number
+          example: '5523041'
+        incorporatedOn:
+          type: string
+          format: date
+          description: Date of incorporation in ISO 8601 format (YYYY-MM-DD)
+          example: '2018-03-14'
+        entityType:
+          $ref: '#/components/schemas/EntityType'
+        taxId:
+          type: string
+          description: Tax identification number
+          example: 47-1234567
+        countriesOfOperation:
+          type: array
+          items:
+            type: string
+          description: List of countries where the business operates (ISO 3166-1 alpha-2)
+          example:
+            - US
+        businessType:
+          $ref: '#/components/schemas/BusinessType'
+        purposeOfAccount:
+          $ref: '#/components/schemas/PurposeOfAccount'
+        sourceOfFunds:
+          type: string
+          description: The primary source of funds for the business
+          example: Funds derived from customer payments for software services
+        expectedMonthlyTransactionCount:
+          type: string
+          enum:
+            - COUNT_UNDER_10
+            - COUNT_10_TO_100
+            - COUNT_100_TO_500
+            - COUNT_500_TO_1000
+            - COUNT_OVER_1000
+          description: Expected number of transactions per month
+          example: COUNT_100_TO_500
+        expectedMonthlyTransactionVolume:
+          type: string
+          enum:
+            - VOLUME_UNDER_10K
+            - VOLUME_10K_TO_100K
+            - VOLUME_100K_TO_1M
+            - VOLUME_1M_TO_10M
+            - VOLUME_OVER_10M
+          description: Expected total transaction volume per month in USD equivalent
+          example: VOLUME_100K_TO_1M
+        expectedRecipientJurisdictions:
+          type: array
+          items:
+            type: string
+          description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
     BusinessCustomerCreateRequest:
       title: Business Customer Create Request
       allOf:

--- a/openapi/components/schemas/customers/BusinessCustomer.yaml
+++ b/openapi/components/schemas/customers/BusinessCustomer.yaml
@@ -5,7 +5,7 @@ allOf:
   - type: object
     properties:
       businessInfo:
-        $ref: ./BusinessInfo.yaml
+        $ref: ./BusinessInfoResponse.yaml
       beneficialOwners:
         type: array
         items:

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -1,0 +1,77 @@
+type: object
+description: |
+  Business information returned on a customer. `taxId` and `incorporatedOn` are
+  required on creation but may be absent on legacy customers that pre-date the
+  requirement, so both are optional in responses.
+required:
+  - legalName
+properties:
+  legalName:
+    type: string
+    description: Legal name of the business
+    example: Acme Corporation, Inc.
+  doingBusinessAs:
+    type: string
+    description: Trade name or DBA name of the business, if different from the legal name
+    example: Acme
+  country:
+    type: string
+    description: Country of incorporation or registration (ISO 3166-1 alpha-2)
+    example: US
+  registrationNumber:
+    type: string
+    description: Business registration number
+    example: '5523041'
+  incorporatedOn:
+    type: string
+    format: date
+    description: Date of incorporation in ISO 8601 format (YYYY-MM-DD)
+    example: '2018-03-14'
+  entityType:
+    $ref: ./EntityType.yaml
+  taxId:
+    type: string
+    description: Tax identification number
+    example: 47-1234567
+  countriesOfOperation:
+    type: array
+    items:
+      type: string
+    description: List of countries where the business operates (ISO 3166-1 alpha-2)
+    example:
+      - US
+  businessType:
+    $ref: ./BusinessType.yaml
+  purposeOfAccount:
+    $ref: ./PurposeOfAccount.yaml
+  sourceOfFunds:
+    type: string
+    description: The primary source of funds for the business
+    example: Funds derived from customer payments for software services
+  expectedMonthlyTransactionCount:
+    type: string
+    enum:
+      - COUNT_UNDER_10
+      - COUNT_10_TO_100
+      - COUNT_100_TO_500
+      - COUNT_500_TO_1000
+      - COUNT_OVER_1000
+    description: Expected number of transactions per month
+    example: COUNT_100_TO_500
+  expectedMonthlyTransactionVolume:
+    type: string
+    enum:
+      - VOLUME_UNDER_10K
+      - VOLUME_10K_TO_100K
+      - VOLUME_100K_TO_1M
+      - VOLUME_1M_TO_10M
+      - VOLUME_OVER_10M
+    description: Expected total transaction volume per month in USD equivalent
+    example: VOLUME_100K_TO_1M
+  expectedRecipientJurisdictions:
+    type: array
+    items:
+      type: string
+    description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+    example:
+      - US


### PR DESCRIPTION
## Summary

- Adds `BusinessInfoResponse` schema where `taxId` and `incorporatedOn` are optional, and points `BusinessCustomer` (response model) at it.
- Leaves the existing `BusinessInfo` schema unchanged for the create request, so KYB creation still enforces `taxId` + `incorporatedOn`.
- Rebundles `openapi.yaml` / `mintlify/openapi.yaml`.

## Why

Pre-existing business customers in our DB have null `tax_id` / `incorporated_on` (data predates the requirement). The current spec marks both required on every read, which causes generated clients to fail when constructing a `BusinessCustomer` from legacy rows for the grid dashboard. Splitting the read and write models lets us keep the write contract strict without lying about legacy reads.

## Test plan

- [ ] `make build` produces a valid bundle
- [ ] `make lint-openapi` passes (Redocly validation)
- [ ] Downstream sparkcore PR regenerates the python client off this spec and removes the now-unnecessary `none_throws(...)` calls