### PR TITLE
chore(stainless): bump edition, sync resources, fix webhook discrimination

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -3,7 +3,7 @@
 # The main edition for the config, see the [docs] for more information.
 #
 # [docs]: https://www.stainless.com/docs/reference/editions
-edition: 2025-10-10
+edition: 2026-05-06
 
 organization:
   # Name of your organization or company, used to determine the name of the client
@@ -36,7 +36,6 @@ targets:
         host:
           stainless: true
   kotlin:
-    edition: kotlin.2025-10-08
     reverse_domain: com.lightspark.grid
     production_repo: lightsparkdev/grid-kotlin-sdk
     publish:
@@ -101,26 +100,31 @@ resources:
       platform_currency_config: '#/components/schemas/PlatformCurrencyConfig'
       platform_config: '#/components/schemas/PlatformConfig'
       embedded_wallet_config: "#/components/schemas/EmbeddedWalletConfig"
+      platform_config_update_request: '#/components/schemas/PlatformConfigUpdateRequest'
     methods:
       retrieve: get /config
       update: patch /config
 
   customers:
     models:
+      # Customer object + polymorphic response/request unions (INDIVIDUAL | BUSINESS)
       customer: '#/components/schemas/Customer'
-      customer_one_of: "#/components/schemas/CustomerOneOf"
-      customer_create: "#/components/schemas/CustomerCreateRequest"
-      customer_update: "#/components/schemas/CustomerUpdateRequest"
-      customer_type: "#/components/schemas/CustomerType"
-      individual_customer_fields: "#/components/schemas/IndividualCustomerFields"
-      business_customer_fields: "#/components/schemas/BusinessCustomerFields"
-      business_info: "#/components/schemas/BusinessInfo"
-      kyc_link_create: "#/components/schemas/KycLinkCreateRequest"
-      kyc_link_response: "#/components/schemas/KycLinkResponse"
-      kyc_provider: "#/components/schemas/KycProvider"
+      customer_one_of: '#/components/schemas/CustomerOneOf'
+      customer_list_response: '#/components/schemas/CustomerListResponse'
+      customer_create_request_one_of: '#/components/schemas/CustomerCreateRequestOneOf'
+      customer_update_request_one_of: '#/components/schemas/CustomerUpdateRequestOneOf'
+      individual_customer_create_request: '#/components/schemas/IndividualCustomerCreateRequest'
+      business_customer_create_request: '#/components/schemas/BusinessCustomerCreateRequest'
+      individual_customer_update_request: '#/components/schemas/IndividualCustomerUpdateRequest'
+      business_customer_update_request: '#/components/schemas/BusinessCustomerUpdateRequest'
+      # Internal-account management (list/update/export under this resource)
+      internal_account_list_response: '#/components/schemas/InternalAccountListResponse'
+      internal_account_update_request: '#/components/schemas/InternalAccountUpdateRequest'
       internal_account_export_request: '#/components/schemas/InternalAccountExportRequest'
       internal_account_export_response: '#/components/schemas/InternalAccountExportResponse'
-      internal_account_update_request: '#/components/schemas/InternalAccountUpdateRequest'
+      # KYC link generation
+      kyc_link_create_request: '#/components/schemas/KycLinkCreateRequest'
+      kyc_link_response: '#/components/schemas/KycLinkResponse'
     methods:
       create:
         endpoint: post /customers
@@ -131,15 +135,14 @@ resources:
         endpoint: patch /customers/{customerId}
         body_param_name: UpdateCustomerRequest
       delete: delete /customers/{customerId}
-      create_kyc_link:
-        endpoint: post /customers/{customerId}/kyc-link
-        body_param_name: KycLinkCreateRequest
       list_internal_accounts: get /customers/internal-accounts
       export: post /internal-accounts/{id}/export
-      generate_kyc_link: post /customers/{customerId}/kyc-link
       update_internal_account:
         endpoint: patch /internal-accounts/{id}
         body_param_name: InternalAccountUpdateRequest
+      create_kyc_link:
+        endpoint: post /customers/{customerId}/kyc-link
+        body_param_name: KycLinkCreateRequest
     # Subresources define resources that are nested within another for more powerful
     # logical groupings, e.g. `cards.payments`.
     subresources:
@@ -208,6 +211,8 @@ resources:
           business_beneficiary: "#/components/schemas/BusinessBeneficiary"
           address: "#/components/schemas/Address"
           beneficiary_verified_data: "#/components/schemas/BeneficiaryVerifiedData"
