### PR TITLE
Add CnyExternalAccountCreateInfo + register in CreateInfo OneOf

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14616,6 +14616,26 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/CadBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    CnyExternalAccountCreateInfo:
+      title: CNY Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/CnyAccountInfoBase'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/CnyBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/CnyBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     CopExternalAccountCreateInfo:
       title: COP Account
       allOf:
@@ -15263,6 +15283,7 @@ components:
         - $ref: '#/components/schemas/BrlExternalAccountCreateInfo'
         - $ref: '#/components/schemas/BwpExternalAccountCreateInfo'
         - $ref: '#/components/schemas/CadExternalAccountCreateInfo'
+        - $ref: '#/components/schemas/CnyExternalAccountCreateInfo'
         - $ref: '#/components/schemas/CopExternalAccountCreateInfo'
         - $ref: '#/components/schemas/DkkExternalAccountCreateInfo'
         - $ref: '#/components/schemas/EgpExternalAccountCreateInfo'
@@ -15310,6 +15331,7 @@ components:
           BRL_ACCOUNT: '#/components/schemas/BrlExternalAccountCreateInfo'
           BWP_ACCOUNT: '#/components/schemas/BwpExternalAccountCreateInfo'
           CAD_ACCOUNT: '#/components/schemas/CadExternalAccountCreateInfo'
+          CNY_ACCOUNT: '#/components/schemas/CnyExternalAccountCreateInfo'
           COP_ACCOUNT: '#/components/schemas/CopExternalAccountCreateInfo'
           DKK_ACCOUNT: '#/components/schemas/DkkExternalAccountCreateInfo'
           EGP_ACCOUNT: '#/components/schemas/EgpExternalAccountCreateInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14616,6 +14616,26 @@ components:
                 mapping:
                   INDIVIDUAL: '#/components/schemas/CadBeneficiary'
                   BUSINESS: '#/components/schemas/BusinessBeneficiary'
+    CnyExternalAccountCreateInfo:
+      title: CNY Account
+      allOf:
+        - $ref: '#/components/schemas/BaseExternalAccountInfo'
+        - $ref: '#/components/schemas/CnyAccountInfoBase'
+        - type: object
+          required:
+            - beneficiary
+          properties:
+            beneficiary:
+              oneOf:
+                - title: Individual Beneficiary
+                  $ref: '#/components/schemas/CnyBeneficiary'
+                - title: Business Beneficiary
+                  $ref: '#/components/schemas/BusinessBeneficiary'
+              discriminator:
+                propertyName: beneficiaryType
+                mapping:
+                  INDIVIDUAL: '#/components/schemas/CnyBeneficiary'
+                  BUSINESS: '#/components/schemas/BusinessBeneficiary'
     CopExternalAccountCreateInfo:
       title: COP Account
       allOf:
@@ -15263,6 +15283,7 @@ components:
         - $ref: '#/components/schemas/BrlExternalAccountCreateInfo'
         - $ref: '#/components/schemas/BwpExternalAccountCreateInfo'
         - $ref: '#/components/schemas/CadExternalAccountCreateInfo'
+        - $ref: '#/components/schemas/CnyExternalAccountCreateInfo'
         - $ref: '#/components/schemas/CopExternalAccountCreateInfo'
         - $ref: '#/components/schemas/DkkExternalAccountCreateInfo'
         - $ref: '#/components/schemas/EgpExternalAccountCreateInfo'
@@ -15310,6 +15331,7 @@ components:
           BRL_ACCOUNT: '#/components/schemas/BrlExternalAccountCreateInfo'
           BWP_ACCOUNT: '#/components/schemas/BwpExternalAccountCreateInfo'
           CAD_ACCOUNT: '#/components/schemas/CadExternalAccountCreateInfo'
+          CNY_ACCOUNT: '#/components/schemas/CnyExternalAccountCreateInfo'
           COP_ACCOUNT: '#/components/schemas/CopExternalAccountCreateInfo'
           DKK_ACCOUNT: '#/components/schemas/DkkExternalAccountCreateInfo'
           EGP_ACCOUNT: '#/components/schemas/EgpExternalAccountCreateInfo'

--- a/openapi/components/schemas/external_accounts/CnyExternalAccountCreateInfo.yaml
+++ b/openapi/components/schemas/external_accounts/CnyExternalAccountCreateInfo.yaml
@@ -1,0 +1,19 @@
+title: CNY Account
+allOf:
+- $ref: ./BaseExternalAccountInfo.yaml
+- $ref: ../common/CnyAccountInfoBase.yaml
+- type: object
+  required:
+  - beneficiary
+  properties:
+    beneficiary:
+      oneOf:
+      - title: Individual Beneficiary
+        $ref: ../common/CnyBeneficiary.yaml
+      - title: Business Beneficiary
+        $ref: ../common/BusinessBeneficiary.yaml
+      discriminator:
+        propertyName: beneficiaryType
+        mapping:
+          INDIVIDUAL: ../common/CnyBeneficiary.yaml
+          BUSINESS: ../common/BusinessBeneficiary.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccountCreateInfoOneOf.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountCreateInfoOneOf.yaml
@@ -4,6 +4,7 @@ oneOf:
 - $ref: ./BrlExternalAccountCreateInfo.yaml
 - $ref: ./BwpExternalAccountCreateInfo.yaml
 - $ref: ./CadExternalAccountCreateInfo.yaml
+- $ref: ./CnyExternalAccountCreateInfo.yaml
 - $ref: ./CopExternalAccountCreateInfo.yaml
 - $ref: ./DkkExternalAccountCreateInfo.yaml
 - $ref: ./EgpExternalAccountCreateInfo.yaml
@@ -51,6 +52,7 @@ discriminator:
     BRL_ACCOUNT: ./BrlExternalAccountCreateInfo.yaml
     BWP_ACCOUNT: ./BwpExternalAccountCreateInfo.yaml
     CAD_ACCOUNT: ./CadExternalAccountCreateInfo.yaml
+    CNY_ACCOUNT: ./CnyExternalAccountCreateInfo.yaml
     COP_ACCOUNT: ./CopExternalAccountCreateInfo.yaml
     DKK_ACCOUNT: ./DkkExternalAccountCreateInfo.yaml
     EGP_ACCOUNT: ./EgpExternalAccountCreateInfo.yaml


### PR DESCRIPTION
## Summary

- Adds the missing `CnyExternalAccountCreateInfo.yaml` (hand-authored, mirrors the existing `BdtExternalAccountCreateInfo.yaml` template) and registers it in `ExternalAccountCreateInfoOneOf.yaml`.
- The auto-sync workflow's `create_external_accounts.py` only generates the read-side `{Currency}ExternalAccountInfo.yaml`; the create-side `{Currency}ExternalAccountCreateInfo.yaml` is hand-authored per corridor and was missed when CNY landed via #551. Without the create variant in the OneOf, the discriminator can't dispatch `accountType: CNY_ACCOUNT` on `POST /customers/external-accounts` and the request fails with `"did not match any expected shape"`.

## Test plan

- [x] `npm run build:openapi` produces a bundle that contains `CnyExternalAccountCreateInfo` (line 15259 in the regenerated `openapi.yaml`).
- [ ] After merge, regen the downstream sparkcore mirror via `update_schema.sh` and confirm `grid_api/models/cny_external_account_create_info.py` exists.
- [ ] Once mirror regen lands in sparkcore, EGP-style CNY create payload accepts.