### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 59 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 60 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="59 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="60 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -33,6 +33,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇫🇮 Finland | FI | `SEPA` `SEPA Instant` |
 | 🇫🇷 France | FR | `SEPA` `SEPA Instant` |
 | 🇩🇪 Germany | DE | `SEPA` `SEPA Instant` |
+| 🇬🇭 Ghana | GH | `Bank Transfer` |
 | 🇬🇷 Greece | GR | `SEPA` `SEPA Instant` |
 | 🇭🇹 Haiti | HT | `Bank Transfer` |
 | 🇭🇺 Hungary | HU | `SEPA` `SEPA Instant` |
@@ -83,7 +84,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="32 countries">
     Primary: SEPA/SEPA Instant
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="13 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="14 countries">
     Primary: Bank Transfer
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="9 countries">


### PR DESCRIPTION
## Summary
- Add Ghana (GH) to the Live country list — sent via Thunes (`Bank Transfer`). Live count goes from 59 → 60.
- Update the Middle East and Africa regional summary count from 13 → 14.
- Coming Soon list (Canada, China, Hong Kong, South Korea) is unchanged.

Source of truth: [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) — rows with Status = Live.

## Test plan
- [ ] Render `mintlify/snippets/country-support.mdx` locally and confirm header counts (60), the new Ghana row sits between Germany and Greece alphabetically, and the regional cards sum to 60 (32 + 14 + 9 + 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)