### PR TITLE
feat(quotes): add accountHolderName and bankAddress to bank payment instructions

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9606,6 +9606,13 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            accountHolderName:
+              type: string
+              description: The name of the account holder at the receiving bank
+              example: Jane Doe
+            bankAddress:
+              $ref: '#/components/schemas/Address'
+              description: The address of the receiving bank
     PaymentBrlAccountInfo:
       title: BRL Account
       allOf:
@@ -11816,6 +11823,13 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            accountHolderName:
+              type: string
+              description: The name of the account holder at the receiving bank
+              example: Jane Doe
+            bankAddress:
+              $ref: '#/components/schemas/Address'
+              description: The address of the receiving bank
     PaymentInstructions:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9606,6 +9606,13 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            accountHolderName:
+              type: string
+              description: The name of the account holder at the receiving bank
+              example: Jane Doe
+            bankAddress:
+              $ref: '#/components/schemas/Address'
+              description: The address of the receiving bank
     PaymentBrlAccountInfo:
       title: BRL Account
       allOf:
@@ -11816,6 +11823,13 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            accountHolderName:
+              type: string
+              description: The name of the account holder at the receiving bank
+              example: Jane Doe
+            bankAddress:
+              $ref: '#/components/schemas/Address'
+              description: The address of the receiving bank
     PaymentInstructions:
       type: object
       required:

--- a/openapi/components/schemas/common/PaymentSwiftAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentSwiftAccountInfo.yaml
@@ -11,3 +11,10 @@ allOf:
       description: Unique reference code that must be included with the payment to
         properly credit it
       example: UMA-Q12345-REF
+    accountHolderName:
+      type: string
+      description: The name of the account holder at the receiving bank
+      example: Jane Doe
+    bankAddress:
+      $ref: ./Address.yaml
+      description: The address of the receiving bank

--- a/openapi/components/schemas/common/PaymentUsdAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentUsdAccountInfo.yaml
@@ -12,3 +12,10 @@ allOf:
           Unique reference code that must be included with the payment to properly
           credit it
         example: UMA-Q12345-REF
+      accountHolderName:
+        type: string
+        description: The name of the account holder at the receiving bank
+        example: Jane Doe
+      bankAddress:
+        $ref: ./Address.yaml
+        description: The address of the receiving bank


### PR DESCRIPTION
## Summary

Adds two optional fields to the bank account payment instructions returned with a quote (`paymentInstructions[].accountOrWalletInfo`):

- **`accountHolderName`** (string) — the name of the account holder at the receiving bank
- **`bankAddress`** (object) — the address of the receiving bank, reusing the shared `Address` schema (line1, line2, city, state, postalCode, country)

## Scope

Applied to the **USD** (`USD_ACCOUNT`) and **SWIFT** (`SWIFT_ACCOUNT`) bank payment instruction types, where account-holder and bank-address details are most commonly needed (e.g. wires). Crypto wallet payment instruction types are unaffected.

Both fields are optional, so this is additive and non-breaking for existing response consumers.

## Changes

- `PaymentUsdAccountInfo.yaml` — added `accountHolderName` and `bankAddress`
- `PaymentSwiftAccountInfo.yaml` — added `accountHolderName` and `bankAddress`
- Rebundled `openapi.yaml` and `mintlify/openapi.yaml` via `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)