### PR TITLE
feat(transactions): add originator info to external funding source

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15869,7 +15869,7 @@ components:
               example: $sender@uma.domain.com
           description: UMA address source details
     RealtimeFundingTransactionSource:
-      title: Real-time Funding Source
+      title: External Funding Source
       allOf:
         - $ref: '#/components/schemas/BaseTransactionSource'
         - type: object
@@ -15889,7 +15889,39 @@ components:
               type: string
               description: Currency code for the funding source
               example: USDC
-          description: Transaction was funded using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
+            accountHolderName:
+              type: string
+              description: The name of the originator (sender) of the payment.
+              example: John Sender
+            accountIdentifier:
+              type: string
+              description: The originator's account number or IBAN. May be masked or partial depending on the rail.
+              example: '****6789'
+            bankName:
+              type: string
+              description: The name of the originating bank.
+              example: Chase Bank
+            bankIdentifier:
+              type: string
+              description: The identifier of the originating bank, such as a routing number, BIC, or SWIFT code.
+              example: '021000021'
+            paymentRail:
+              description: The payment rail the funds arrived on.
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
+            remittanceInformation:
+              type: string
+              description: 'Free-form information about the payment provided by the originator. The source field depends on the payment rail: the Addenda record for ACH, the OBI / beneficiary information for wires, and the remittanceInformation field for RTP and FedNow.'
+              example: '12345'
+            endToEndId:
+              type: string
+              description: The originator's own end-to-end reference for the payment.
+              example: E2E-9f2c6b6f
+            traceNumber:
+              type: string
+              description: Rail-level tracking identifier for the payment, such as an ACH trace number or a wire IMAD/OMAD, useful for reconciliation.
+              example: '021000020123456'
+          description: Transaction was funded using an external funding source. All originator fields are optional and populated on a best-effort basis depending on what the funding source provides.
     TransactionSourceOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountTransactionSource'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15869,7 +15869,7 @@ components:
               example: $sender@uma.domain.com
           description: UMA address source details
     RealtimeFundingTransactionSource:
-      title: Real-time Funding Source
+      title: External Funding Source
       allOf:
         - $ref: '#/components/schemas/BaseTransactionSource'
         - type: object
@@ -15889,7 +15889,39 @@ components:
               type: string
               description: Currency code for the funding source
               example: USDC
-          description: Transaction was funded using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).
+            accountHolderName:
+              type: string
+              description: The name of the originator (sender) of the payment.
+              example: John Sender
+            accountIdentifier:
+              type: string
+              description: The originator's account number or IBAN. May be masked or partial depending on the rail.
+              example: '****6789'
+            bankName:
+              type: string
+              description: The name of the originating bank.
+              example: Chase Bank
+            bankIdentifier:
+              type: string
+              description: The identifier of the originating bank, such as a routing number, BIC, or SWIFT code.
+              example: '021000021'
+            paymentRail:
+              description: The payment rail the funds arrived on.
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
+            remittanceInformation:
+              type: string
+              description: 'Free-form information about the payment provided by the originator. The source field depends on the payment rail: the Addenda record for ACH, the OBI / beneficiary information for wires, and the remittanceInformation field for RTP and FedNow.'
+              example: '12345'
+            endToEndId:
+              type: string
+              description: The originator's own end-to-end reference for the payment.
+              example: E2E-9f2c6b6f
+            traceNumber:
+              type: string
+              description: Rail-level tracking identifier for the payment, such as an ACH trace number or a wire IMAD/OMAD, useful for reconciliation.
+              example: '021000020123456'
+          description: Transaction was funded using an external funding source. All originator fields are optional and populated on a best-effort basis depending on what the funding source provides.
     TransactionSourceOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountTransactionSource'

--- a/openapi/components/schemas/transactions/RealtimeFundingTransactionSource.yaml
+++ b/openapi/components/schemas/transactions/RealtimeFundingTransactionSource.yaml
@@ -1,4 +1,4 @@
-title: Real-time Funding Source
+title: External Funding Source
 allOf:
   - $ref: ./BaseTransactionSource.yaml
   - type: object
