### PR TITLE
Add ID_TYPE and ID_NUMBER to CustomerInfoFieldName

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -7987,6 +7987,8 @@ components:
         - IDENTIFIER
         - BUSINESS_TYPE
         - COMPANY_LEGAL_NAME
+        - ID_TYPE
+        - ID_NUMBER
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7987,6 +7987,8 @@ components:
         - IDENTIFIER
         - BUSINESS_TYPE
         - COMPANY_LEGAL_NAME
+        - ID_TYPE
+        - ID_NUMBER
       description: Name of a type of field containing info about a platform's customer or counterparty customer.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
+++ b/openapi/components/schemas/customers/CustomerInfoFieldName.yaml
@@ -18,6 +18,8 @@ enum:
   - IDENTIFIER
   - BUSINESS_TYPE
   - COMPANY_LEGAL_NAME
+  - ID_TYPE
+  - ID_NUMBER
 description: >-
   Name of a type of field containing info about a platform's customer or
   counterparty customer.


### PR DESCRIPTION
## Summary

- Adds `ID_TYPE` and `ID_NUMBER` to the `CustomerInfoFieldName` enum so platforms can pass sender identity documents in `senderCustomerInfo` on quote create.
- Required for Thunes corridors where the upstream payer spec demands sender identity on every payer combination — currently EGP. The receiver-side field provider in sparkcore (PR #27983) already advertises these fields as required at LNURLP time; this PR closes the last gap so the request validator accepts them.

## Test plan

- [x] Verify the bundled `openapi.yaml` re-generated cleanly with only the two added enum values (no unrelated drift)
- [ ] After merge, run `update_schema.sh` in webdev/grid-api/ to regenerate Pydantic models; verify the regenerated `customer_info_field_name.py` includes `ID_TYPE = 'ID_TYPE'` and `ID_NUMBER = 'ID_NUMBER'`
- [ ] Retry the failing EGP quote-create against the Housing & Development Bank external account; expect quote success (or a different downstream error that's no longer about field-name validation)