### PR TITLE
Add CNY bank-transfer rail (B2B) alongside mobile wallet

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11905,6 +11905,7 @@ components:
       example:
         accountType: CNY_ACCOUNT
         accountNumber: '1234567890'
+        phoneNumber: '+1234567890'
         bankName: China Construction Bank
     CnyAccountInfo:
       allOf:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11875,29 +11875,37 @@ components:
       type: object
       required:
         - accountType
-        - phoneNumber
         - bankName
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - BANK_TRANSFER: accountNumber, bankName
+        - MOBILE_MONEY: phoneNumber, bankName
       properties:
         accountType:
           type: string
           enum:
             - CNY_ACCOUNT
+        accountNumber:
+          type: string
+          description: The destination bank account number (BANK_TRANSFER rail)
+          minLength: 1
+          maxLength: 34
         phoneNumber:
           type: string
-          description: The phone number in international format
+          description: The phone number in international format (MOBILE_MONEY rail)
           example: '+1234567890'
           minLength: 7
           maxLength: 15
           pattern: ^\+[0-9]{6,14}$
         bankName:
           type: string
-          description: The name of the bank
+          description: The name of the bank or mobile-wallet provider
           minLength: 1
           maxLength: 255
       example:
         accountType: CNY_ACCOUNT
-        phoneNumber: '+1234567890'
-        bankName: Example Bank
+        accountNumber: '1234567890'
+        bankName: China Construction Bank
     CnyAccountInfo:
       allOf:
         - $ref: '#/components/schemas/CnyAccountInfoBase'
@@ -11911,6 +11919,7 @@ components:
                 type: string
                 enum:
                   - MOBILE_MONEY
+                  - BANK_TRANSFER
     PaymentCnyAccountInfo:
       title: CNY Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11905,6 +11905,7 @@ components:
       example:
         accountType: CNY_ACCOUNT
         accountNumber: '1234567890'
+        phoneNumber: '+1234567890'
         bankName: China Construction Bank
     CnyAccountInfo:
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11875,29 +11875,37 @@ components:
       type: object
       required:
         - accountType
-        - phoneNumber
         - bankName
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - BANK_TRANSFER: accountNumber, bankName
+        - MOBILE_MONEY: phoneNumber, bankName
       properties:
         accountType:
           type: string
           enum:
             - CNY_ACCOUNT
+        accountNumber:
+          type: string
+          description: The destination bank account number (BANK_TRANSFER rail)
+          minLength: 1
+          maxLength: 34
         phoneNumber:
           type: string
-          description: The phone number in international format
+          description: The phone number in international format (MOBILE_MONEY rail)
           example: '+1234567890'
           minLength: 7
           maxLength: 15
           pattern: ^\+[0-9]{6,14}$
         bankName:
           type: string
-          description: The name of the bank
+          description: The name of the bank or mobile-wallet provider
           minLength: 1
           maxLength: 255
       example:
         accountType: CNY_ACCOUNT
-        phoneNumber: '+1234567890'
-        bankName: Example Bank
+        accountNumber: '1234567890'
+        bankName: China Construction Bank
     CnyAccountInfo:
       allOf:
         - $ref: '#/components/schemas/CnyAccountInfoBase'
@@ -11911,6 +11919,7 @@ components:
                 type: string
                 enum:
                   - MOBILE_MONEY
+                  - BANK_TRANSFER
     PaymentCnyAccountInfo:
       title: CNY Account
       allOf:

--- a/openapi/components/schemas/common/CnyAccountInfo.yaml
+++ b/openapi/components/schemas/common/CnyAccountInfo.yaml
@@ -10,3 +10,4 @@ allOf:
         type: string
         enum:
         - MOBILE_MONEY
+        - BANK_TRANSFER

--- a/openapi/components/schemas/common/CnyAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/CnyAccountInfoBase.yaml
@@ -1,26 +1,35 @@
 type: object
 required:
 - accountType
-- phoneNumber
 - bankName
+description: 'Required fields depend on the selected paymentRails:
+
+  - BANK_TRANSFER: accountNumber, bankName
+
+  - MOBILE_MONEY: phoneNumber, bankName'
 properties:
   accountType:
     type: string
     enum:
     - CNY_ACCOUNT
+  accountNumber:
+    type: string
+    description: The destination bank account number (BANK_TRANSFER rail)
+    minLength: 1
+    maxLength: 34
   phoneNumber:
     type: string
-    description: The phone number in international format
+    description: The phone number in international format (MOBILE_MONEY rail)
     example: '+1234567890'
     minLength: 7
     maxLength: 15
     pattern: ^\+[0-9]{6,14}$
   bankName:
     type: string
-    description: The name of the bank
+    description: The name of the bank or mobile-wallet provider
     minLength: 1
     maxLength: 255
 example:
   accountType: CNY_ACCOUNT
-  phoneNumber: '+1234567890'
-  bankName: Example Bank
+  accountNumber: '1234567890'
+  bankName: China Construction Bank

--- a/openapi/components/schemas/common/CnyAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/CnyAccountInfoBase.yaml
@@ -32,4 +32,5 @@ properties:
 example:
   accountType: CNY_ACCOUNT
   accountNumber: '1234567890'
+  phoneNumber: '+1234567890'
   bankName: China Construction Bank


### PR DESCRIPTION
## Summary
Adds the `BANK_TRANSFER` rail to the CNY account schema so CNY payouts can target a **bank account** (business-to-business), in addition to the existing `MOBILE_MONEY` wallet rail. Mirrors the dual-rail `COP` schema pattern.

## Changes
- **`CnyAccountInfoBase.yaml`**: `bankName` is now the only required field beyond `accountType`. `phoneNumber` becomes optional (`MOBILE_MONEY` only); new optional `accountNumber` added (`BANK_TRANSFER` only). Per-rail requirements documented on the schema and enforced at the application layer, exactly like `COP`.
- **`CnyAccountInfo.yaml`**: add `BANK_TRANSFER` to the `paymentRails` enum.

The `beneficiary` oneOf already supports `BUSINESS` (`BusinessBeneficiary`) alongside `INDIVIDUAL`, so the B2B shape the bank rail requires (`legalName` + `address`) needs no further schema change. The credit-party identifier for the bank rail is just `bank_account_number` (confirmed against the live payer requirements).

## Test plan
- [x] `npm run build:openapi` bundles cleanly
- [ ] CI lint passes
- [ ] After merge: regen `grid_api` in webdev, wire the bank rail in sparkcore (rails config, fields provider, account.py, B2B transaction-type resolution), add itests