### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 60 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 62 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="60 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="62 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -30,6 +30,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇨🇾 Cyprus | CY | `SEPA` `SEPA Instant` |
 | 🇨🇿 Czech Republic | CZ | `SEPA` `SEPA Instant` |
 | 🇩🇰 Denmark | DK | `SEPA` `SEPA Instant` |
+| 🇪🇬 Egypt | EG | `Bank Transfer` |
 | 🇪🇪 Estonia | EE | `SEPA` `SEPA Instant` |
 | 🇫🇮 Finland | FI | `SEPA` `SEPA Instant` |
 | 🇫🇷 France | FR | `SEPA` `SEPA Instant` |
@@ -85,7 +86,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="32 countries">
     Primary: SEPA/SEPA Instant
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="14 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="15 countries">
     Primary: Bank Transfer
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="10 countries">


### PR DESCRIPTION
## Summary

Sync `mintlify/snippets/country-support.mdx` with the [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) source of truth (tab: *Grid Switch Corridor List*).

- Add **Egypt (EG)** as a Live destination — newly live via Thunes (`Bank Transfer`).
- Bump headline count: **60 → 62** countries (header `FeatureCard` tags + "Send payments to N countries" copy). The published table actually listed 61 rows while the copy still said 60; this brings copy, tag, table, and regional totals into agreement.
- Bump Middle East & Africa regional count: **14 → 15** (Egypt). Totals reconcile: 32 (Europe) + 15 (MEA) + 10 (Asia-Pacific) + 5 (Americas) = **62**.
- Coming Soon (Canada, Hong Kong, South Korea) unchanged.

### Live derivation
Live destinations = rows with Status = "Live" (column J), deduped on ISO code. **China (CN) stays a Live destination**: it has a Live corridor (Thunes) as well as a Scoping row with Public Roadmap = Yes (Tazapay), and the dedupe rule prefers the Live row — so China remains in the main table and is **not** listed under Coming Soon. Egypt was the only net-new Live destination vs. the current published table.

## Test plan

- [ ] `make lint-markdown` (no OpenAPI changes, no rebundle needed)
- [ ] Spot check the rendered snippet in `mint dev`