### PR TITLE
fix(cards): use anyOf for nullable Card.stateReason

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -18096,7 +18096,7 @@ components:
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
-          oneOf:
+          anyOf:
             - $ref: '#/components/schemas/CardStateReason'
             - type: 'null'
           description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18096,7 +18096,7 @@ components:
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
-          oneOf:
+          anyOf:
             - $ref: '#/components/schemas/CardStateReason'
             - type: 'null'
           description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -26,7 +26,7 @@ properties:
   state:
     $ref: ./CardState.yaml
   stateReason:
-    oneOf:
+    anyOf:
       - $ref: ./CardStateReason.yaml
       - type: 'null'
     description: >-


### PR DESCRIPTION
The stateReason oneOf is a nullability wrapper (CardStateReason enum or
null), not a discriminated union, so it can't carry a discriminator.
Switch to anyOf, the standard OpenAPI 3.1 idiom for nullable refs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>