@@ -18,6 +18,49 @@ allOf:
         type: string
         description: Currency code for the funding source
         example: USDC
+      accountHolderName:
+        type: string
+        description: The name of the originator (sender) of the payment.
+        example: John Sender
+      accountIdentifier:
+        type: string
+        description: >-
+          The originator's account number or IBAN. May be masked or partial
+          depending on the rail.
+        example: '****6789'
+      bankName:
+        type: string
+        description: The name of the originating bank.
+        example: Chase Bank
+      bankIdentifier:
+        type: string
+        description: >-
+          The identifier of the originating bank, such as a routing number, BIC,
+          or SWIFT code.
+        example: '021000021'
+      paymentRail:
+        description: The payment rail the funds arrived on.
+        allOf:
+          - $ref: ../common/PaymentRail.yaml
+      remittanceInformation:
+        type: string
+        description: >-
+          Free-form information about the payment provided by the originator.
+          The source field depends on the payment rail: the Addenda record for
+          ACH, the OBI / beneficiary information for wires, and the
+          remittanceInformation field for RTP and FedNow.
+        example: '12345'
+      endToEndId:
+        type: string
+        description: The originator's own end-to-end reference for the payment.
+        example: E2E-9f2c6b6f
+      traceNumber:
+        type: string
+        description: >-
+          Rail-level tracking identifier for the payment, such as an ACH trace
+          number or a wire IMAD/OMAD, useful for reconciliation.
+        example: '021000020123456'
     description: >-
-      Transaction was funded using a real-time funding source
-      (RTP, SEPA Instant, Spark, Stables, etc.).
+      Transaction was funded using an external funding source. All originator
+      fields are optional and populated on a best-effort basis depending on what
+      the funding source provides.


### PR DESCRIPTION
## Summary

Exposes structured **originator (sender) information** for externally-funded inbound (`INCOMING`) payments by generalizing the existing `REALTIME_FUNDING` transaction source into an **External Funding Source** and adding originator fields inline. Fields are modeled on ISO 20022 (pacs.008 / camt) debtor concepts, the shared vocabulary the underlying rails (ACH, wire, RTP, FedNow, Spark, Stables) map onto.

### Why on this source

- An external funding source only ever occurs on **inbound** payments (outgoing sources are the platform's internal accounts), so these fields are **isolated to inbound** — no leakage onto outgoing transactions.
- Transactions and quotes use **separate** source schemas, so the quote source is untouched.
- `REALTIME_FUNDING` already represents external funding across rails, so generalizing it (retitle + description) avoids an overlapping new source type.
- Inbound senders are frequently **unknown third parties** never registered as an external account, so there is **no `externalAccountId`** — originator details are carried inline.

## Changes to `RealtimeFundingTransactionSource`

- Retitled to **"External Funding Source"**; description updated to "Transaction was funded using an external funding source."
- `sourceType` discriminator value stays `REALTIME_FUNDING` (no enum/union change).
- New optional, best-effort originator fields (availability varies by rail):

| Field | Notes |
|---|---|
| `name` | Sender / debtor name |
| `accountIdentifier` | Sender account number or IBAN (often masked) |
| `bankName` | Originating bank name |
| `bankIdentifier` | Routing number / BIC / SWIFT of originating bank |
| `paymentRail` | Rail funds arrived on (reuses the existing `PaymentRail` enum) |
| `remittanceInformation` | Unified addenda (ACH) / OBI (wire) / remittance (RTP, FedNow) / description |
| `endToEndId` | Originator's own payment reference |
| `traceNumber` | ACH trace number / wire IMAD/OMAD, for reconciliation |

## Out of scope

- Originator postal address (deferred)
- `externalAccountId` (senders may be unregistered)
- Renaming the `REALTIME_FUNDING` discriminator value
- Outgoing transactions, quotes, and the shared destination union (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)