### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 59 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 60 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="59 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="60 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -33,6 +33,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇫🇮 Finland | FI | `SEPA` `SEPA Instant` |
 | 🇫🇷 France | FR | `SEPA` `SEPA Instant` |
 | 🇩🇪 Germany | DE | `SEPA` `SEPA Instant` |
+| 🇬🇭 Ghana | GH | `Bank Transfer` |
 | 🇬🇷 Greece | GR | `SEPA` `SEPA Instant` |
 | 🇭🇹 Haiti | HT | `Bank Transfer` |
 | 🇭🇺 Hungary | HU | `SEPA` `SEPA Instant` |
@@ -83,7 +84,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="32 countries">
     Primary: SEPA/SEPA Instant
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="13 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="14 countries">
     Primary: Bank Transfer
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="9 countries">


### PR DESCRIPTION
## Summary
- Add Ghana (GH) to the Live destinations table — `Bank Transfer` rail
- Bump the headline counts to 60 countries (was 59) and Middle East and Africa to 14 (was 13)
- Coming Soon list (Canada, China, Hong Kong, South Korea) unchanged

Source of truth: [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184). Live rows (Status = "Live") were deduped on ISO code; Coming Soon filters on Public Roadmap = "Yes" AND Status ≠ "Live".

## Test plan
- [ ] `make lint-markdown` passes
- [ ] Preview renders the new Ghana row in alphabetical position and shows the updated totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)