### PR TITLE
docs: sync country coverage with Grid Switch Corridor List

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -7,9 +7,9 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
     </FeatureCard>
     <FeatureCard icon="/images/icons/blocks.svg" title="Full Platform Access" tag="United States & Europe" tagPosition="inline" layout="horizontal" variant="flat">
       Onboard as a platform with complete access to APIs, hosted KYC/KYB, dashboard, and business integrations.
-      Send payments to 60 countries on local banking rails, in addition to BTC and stablecoins.
+      Send payments to 62 countries on local banking rails, in addition to BTC and stablecoins.
     </FeatureCard>
-    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="60 Countries" tagPosition="inline" layout="horizontal" variant="flat">
+    <FeatureCard icon="/images/icons/globe.svg" title="Local Payment Rails" tag="62 Countries" tagPosition="inline" layout="horizontal" variant="flat">
       Receive payments via local rails like SEPA, PIX, UPI, and more.
     </FeatureCard>
   </FeatureCardList>
@@ -30,6 +30,7 @@ import { FeatureCard, FeatureCardGrid, FeatureCardList, FeatureCardContainer } f
 | 🇨🇾 Cyprus | CY | `SEPA` `SEPA Instant` |
 | 🇨🇿 Czech Republic | CZ | `SEPA` `SEPA Instant` |
 | 🇩🇰 Denmark | DK | `SEPA` `SEPA Instant` |
+| 🇪🇬 Egypt | EG | `Bank Transfer` |
 | 🇪🇪 Estonia | EE | `SEPA` `SEPA Instant` |
 | 🇫🇮 Finland | FI | `SEPA` `SEPA Instant` |
 | 🇫🇷 France | FR | `SEPA` `SEPA Instant` |
@@ -85,7 +86,7 @@ Regional Summary
   <FeatureCard icon="/images/icons/globe.svg" title="Europe" tag="32 countries">
     Primary: SEPA/SEPA Instant
   </FeatureCard>
-  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="14 countries">
+  <FeatureCard icon="/images/icons/globe.svg" title="Middle East and Africa" tag="15 countries">
     Primary: Bank Transfer
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Asia-Pacific" tag="10 countries">


### PR DESCRIPTION
## Summary

Sync `mintlify/snippets/country-support.mdx` with the [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) source of truth.

- Add **Egypt (EG)** as a Live destination — newly live via Thunes (`Bank Transfer`).
- Bump headline count: 60 → 62 (header `FeatureCard` tags + "Send payments to N countries" copy). This also reconciles a prior off-by-one in the headline (the table on main already had 61 rows while the header said 60).
- Bump Middle East & Africa regional count: 14 → 15. Regional total now reconciles: 32 + 15 + 10 + 5 = 62.
- Coming Soon (CA, HK, KR) already matches the spreadsheet filter (Public Roadmap = Yes AND Status ≠ Live) — no change.

### Note on #534

This PR supersedes #534, which was opened on 2026-06-05 and demoted China (CN) from Live to Coming Soon. As of the current sheet, China's Thunes row (row 66) is Status = "Live" with the note "successful prod test on 6/5/2026" — so China should remain in the Live table. Recommend closing #534.

Live destinations were derived from rows with Status = "Live" (column J), deduped on ISO code; Egypt was the only delta vs. the current published table.

## Test plan

- [ ] `make lint-markdown` (no OpenAPI changes, no rebundle needed)
- [ ] Spot check the rendered snippet in `mint dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)