### PR TITLE
feat(transfers): allow selecting payment rail on transfer-out destination

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2143,6 +2143,7 @@ paths:
                     accountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
                   destination:
                     accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    paymentRail: ACH
                   amount: 12550
       responses:
         '201':
@@ -16123,6 +16124,19 @@ components:
         mapping:
           INCOMING: '#/components/schemas/IncomingTransaction'
           OUTGOING: '#/components/schemas/OutgoingTransaction'
+    ExternalAccountDestinationReference:
+      type: object
+      required:
+        - accountId
+      properties:
+        accountId:
+          type: string
+          description: Reference to an external account ID
+          example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+        paymentRail:
+          description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
     TransferOutRequest:
       type: object
       required:
@@ -16133,7 +16147,7 @@ components:
           $ref: '#/components/schemas/InternalAccountReference'
           description: Source internal account details
         destination:
-          $ref: '#/components/schemas/ExternalAccountReference'
+          $ref: '#/components/schemas/ExternalAccountDestinationReference'
           description: Destination external account details
         amount:
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2143,6 +2143,7 @@ paths:
                     accountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
                   destination:
                     accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                    paymentRail: ACH
                   amount: 12550
       responses:
         '201':
@@ -16123,6 +16124,19 @@ components:
         mapping:
           INCOMING: '#/components/schemas/IncomingTransaction'
           OUTGOING: '#/components/schemas/OutgoingTransaction'
+    ExternalAccountDestinationReference:
+      type: object
+      required:
+        - accountId
+      properties:
+        accountId:
+          type: string
+          description: Reference to an external account ID
+          example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+        paymentRail:
+          description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
     TransferOutRequest:
       type: object
       required:
@@ -16133,7 +16147,7 @@ components:
           $ref: '#/components/schemas/InternalAccountReference'
           description: Source internal account details
         destination:
-          $ref: '#/components/schemas/ExternalAccountReference'
+          $ref: '#/components/schemas/ExternalAccountDestinationReference'
           description: Destination external account details
         amount:
           type: integer

--- a/openapi/components/schemas/transfers/ExternalAccountDestinationReference.yaml
+++ b/openapi/components/schemas/transfers/ExternalAccountDestinationReference.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - accountId
+properties:
+  accountId:
+    type: string
+    description: Reference to an external account ID
+    example: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+  paymentRail:
+    description: >-
+      The payment rail to use for the transfer. Must be one of the rails
+      supported by the destination account. If not specified, the system
+      will select a default rail.
+    allOf:
+      - $ref: ../common/PaymentRail.yaml

--- a/openapi/components/schemas/transfers/TransferOutRequest.yaml
+++ b/openapi/components/schemas/transfers/TransferOutRequest.yaml
@@ -7,7 +7,7 @@ properties:
     $ref: ./InternalAccountReference.yaml
     description: Source internal account details
   destination:
-    $ref: ./ExternalAccountReference.yaml
+    $ref: ./ExternalAccountDestinationReference.yaml
     description: Destination external account details
   amount:
     type: integer

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -31,6 +31,7 @@ post:
                 accountId: InternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123
               destination:
                 accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
+                paymentRail: ACH
               amount: 12550
   responses:
     '201':


### PR DESCRIPTION
## What

Adds an optional `paymentRail` field to the **transfer-out destination**, mirroring the rail selection already available on quote destinations.

## Changes

- **New** `TransferOutDestination` schema (`accountId` + optional `paymentRail`) — used only by transfer-out, so the shared `ExternalAccountReference` (transfer-in source) is left unchanged.
- `TransferOutRequest.destination` now references the new schema.
- `paymentRail` reuses the common `PaymentRail` enum (ACH, SEPA, PIX, WIRE, …); when omitted, the system selects a default rail.
- Added `paymentRail: ACH` to the transfer-out request example.
- Rebundled `openapi.yaml` + `mintlify/openapi.yaml`.

## Verification

- `make build` + `make lint` pass with **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)