### PR TITLE
feat(transfers): add remittanceInformation to transfer-out request

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2145,6 +2145,7 @@ paths:
                     accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
                     paymentRail: ACH
                   amount: 12550
+                  remittanceInformation: '12345'
       responses:
         '201':
           description: Transfer-out request created successfully
@@ -16213,6 +16214,11 @@ components:
           format: int64
           description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
           example: 12550
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
     CurrencyPreference:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2145,6 +2145,7 @@ paths:
                     accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
                     paymentRail: ACH
                   amount: 12550
+                  remittanceInformation: '12345'
       responses:
         '201':
           description: Transfer-out request created successfully
@@ -16213,6 +16214,11 @@ components:
           format: int64
           description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
           example: 12550
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
     CurrencyPreference:
       type: object
       required:

--- a/openapi/components/schemas/transfers/TransferOutRequest.yaml
+++ b/openapi/components/schemas/transfers/TransferOutRequest.yaml
@@ -16,3 +16,13 @@ properties:
       Amount in the smallest unit of the currency (e.g., cents for USD/EUR,
       satoshis for BTC)
     example: 12550
+  remittanceInformation:
+    type: string
+    maxLength: 80
+    description: >-
+      Free-form information about the payment that travels with it to the
+      recipient. The field this populates depends on the payment rail: for ACH
+      it populates the Addenda record, for FedNow and RTP it populates the
+      remittanceInformation field, and for wires it populates the OBI
+      (Originator to Beneficiary Information) / beneficiary information.
+    example: '12345'

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -33,6 +33,7 @@ post:
                 accountId: ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965
                 paymentRail: ACH
               amount: 12550
+              remittanceInformation: '12345'
   responses:
     '201':
       description: Transfer-out request created successfully


### PR DESCRIPTION
## Summary

Adds an optional `remittanceInformation` field to the transfer-out request body (`POST /transfers/transfer-out`).

The field that this value populates depends on the payment rail:
- **ACH** → Addenda record
- **FedNow / RTP** → `remittanceInformation` field
- **Wires** → OBI (Originator to Beneficiary Information) / beneficiary information

## Changes

- Added `remittanceInformation` (string, optional) to `TransferOutRequest.yaml` with a rail-specific description
- Added the field to the request example in `transfer_out.yaml`
- Rebundled `openapi.yaml` and `mintlify/openapi.yaml` via `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)