### PR TITLE
[grid] fix Global Account sandbox docs

### DIFF
--- a/mintlify/snippets/sandbox-global-account-magic.mdx
+++ b/mintlify/snippets/sandbox-global-account-magic.mdx
@@ -77,7 +77,7 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMet
 curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMethod:abc123/verify \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -H "Request-Id: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
+  -H "Request-Id: Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
   -d '{
     "type": "PASSKEY",
     "assertion": {
@@ -137,7 +137,6 @@ NODE
 curl -X POST https://api.lightspark.com/grid/2025-10-13/auth/credentials/AuthMethod:abc123/verify \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -H "Request-Id: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
   -d '{
     "type": "OAUTH",
     "oidcToken": "'"$OIDC_TOKEN"'",

--- a/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
+++ b/samples/frontend/src/steps/embeddedWallet/AuthenticateAndSign.tsx
@@ -42,8 +42,8 @@ const TURNKEY_HPKE_INFO = new TextEncoder().encode('turnkey_hpke')
 // Sandbox flow (this is what runs by default):
 //   - Step 3 still triggers the real OS biometric prompt.
 //   - Step 4's wire signature is the magic value sandbox-valid-passkey-signature.
-//   - Step 5 is skipped (the encryptedSessionSigningKey is a stub in sandbox).
-//   - Step 6 returns the magic value sandbox-valid-signature for step 8.
+//   - Step 5 is skipped because this mode intentionally uses sandbox shortcuts.
+//   - Step 6 returns the legacy magic value sandbox-valid-signature for step 8.
 export default function AuthenticateAndSign({
   authMethodId,
   payloadToSign,
@@ -113,9 +113,9 @@ export default function AuthenticateAndSign({
         { 'Request-Id': challenge.requestId },
       )
 
-      // 5 + 6. Decrypt the session signing key and sign payloadToSign. In
-      //        sandbox the encryptedSessionSigningKey is a stub, so we skip
-      //        the crypto and use the magic wallet-signature header value.
+      // 5 + 6. Decrypt the session signing key and sign payloadToSign. In the
+      //        default sandbox shortcut mode, skip the crypto and use the
+      //        magic wallet-signature header value.
       let signature: string
       if (SANDBOX_MODE) {
         signature = SANDBOX_WALLET_SIGNATURE

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ SIGN="node $(pwd)/scripts/embedded-wallet-sign.js"
 g() { curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" "$@"; }
 ```
 
-`$SIGN --help` lists the three subcommands. `g` is a shorthand for
+`$SIGN --help` lists the four subcommands. `g` is a shorthand for
 authenticated curl used throughout the snippets below.
 
 ## 1. Onboarding
@@ -77,12 +77,12 @@ g "$GRID_BASE_URL/customers/internal-accounts?customerId=$CUSTOMER_ID" \
 
 Capture the **USDB account id** into `$USDB_ACCT`.
 
-### 1.4 Bootstrap the embedded wallet (verify the EMAIL_OTP credential)
+### 1.4 Bootstrap the embedded wallet (issue the EMAIL_OTP challenge)
 
 > **Required before the first quote.** The USDB embedded wallet's Turnkey
 > sub-org and Spark network wallet aren't fully provisioned at customer
-> creation time. Verifying the auto-created auth credential triggers that
-> bootstrap. Skipping causes the first on-ramp quote to fail with
+> creation time. Challenging and later verifying the auto-created auth
+> credential triggers that bootstrap. Skipping causes the first on-ramp quote to fail with
 > `to_network INTERNAL_FUNDED_FIAT does not support USDB`.
 
 An `EMAIL_OTP` credential is automatically created when the embedded wallet


### PR DESCRIPTION
## Summary
- Fix the sandbox passkey verify curl example to echo the full `Request:<uuid>` header value.
- Remove the unused `Request-Id` header from the OAuth sandbox verify example.
- Update the scripts README to say the helper has four subcommands and clarify that bootstrap step 1.4 only issues the EMAIL_OTP challenge.
- Clarify the frontend sandbox comments: default sandbox mode uses legacy magic signatures as shortcuts, while production-shaped sandbox tests can use real decryptable bundles and stamps.

## Validation
- `npm run build` in `samples/frontend`
- `make build` at the stack tip