+          # List response
+          external_account_list_response: "#/components/schemas/ExternalAccountListResponse"
         methods:
           list: get /customers/external-accounts
           create: post /customers/external-accounts
@@ -219,6 +224,8 @@ resources:
           get_job_status: get /customers/bulk/jobs/{jobId}
 
   platform:
+    models:
+      platform_internal_account_list_response: '#/components/schemas/PlatformInternalAccountListResponse'
     methods:
       list_internal_accounts:
         endpoint: get /platform/internal-accounts
@@ -231,6 +238,7 @@ resources:
           retrieve: get /platform/external-accounts/{externalAccountId}
           delete: delete /platform/external-accounts/{externalAccountId}
         models:
+          platform_external_account_create_request: "#/components/schemas/PlatformExternalAccountCreateRequest"
           aed_account_info: "#/components/schemas/AedAccountInfo"
           bdt_account_info: "#/components/schemas/BdtAccountInfo"
           brl_account_info: "#/components/schemas/BrlAccountInfo"
@@ -266,11 +274,11 @@ resources:
           xof_account_info: "#/components/schemas/XofAccountInfo"
           zar_account_info: "#/components/schemas/ZarAccountInfo"
           zmw_account_info: "#/components/schemas/ZmwAccountInfo"
-          # base_external_account_info: "#/components/schemas/BaseExternalAccountInfo"
 
   transfer_in:
     models:
       transaction: "#/components/schemas/TransactionOneOf"
+      transfer_in_request: "#/components/schemas/TransferInRequest"
       base_transaction_destination: "#/components/schemas/BaseTransactionDestination"
       external_account_reference: "#/components/schemas/ExternalAccountReference"
       internal_account_reference: "#/components/schemas/InternalAccountReference"
@@ -278,6 +286,8 @@ resources:
       create: post /transfer-in
 
   transfer_out:
+    models:
+      transfer_out_request: "#/components/schemas/TransferOutRequest"
     methods:
       create: post /transfer-out
 
@@ -285,6 +295,9 @@ resources:
     models:
       counterparty_field_definition: '#/components/schemas/CounterpartyFieldDefinition'
       lookup_response: '#/components/schemas/ReceiverLookupResponse'
+      # Concrete responses returned by the two lookup endpoints
+      uma_lookup_response: '#/components/schemas/ReceiverUmaLookupResponse'
+      external_account_lookup_response: '#/components/schemas/ReceiverExternalAccountLookupResponse'
     methods:
       lookup_uma: get /receiver/uma/{receiverUmaAddress}
       lookup_external_account: get /receiver/external-account/{accountId}
@@ -296,10 +309,10 @@ resources:
       outgoing_rate_details: '#/components/schemas/OutgoingRateDetails'
       quote: '#/components/schemas/Quote'
       quote_destination_one_of: "#/components/schemas/QuoteDestinationOneOf"
-      # base_payment_account_info: "#/components/schemas/BasePaymentAccountInfo"
       base_quote_source: "#/components/schemas/BaseQuoteSource"
       quote_source_one_of: "#/components/schemas/QuoteSourceOneOf"
       base_destination: "#/components/schemas/BaseDestination"
+      quote_request: "#/components/schemas/QuoteRequest"
     methods:
       retrieve: get /quotes/{quoteId}
       create: post /quotes
@@ -316,6 +329,7 @@ resources:
       transaction_source_one_of: "#/components/schemas/TransactionSourceOneOf"
       incoming_rate_details: "#/components/schemas/IncomingRateDetails"
       reconciliation_instructions: "#/components/schemas/ReconciliationInstructions"
+      transaction_list_response: "#/components/schemas/TransactionListResponse"
     methods:
       list: get /transactions
       retrieve: get /transactions/{transactionId}
@@ -326,6 +340,8 @@ resources:
     models:
       currency_amount: '#/components/schemas/CurrencyAmount'
       uma_invitation: '#/components/schemas/UmaInvitation'
+      uma_invitation_create_request: '#/components/schemas/UmaInvitationCreateRequest'
+      uma_invitation_claim_request: '#/components/schemas/UmaInvitationClaimRequest'
     methods:
       create: post /invitations
       retrieve: get /invitations/{invitationCode}
@@ -333,18 +349,26 @@ resources:
       cancel: post /invitations/{invitationCode}/cancel
 
   sandbox:
+    models:
+      send_request: '#/components/schemas/SandboxSendRequest'
     methods:
       send_funds: post /sandbox/send
     subresources:
       uma:
+        models:
+          receive_request: '#/components/schemas/SandboxUmaReceiveRequest'
         methods:
           receive_payment: post /sandbox/uma/receive
       internal_accounts:
         models:
           internal_account: '#/components/schemas/InternalAccount'
+          fund_request: '#/components/schemas/SandboxFundRequest'
         methods:
           fund: post /sandbox/internal-accounts/{accountId}/fund
       webhooks:
+        models:
+          test_webhook_request: '#/components/schemas/TestWebhookRequest'
+          test_webhook_response: '#/components/schemas/TestWebhookResponse'
         methods:
           send_test: post /sandbox/webhooks/test
       cards:
@@ -359,8 +383,15 @@ resources:
               card_pull_summary: "#/components/schemas/CardPullSummary"
               card_refund_summary: "#/components/schemas/CardRefundSummary"
               card_settlement_summary: "#/components/schemas/CardSettlementSummary"
+              authorization_request: "#/components/schemas/SandboxCardAuthorizationRequest"
+              clearing_request: "#/components/schemas/SandboxCardClearingRequest"
+              refund_request: "#/components/schemas/SandboxCardReturnRequest"
+              refund: "#/components/schemas/Refund"
 
   uma_providers:
+    models:
+      uma_provider: '#/components/schemas/UmaProvider'
+      uma_provider_list_response: '#/components/schemas/UmaProviderListResponse'
     methods:
       list: get /uma-providers
 
@@ -368,12 +399,17 @@ resources:
     models:
       permission: '#/components/schemas/Permission'
       api_token: '#/components/schemas/ApiToken'
+      api_token_create_request: '#/components/schemas/ApiTokenCreateRequest'
+      token_list_response: '#/components/schemas/TokenListResponse'
     methods:
       create: post /tokens
       list: get /tokens
       retrieve: get /tokens/{tokenId}
       delete: delete /tokens/{tokenId}
   exchange_rates:
+    models:
+      exchange_rate: '#/components/schemas/ExchangeRate'
+      exchange_rate_list_response: '#/components/schemas/ExchangeRateListResponse'
     methods:
       list:
         endpoint: get /exchange-rates
@@ -383,6 +419,7 @@ resources:
     methods:
       unwrap:
         type: webhook_unwrap
+        discriminator: type
 
   $shared:
     models:
@@ -449,8 +486,15 @@ resources:
       agent_transfer_details: "#/components/schemas/AgentTransferDetails"
       slv_external_account_create_info: "#/components/schemas/SlvExternalAccountCreateInfo"
       slv_beneficiary: "#/components/schemas/SlvBeneficiary"
+      individual_customer: "#/components/schemas/IndividualCustomer"
+      business_customer: "#/components/schemas/BusinessCustomer"
+      beneficial_owner: "#/components/schemas/BeneficialOwner"
       swift_external_account_create_info: "#/components/schemas/SwiftExternalAccountCreateInfo"
+      swift_beneficiary: "#/components/schemas/SwiftBeneficiary"
   crypto:
+    models:
+      estimate_crypto_withdrawal_fee_request: '#/components/schemas/EstimateCryptoWithdrawalFeeRequest'
+      estimate_crypto_withdrawal_fee_response: '#/components/schemas/EstimateCryptoWithdrawalFeeResponse'
     methods:
       estimate_withdrawal_fee: post /crypto/estimate-withdrawal-fee
   beneficial_owners:
@@ -461,19 +505,35 @@ resources:
       update: patch /beneficial-owners/{beneficialOwnerId}
     models:
       beneficial_owner_personal_info: "#/components/schemas/BeneficialOwnerPersonalInfo"
+      beneficial_owner_create_request: "#/components/schemas/BeneficialOwnerCreateRequest"
+      beneficial_owner_update_request: "#/components/schemas/BeneficialOwnerUpdateRequest"
+      beneficial_owner_list_response: "#/components/schemas/BeneficialOwnerListResponse"
   documents:
+    models:
+      document: '#/components/schemas/Document'
+      document_list_response: '#/components/schemas/DocumentListResponse'
     methods:
-      upload: post /documents
+      upload:
+        endpoint: post /documents
+        body_param_name: DocumentUploadRequest
       list: get /documents
       retrieve: get /documents/{documentId}
