### PR TITLE
docs: add end-user terms disclosures guide; link refund policy in receipts

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -125,7 +125,8 @@
             "group": "Onboarding",
             "pages": [
               "payouts-and-b2b/onboarding/platform-configuration",
-              "payouts-and-b2b/onboarding/configuring-customers"
+              "payouts-and-b2b/onboarding/configuring-customers",
+              "payouts-and-b2b/onboarding/disclosures"
             ]
           },
           {

--- a/mintlify/payouts-and-b2b/onboarding/disclosures.mdx
+++ b/mintlify/payouts-and-b2b/onboarding/disclosures.mdx
@@ -1,0 +1,27 @@
+---
+title: "Disclosures"
+description: "Expose Lightspark's End User Terms and provide evidence of your consent flow"
+icon: "/images/icons/shield.svg"
+"og:image": "/images/og/og-payouts-b2b.png"
+---
+
+If you're an **unregulated platform** moving funds using Grid's money transmitter licenses, Grid (operating as Lightspark Payments, LLC) is the licensed money transmitter on your transactions. Your end users contract directly with Lightspark for these services, so you must present Lightspark's End User Terms to each end user and capture their consent before they transact.
+
+<Warning>
+Exposing the End User Terms and collecting consent is a **launch precondition**. Provide Lightspark with evidence of your consent flow and receive approval before making Grid available to your end users.
+</Warning>
+
+## Include the End User Terms in your terms
+
+Copy Lightspark's End User Terms and append your own terms of service to them, so each end user accepts a single combined document:
+
+- **End User Terms:** [https://www.lightspark.com/legal/grid/enduserterms](https://www.lightspark.com/legal/grid/enduserterms)
+
+Present the combined terms in your onboarding or consent flow, and require each end user to affirmatively accept them (for example, an unchecked checkbox or an "I Agree" button) before they can use Grid.
+
+## Provide evidence of your consent flow
+
+Send Lightspark evidence that your end users are shown the End User Terms and consent to them. Provide both:
+
+- **A screenshot of the consent screen** showing how the End User Terms are presented and accepted.
+- **How you track consent** — the record you keep each time an end user accepts, such as the end user identifier, the timestamp of acceptance, and the version of the terms accepted.

--- a/mintlify/snippets/receipts.mdx
+++ b/mintlify/snippets/receipts.mdx
@@ -111,7 +111,7 @@ export const ReceiptExample = () => {
           <p style={{ margin: 0 }}>To report fraud or suspected fraud in connection with the money transmission services, please call customer service toll-free at <span style={{ color: '#1a1a1a', fontWeight: 450 }}>(855) 516-0103</span>.</p>
           <div>
             <div style={secLabelMb}>Refund Policy</div>
-            <p style={{ margin: 0 }}>You may cancel for a full refund within 30 minutes of payment, unless the funds have already been picked up or deposited. Refund requests can be made at www.lightspark.com/refunds or by calling the number above.</p>
+            <p style={{ margin: 0 }}>You may cancel for a full refund within 30 minutes of payment, unless the funds have already been picked up or deposited. See the <a href="https://support.lightspark.com/hc/en-us/categories/51347651720859-Cards" style={{ color: '#1a1a1a', fontWeight: 450 }}>refund policy</a> or call the number above.</p>
           </div>
           <p style={{ margin: 0, fontSize: '11px', color: '#989898', borderTop: '1px solid rgba(38,38,35,0.08)', paddingTop: '10px' }}>Recipient may receive less than the total to recipient due to fees charged by the recipient's bank and any foreign taxes. <em>(Foreign remittance only.)</em></p>
         </div>
@@ -164,7 +164,7 @@ Include these exactly as written on every receipt:
 | Website | www.lightspark.com |
 | Customer service phone | (855) 516-0103 |
 | Fraud reporting | "To report fraud or suspected fraud in connection with the money transmission services, please call customer services toll-free at (855) 516-0103." |
-| Refund policy | Lightspark's refund policy for transmitted funds (link or full text). |
+| Refund policy | Link to Lightspark's refund policy: https://support.lightspark.com/hc/en-us/categories/51347651720859-Cards |
 
 ### Transaction fields
 


### PR DESCRIPTION
Add a B2B onboarding "Disclosures" page instructing unregulated platforms to
expose Lightspark's End User Terms and provide evidence of their consent flow.
Update the receipts snippet to link the refund policy support article.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>