### PR TITLE
[grid] fix passkey registration samples

### DIFF
--- a/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/RegisterPasskey.tsx
@@ -9,9 +9,12 @@ interface Props {
   disabled: boolean
 }
 
-// Two-phase: backend mints a WebAuthn challenge, client runs
-// navigator.credentials.create(), client posts the attestation back, backend
-// forwards to Grid as POST /auth/credentials.
+const SANDBOX_MODE = (import.meta.env.VITE_SANDBOX_PASSKEY ?? '1') !== '0'
+const SANDBOX_WALLET_SIGNATURE = 'sandbox-valid-signature'
+
+// Backend mints a WebAuthn challenge, client runs navigator.credentials.create(),
+// client posts the attestation back, and Grid may require a signed retry before
+// returning the new auth method.
 export default function RegisterPasskey({
   walletAccountId,
   customerId,
@@ -62,7 +65,7 @@ export default function RegisterPasskey({
         (att as AuthenticatorAttestationResponse & { getTransports?: () => string[] })
           .getTransports?.() ?? []
 
-      const data = await apiPost<Record<string, unknown>>('/api/auth/credentials', {
+      const createBody = {
         accountId: walletAccountId,
         challenge: reg.challenge,
         nickname: 'Grid Global Account passkey',
@@ -72,7 +75,16 @@ export default function RegisterPasskey({
           attestationObject: bytesToBase64url(new Uint8Array(att.attestationObject)),
           transports,
         },
-      })
+      }
+
+      let data = await apiPost<Record<string, unknown>>('/api/auth/credentials', createBody)
+      if (typeof data.payloadToSign === 'string' && typeof data.requestId === 'string') {
+        const signature = registrationSignature(data.payloadToSign)
+        data = await apiPost<Record<string, unknown>>('/api/auth/credentials', createBody, {
+          'Grid-Wallet-Signature': signature,
+          'Request-Id': data.requestId,
+        })
+      }
 
       setResponse(JSON.stringify(data, null, 2))
       const authMethodId = (data.id ?? data.authMethodId) as string | undefined
@@ -102,6 +114,15 @@ export default function RegisterPasskey({
       </button>
       <ResponsePanel response={response} error={error} />
     </div>
+  )
+}
+
+function registrationSignature(payloadToSign: string): string {
+  const configured = import.meta.env.VITE_REGISTRATION_GRID_WALLET_SIGNATURE
+  if (configured) return configured
+  if (SANDBOX_MODE) return SANDBOX_WALLET_SIGNATURE
+  throw new Error(
+    `Passkey registration requires a signed retry for payloadToSign: ${payloadToSign}`,
   )
 }
 

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/AuthCredentials.kt
@@ -1,5 +1,6 @@
 package com.grid.sample.routes
 
+import com.lightspark.grid.models.auth.credentials.CredentialCreateParams
 import com.lightspark.grid.models.auth.credentials.CredentialCreateParams.AuthCredentialCreateRequest.PasskeyCredentialCreateRequest
 import com.lightspark.grid.models.auth.credentials.CredentialResendChallengeParams
 import com.lightspark.grid.models.auth.credentials.CredentialVerifyParams
@@ -32,6 +33,11 @@ private object RegistrationChallengeStore {
 
     fun consume(challenge: String): Boolean {
         val expiresAt = store.remove(challenge) ?: return false
+        return System.currentTimeMillis() < expiresAt
+    }
+
+    fun isValid(challenge: String): Boolean {
+        val expiresAt = store[challenge] ?: return false
         return System.currentTimeMillis() < expiresAt
     }
 }
@@ -89,7 +95,7 @@ fun Route.authCredentialRoutes() {
 
                 val challenge = json.optText("challenge")
                     ?: throw IllegalArgumentException("challenge is required")
-                if (!RegistrationChallengeStore.consume(challenge)) {
+                if (!RegistrationChallengeStore.isValid(challenge)) {
                     return@post call.respondText(
                         """{"error": "challenge is invalid or expired"}""",
                         ContentType.Application.Json,
@@ -114,13 +120,34 @@ fun Route.authCredentialRoutes() {
                         json.optText("nickname")?.let { nickname(it) }
                     }
                     .build()
+                val gridWalletSignature = call.request.headers["Grid-Wallet-Signature"]
+                val requestId = call.request.headers["Request-Id"]
+                val params = CredentialCreateParams.builder()
+                    .authCredentialCreateRequest(request)
+                    .apply {
+                        gridWalletSignature?.let { gridWalletSignature(it) }
+                        requestId?.let { requestId(it) }
+                    }
+                    .build()
 
-                Log.gridRequest("auth.credentials.create", JsonUtils.prettyPrint(request))
-                val response = GridClientBuilder.client.auth().credentials().create(request)
-                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridRequest(
+                    "auth.credentials.create",
+                    "signedRetry=${gridWalletSignature != null} body=${JsonUtils.prettyPrint(request)}",
+                )
+                val response = GridClientBuilder.client.auth().credentials()
+                    .withRawResponse()
+                    .create(params)
+                val responseJson = response.body().bufferedReader().use { it.readText() }
                 Log.gridResponse("auth.credentials.create", responseJson)
+                if (response.statusCode() != HttpStatusCode.Accepted.value) {
+                    RegistrationChallengeStore.consume(challenge)
+                }
 
-                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+                call.respondText(
+                    responseJson,
+                    ContentType.Application.Json,
+                    HttpStatusCode.fromValue(response.statusCode()),
+                )
             } catch (e: Exception) {
                 Log.gridError("auth.credentials.create", e)
                 call.respondText(


### PR DESCRIPTION
## Summary
- Update the frontend passkey registration sample to handle Grid’s `202` signed-retry response before expecting an auth method id.
- Forward `Grid-Wallet-Signature` and `Request-Id` through the Kotlin sample’s `CredentialCreateParams` on the signed retry.
- Keep the local WebAuthn registration challenge valid through the signed retry and consume it only when registration completes.

## Validation
- `npm run build` in `samples/frontend`
- Inspected the published Grid Kotlin SDK classes to confirm `CredentialCreateParams` supports `gridWalletSignature` and `requestId`
- Kotlin compile was not run locally because this machine has Java 17 while the sample Gradle config requires Java 21
