### PR TITLE
Add receipt delivery confirmation endpoint

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2771,6 +2771,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /transactions/{transactionId}/confirm:
+    post:
+      summary: Confirm receipt delivery
+      description: |
+        Confirm that the platform delivered the transaction receipt to its customer. This confirmation is only necessary when the platform is contractually required to send a receipt. If `receiptDeliveryConfirmedAt` is omitted, the confirmation time is set to the current server time. Calling this endpoint again for the same transaction updates the stored confirmation time.
+      operationId: confirmReceiptDelivery
+      tags:
+        - Transactions
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: transactionId
+          in: path
+          description: Unique identifier of the transaction to confirm receipt delivery for
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmReceiptDeliveryRequest'
+      responses:
+        '200':
+          description: Receipt delivery confirmation recorded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionOneOf'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/approve:
     post:
       summary: Approve a pending incoming payment
@@ -15744,6 +15798,11 @@ components:
           format: date-time
           description: When the transaction was last updated
           example: '2025-08-15T14:30:00Z'
+        receiptDeliveryConfirmedAt:
+          type: string
+          format: date-time
+          description: The time at which the platform confirmed delivery of the receipt to their customer.
+          example: '2025-08-15T14:31:00Z'
         agentId:
           type: string
           description: If this transaction was initiated by an agent, the system-generated ID of that agent. Absent for platform-initiated transactions.
@@ -16583,6 +16642,14 @@ components:
         totalCount:
           type: integer
           description: Total number of transactions matching the criteria (excluding pagination)
+    ConfirmReceiptDeliveryRequest:
+      type: object
+      properties:
+        receiptDeliveryConfirmedAt:
+          type: string
+          format: date-time
+          description: The time at which the platform delivered the transaction receipt to their customer. If omitted, the current server time is used.
+          example: '2025-08-15T14:31:00Z'
     ApprovePaymentRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2771,6 +2771,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /transactions/{transactionId}/confirm:
+    post:
+      summary: Confirm receipt delivery
+      description: |
+        Confirm that the platform delivered the transaction receipt to its customer. This confirmation is only necessary when the platform is contractually required to send a receipt. If `receiptDeliveryConfirmedAt` is omitted, the confirmation time is set to the current server time. Calling this endpoint again for the same transaction updates the stored confirmation time.
+      operationId: confirmReceiptDelivery
+      tags:
+        - Transactions
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: transactionId
+          in: path
+          description: Unique identifier of the transaction to confirm receipt delivery for
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmReceiptDeliveryRequest'
+      responses:
+        '200':
+          description: Receipt delivery confirmation recorded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionOneOf'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/approve:
     post:
       summary: Approve a pending incoming payment
@@ -15744,6 +15798,11 @@ components:
           format: date-time
           description: When the transaction was last updated
           example: '2025-08-15T14:30:00Z'
+        receiptDeliveryConfirmedAt:
+          type: string
+          format: date-time
+          description: The time at which the platform confirmed delivery of the receipt to their customer.
+          example: '2025-08-15T14:31:00Z'
         agentId:
           type: string
           description: If this transaction was initiated by an agent, the system-generated ID of that agent. Absent for platform-initiated transactions.
@@ -16583,6 +16642,14 @@ components:
         totalCount:
           type: integer
           description: Total number of transactions matching the criteria (excluding pagination)
+    ConfirmReceiptDeliveryRequest:
+      type: object
+      properties:
+        receiptDeliveryConfirmedAt:
+          type: string
+          format: date-time
+          description: The time at which the platform delivered the transaction receipt to their customer. If omitted, the current server time is used.
+          example: '2025-08-15T14:31:00Z'
     ApprovePaymentRequest:
       type: object
       properties:

--- a/openapi/components/schemas/transactions/ConfirmReceiptDeliveryRequest.yaml
+++ b/openapi/components/schemas/transactions/ConfirmReceiptDeliveryRequest.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  receiptDeliveryConfirmedAt:
+    type: string
+    format: date-time
+    description: >-
+      The time at which the platform delivered the transaction receipt to their
+      customer. If omitted, the current server time is used.
+    example: '2025-08-15T14:31:00Z'

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -42,6 +42,13 @@ properties:
     format: date-time
     description: When the transaction was last updated
     example: '2025-08-15T14:30:00Z'
+  receiptDeliveryConfirmedAt:
+    type: string
+    format: date-time
+    description: >-
+      The time at which the platform confirmed delivery of the receipt to their
+      customer.
+    example: '2025-08-15T14:31:00Z'
   agentId:
     type: string
     description: >-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -173,6 +173,8 @@ paths:
     $ref: paths/transactions/transactions.yaml
   /transactions/{transactionId}:
     $ref: paths/transactions/transactions_{transactionId}.yaml
+  /transactions/{transactionId}/confirm:
+    $ref: paths/transactions/transactions_{transactionId}_confirm.yaml
   /transactions/{transactionId}/approve:
     $ref: paths/transactions/transactions_{transactionId}_approve.yaml
   /transactions/{transactionId}/reject:

--- a/openapi/paths/transactions/transactions_{transactionId}_confirm.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_confirm.yaml
@@ -1,0 +1,58 @@
+post:
+  summary: Confirm receipt delivery
+  description: >
+    Confirm that the platform delivered the transaction receipt to its
+    customer. This confirmation is only necessary when the platform is
+    contractually required to send a receipt. If `receiptDeliveryConfirmedAt` is
+    omitted, the confirmation time is set to the current server time. Calling
+    this endpoint again for the same transaction updates the stored
+    confirmation time.
+  operationId: confirmReceiptDelivery
+  tags:
+    - Transactions
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: transactionId
+      in: path
+      description: Unique identifier of the transaction to confirm receipt delivery for
+      required: true
+      schema:
+        type: string
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/transactions/ConfirmReceiptDeliveryRequest.yaml
+  responses:
+    '200':
+      description: Receipt delivery confirmation recorded successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
+    '400':
+      description: Bad request - Invalid parameters
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Transaction not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
## Summary
- add POST /transactions/{transactionId}/confirm to confirm transaction receipt delivery
- allow an optional receiptDeliveryConfirmedAt timestamp, with server-time default handled by the implementation
- expose receiptDeliveryConfirmedAt on transaction responses
- return the updated TransactionOneOf from the confirm endpoint

## Test plan
- npm run lint