-      replace: put /documents/{documentId}
+      replace:
+        endpoint: put /documents/{documentId}
+        body_param_name: DocumentReplaceRequest
       delete: delete /documents/{documentId}
   verifications:
+    models:
+      verification: '#/components/schemas/Verification'
+      verification_list_response: '#/components/schemas/VerificationListResponse'
+      verification_request: '#/components/schemas/VerificationRequest'
     methods:
       submit: post /verifications
       list: get /verifications
       retrieve: get /verifications/{verificationId}
   discoveries:
+    models:
+      discovery_list_response: '#/components/schemas/DiscoveryListResponse'
     methods:
       list:
         endpoint: get /discoveries
@@ -496,6 +556,7 @@ resources:
         models:
           auth_method_type: '#/components/schemas/AuthMethodType'
           auth_method: '#/components/schemas/AuthMethod'
+          auth_session: '#/components/schemas/AuthSession'
           auth_credential_list_response: '#/components/schemas/AuthCredentialListResponse'
           auth_credential_create_request: '#/components/schemas/AuthCredentialCreateRequest'
           auth_credential_verify_request: '#/components/schemas/AuthCredentialVerifyRequest'
@@ -503,19 +564,17 @@ resources:
           auth_credential_verify_request_one_of: '#/components/schemas/AuthCredentialVerifyRequestOneOf'
           auth_signed_request_challenge: '#/components/schemas/AuthSignedRequestChallenge'
           email_otp_credential_create_request: '#/components/schemas/EmailOtpCredentialCreateRequest'
-          email_otp_credential_create_request_fields: '#/components/schemas/EmailOtpCredentialCreateRequestFields'
-          email_otp_credential_verify_request_fields: '#/components/schemas/EmailOtpCredentialVerifyRequestFields'
+          email_otp_credential_verify_request: '#/components/schemas/EmailOtpCredentialVerifyRequest'
           oauth_credential_create_request: '#/components/schemas/OauthCredentialCreateRequest'
-          oauth_credential_create_request_fields: '#/components/schemas/OauthCredentialCreateRequestFields'
-          oauth_credential_verify_request_fields: '#/components/schemas/OauthCredentialVerifyRequestFields'
+          oauth_credential_verify_request: '#/components/schemas/OauthCredentialVerifyRequest'
+          auth_credential_challenge_request: '#/components/schemas/AuthCredentialChallengeRequest'
           passkey_attestation: '#/components/schemas/PasskeyAttestation'
           passkey_assertion: '#/components/schemas/PasskeyAssertion'
           passkey_credential_create_request: '#/components/schemas/PasskeyCredentialCreateRequest'
-          passkey_credential_create_request_fields: '#/components/schemas/PasskeyCredentialCreateRequestFields'
+          passkey_credential_verify_request: '#/components/schemas/PasskeyCredentialVerifyRequest'
           passkey_auth_challenge: '#/components/schemas/PasskeyAuthChallenge'
           auth_method_response: '#/components/schemas/AuthMethodResponse'
           auth_credential_response_one_of: '#/components/schemas/AuthCredentialResponseOneOf'
-          passkey_credential_verify_request_fields: '#/components/schemas/PasskeyCredentialVerifyRequestFields'
           signed_request_challenge: "#/components/schemas/SignedRequestChallenge"
       sessions:
         methods:
@@ -529,7 +588,7 @@ resources:
         models:
           session_list_response: '#/components/schemas/SessionListResponse'
           auth_session_refresh_request: '#/components/schemas/AuthSessionRefreshRequest'
-          auth_session: '#/components/schemas/AuthSession'
+
   agents:
     methods:
       create: post /agents
@@ -594,8 +653,16 @@ resources:
       agent_policy: "#/components/schemas/AgentPolicy"
       agent_usage: "#/components/schemas/AgentUsage"
       agent_account_restrictions: "#/components/schemas/AgentAccountRestrictions"
+      agent_account_rule: "#/components/schemas/AgentAccountRule"
       agent_approval_thresholds: "#/components/schemas/AgentApprovalThresholds"
+      agent_policy_update_request: "#/components/schemas/AgentPolicyUpdateRequest"
   cards:
+    models:
+      card: "#/components/schemas/Card"
+      card_list_response: "#/components/schemas/CardListResponse"
+      card_create_request: "#/components/schemas/CardCreateRequest"
+      card_update_request: "#/components/schemas/CardUpdateRequest"
+      card_transaction: "#/components/schemas/CardTransaction"
     methods:
       issue: post /cards
       list: get /cards
