### PR TITLE
docs: escape quote currency values

### DIFF
--- a/mintlify/platform-overview/core-concepts/quote-system.mdx
+++ b/mintlify/platform-overview/core-concepts/quote-system.mdx
@@ -102,7 +102,7 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/quotes \
 }
 ```
 
-This quote says: Send $1,000 USD, recipient receives 0.00829167 BTC, fees are $5.00, expires in 5 minutes.
+This quote says: Send \$1,000 USD, recipient receives 0.00829167 BTC, fees are \$5.00, expires in 5 minutes.
 
 ### Locked Currency Side
 


### PR DESCRIPTION
Current docs formatting on this line is messed up: ![Screenshot 2026-05-28 at 3.06.32 PM.png](https://app.graphite.com/user-attachments/assets/232fac0c-1108-423c-8915-b6111e70ea38.png)

Now it looks like:  
![Screenshot 2026-05-28 at 3.07.21 PM.png](https://app.graphite.com/user-attachments/assets/8355fba1-91eb-4577-b1ae-fc3b263c6f8d.png)