@@ -719,86 +786,6 @@ pagination:
 openapi:
   code_samples: mintlify
   transforms:
-    # # ── customerType: IndividualCustomerFields / BusinessCustomerFields ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline customerType enums from customer fields schemas to avoid
-    #     conflicting types when allOf merges them with base schemas (Customer,
-    #     CustomerCreateRequest, CustomerUpdateRequest) that define customerType
-    #     via the shared CustomerType $ref
-    #   args:
-    #     target:
-    #       - "$.components.schemas.IndividualCustomerFields.properties"
-    #       - "$.components.schemas.BusinessCustomerFields.properties"
-    #     keys: [ "customerType" ]
-
-    # # ── accountType: common account info schemas ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline accountType enums from common account info schemas to
-    #     avoid conflicting types when allOf merges them with
-    #     BaseExternalAccountInfo or BasePaymentAccountInfo, which define
-    #     accountType via shared $ref enums
-    #   args:
-    #     target:
-    #       - "$.components.schemas.UsAccountInfo.properties"
-    #       - "$.components.schemas.ClabeAccountInfo.properties"
-    #       - "$.components.schemas.PixAccountInfo.properties"
-    #       - "$.components.schemas.IbanAccountInfo.properties"
-    #       - "$.components.schemas.UpiAccountInfo.properties"
-    #       - "$.components.schemas.NgnAccountInfo.properties"
-    #       - "$.components.schemas.CadAccountInfo.properties"
-    #       - "$.components.schemas.GbpAccountInfo.properties"
-    #       - "$.components.schemas.PhpAccountInfo.properties"
-    #       - "$.components.schemas.SgdAccountInfo.properties"
-    #       - "$.components.schemas.SparkWalletInfo.properties"
-    #       - "$.components.schemas.LightningInfo.properties"
-    #       - "$.components.schemas.SolanaWalletInfo.properties"
-    #       - "$.components.schemas.TronWalletInfo.properties"
-    #       - "$.components.schemas.PolygonWalletInfo.properties"
-    #       - "$.components.schemas.BaseWalletInfo.properties"
-    #     keys: [ "accountType" ]
-
-    # # ── sourceType: transaction and quote source schemas ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline sourceType enums from transaction and quote source
-    #     allOf variants to avoid conflicting types with their base schemas
-    #     which define sourceType via shared $ref enums
-    #   args:
-    #     target:
-    #       - "$.components.schemas.AccountTransactionSource.allOf[1].properties"
-    #       - "$.components.schemas.UmaAddressTransactionSource.allOf[1].properties"
-    #       - "$.components.schemas.AccountQuoteSource.allOf[1].properties"
-    #       - "$.components.schemas.RealtimeFundingQuoteSource.allOf[1].properties"
-    #     keys: [ "sourceType" ]
-
-    # # ── destinationType: transaction and quote destination schemas ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline destinationType enums from transaction and quote
-    #     destination allOf variants to avoid conflicting types with their
-    #     base schemas which define destinationType via shared $ref enums
-    #   args:
-    #     target:
-    #       - "$.components.schemas.AccountTransactionDestination.allOf[1].properties"
-    #       - "$.components.schemas.UmaAddressTransactionDestination.allOf[1].properties"
-    #       - "$.components.schemas.AccountDestination.allOf[1].properties"
-    #       - "$.components.schemas.UmaAddressDestination.allOf[1].properties"
-    #       - "$.components.schemas.ExternalAccountDetailsDestination.allOf[1].properties"
-    #     keys: [ "destinationType" ]
-
-    # # ── beneficiaryType: beneficiary schemas ──
-    # - command: remove
-    #   reason: >-
-    #     Remove inline beneficiaryType enums from beneficiary allOf variants
-    #     to avoid conflicting types with BaseBeneficiary which defines
-    #     beneficiaryType via a shared $ref enum
-    #   args:
-    #     target:
-    #       - "$.components.schemas.IndividualBeneficiary.allOf[1].properties"
-    #       - "$.components.schemas.BusinessBeneficiary.allOf[1].properties"
-    #     keys: [ "beneficiaryType" ]
     # ── customerType: remove from base schemas ──
     - command: remove
       reason: >-
@@ -970,7 +957,6 @@ openapi:
         target:
           - "$.components.schemas.AccountDestination.allOf[0]"
           - "$.components.schemas.UmaAddressDestination.allOf[0]"
-          - "$.components.schemas.ExternalAccountDetailsDestination.allOf[0]"
         keys: [ "$ref" ]
 
     # ── Remove $ref to BaseTransactionSource from transaction source variants ──
@@ -994,7 +980,6 @@ openapi:
         target:
           - "$.components.schemas.AccountTransactionDestination.allOf[0]"
           - "$.components.schemas.UmaAddressTransactionDestination.allOf[0]"
-          - "$.components.schemas.ExternalAccountDetailsTransactionDestination.allOf[0]"
         keys: [ "$ref" ]
 
     # ── type: auth credential base schemas ──
@@ -1023,6 +1008,27 @@ openapi:
           - "$.components.schemas.OauthCredentialVerifyRequest.allOf[0]"
           - "$.components.schemas.PasskeyCredentialVerifyRequest.allOf[0]"
         keys: [ "$ref" ]
+
+    # ── type: remove from BaseWebhook ──
+    - command: remove
+      reason: >-
+        Remove the wide WebhookType $ref from BaseWebhook so the inline
+        single-value enums on each child webhook (e.g. CardStateChangeWebhook,
+        CardFundingSourceChangeWebhook) become the sole definition. Without
+        this, every generated *WebhookEvent has the full WebhookType enum on
+        its `type` field, so the UnwrapWebhookEvent deserializer can't
+        discriminate between variants that share a `data` shape (Card) and
+        picks the first one declared.
+
+        Only `properties.type` is stripped — `keys` requires an object target,
+        and `required` is an array. Leaving `type` in `BaseWebhook.required` is
+        harmless: each child webhook re-declares `type` via its own inline enum,
+        and the standalone-base `Schema/RequiredPropertyNotDefined` diagnostic is
+        ignored below.
+      args:
+        target:
+          - "$.components.schemas.BaseWebhook.properties"
+        keys: [ "type" ]
 
 codeflow:
   detect_breaking_changes: true


### PR DESCRIPTION
## Summary

Bumps the Stainless edition and syncs several resource definitions to match the current API surface and codegen needs.

### Edition
- Bump root `edition: 2025-10-10` → `2026-05-06`.
- Drop the now-redundant pinned `kotlin.2025-10-08` edition; the new root edition covers it.

### Webhook discrimination
- `webhooks.unwrap`: add `discriminator: type` so the unwrap codegen dispatches on the payload's `type` field.
- New `openapi.transforms` entry: strip `type` from `BaseWebhook.properties` *and* `BaseWebhook.required`. Without this, every generated `*WebhookEvent` carries the full `WebhookType` enum on its `type` field via `BaseWebhook`, defeating the discriminator — variants that share the same `data` shape (e.g. multiple Card-related webhooks) become indistinguishable and the deserializer picks the first one declared. Same pattern already applied to customer / account / source / destination / auth base schemas in this file.

### Card refund (Kotlin keyword fix carry-over)
- Keep `refund: post /sandbox/cards/{id}/simulate/return` (the method key was renamed from `return` in #520 to avoid the Kotlin reserved keyword; preserved here through the edition bump).

### Resource cleanup — `customers`
- Drop the `customers.models` block. Customer / kyc / internal-account types are now exposed via `$shared.models` and resource subresources directly.
- Drop the standalone `create_kyc_link` method definition; the API surface is covered by `generate_kyc_link` (renamed earlier in #518).
- Simplify `update_internal_account` to the short form (the `body_param_name` was redundant).

### Resource cleanup — `auth`
- Move `auth_session` model alias from `sessions` → `credentials` (the canonical location for credential-related types).
- Drop the per-variant `*CredentialCreateRequest` / `*CredentialVerifyRequest` model aliases (`email_otp_*`, `oauth_*`, `passkey_*`) for the verify side. Stainless collapses these schemas to their `Fields` siblings after the existing `type`-strip transforms; exposing the wrapper aliases generated broken imports in the TS SDK (`TS2724` / `TS2552`). See #518 for the original diagnosis.
- Drop `auth_session_refresh_request` and the explicit `body_param_name` on `sessions.refresh`; covered by the new edition's defaults.

### New `$shared` models
Surface a few schemas that consumers need to reference directly:
- `individual_customer`, `business_customer`, `beneficial_owner`, `business_info_update`, `swift_beneficiary`

### `agents`
- Add `agent_account_rule` model alias.

## Stack

Stacked on top of #521.