### PR TITLE
docs: add Global Accounts Playground page (interactive wallet demo)

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -79,6 +79,7 @@
             "group": "Overview",
             "pages": [
               "global-accounts/index",
+              "global-accounts/demo",
               "global-accounts/implementation-overview"
             ]
           },

--- a/mintlify/global-accounts/demo.mdx
+++ b/mintlify/global-accounts/demo.mdx
@@ -1,0 +1,12 @@
+---
+title: "Playground"
+description: "Create a Grid Global Account and watch the API calls fire in real time"
+icon: "/images/icons/phone.svg"
+"og:image": "/images/og/og-global-accounts.webp"
+---
+
+import { WalletDemoEmbed } from '/snippets/global-accounts/wallet-demo-embed.mdx';
+
+<div id="wallet-demo-container"></div>
+
+<WalletDemoEmbed />

--- a/mintlify/images/icons/phone.svg
+++ b/mintlify/images/icons/phone.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M9.5 3H14.5C15.8807 3 17 4.11929 17 5.5V18.5C17 19.8807 15.8807 21 14.5 21H9.5C8.11929 21 7 19.8807 7 18.5V5.5C7 4.11929 8.11929 3 9.5 3Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M10.5 18H13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
+++ b/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
@@ -1,0 +1,87 @@
+export const WalletDemoEmbed = () => {
+  React.useEffect(() => {
+    const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const base = isLocal ? 'http://localhost:4000' : 'https://grid-wallet-demo.vercel.app';
+    const isDark = () => document.documentElement.classList.contains('dark');
+
+    let host = document.getElementById('wallet-demo-host');
+    if (!host) {
+      host = document.createElement('div');
+      host.id = 'wallet-demo-host';
+      host.style.cssText = 'position:fixed;z-index:1;overflow:hidden;';
+      const iframe = document.createElement('iframe');
+      iframe.id = 'wallet-demo-iframe';
+      iframe.src = base + '/?embed=true&theme=' + (isDark() ? 'dark' : 'light');
+      iframe.title = 'Grid Global Accounts — live demo';
+      iframe.setAttribute('allow', 'publickey-credentials-create *; publickey-credentials-get *; clipboard-write');
+      iframe.style.cssText = 'width:100%;height:100%;border:0;display:block;';
+      host.appendChild(iframe);
+      document.body.appendChild(host);
+    }
+    if (window.__wdHideTimer) { clearTimeout(window.__wdHideTimer); window.__wdHideTimer = null; }
+    host.style.display = 'block';
+
+    let raf = 0;
+    let last = { left: -1, top: -1, width: -1, height: -1 };
+    const sync = () => {
+      const el = document.getElementById('wallet-demo-container');
+      if (el && host) {
+        const r = el.getBoundingClientRect();
+        if (r.left !== last.left || r.top !== last.top || r.width !== last.width || r.height !== last.height) {
+          host.style.left = r.left + 'px';
+          host.style.top = r.top + 'px';
+          host.style.width = r.width + 'px';
+          host.style.height = r.height + 'px';
+          last = { left: r.left, top: r.top, width: r.width, height: r.height };
+        }
+      }
+      raf = requestAnimationFrame(sync);
+    };
+    raf = requestAnimationFrame(sync);
+
+    let ignoreNextMutation = false;
+    const sendTheme = () => {
+      const t = isDark() ? 'dark' : 'light';
+      const iframe = document.getElementById('wallet-demo-iframe');
+      if (iframe && iframe.contentWindow) {
+        iframe.contentWindow.postMessage({ type: 'theme-sync', theme: t }, '*');
+      }
+    };
+
+    const handleMessage = (e) => {
+      if (e.data && e.data.type === 'theme-request') {
+        sendTheme();
+        return;
+      }
+      if (e.data && e.data.type === 'theme-sync') {
+        const wantsDark = e.data.theme === 'dark';
+        if (isDark() !== wantsDark) {
+          ignoreNextMutation = true;
+          document.documentElement.classList.toggle('dark');
+        }
+      }
+    };
+    window.addEventListener('message', handleMessage);
+
+    const obs = new MutationObserver(() => {
+      if (ignoreNextMutation) { ignoreNextMutation = false; return; }
+      sendTheme();
+    });
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+    sendTheme();
+    requestAnimationFrame(sendTheme);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('message', handleMessage);
+      obs.disconnect();
+      window.__wdHideTimer = setTimeout(() => {
+        const h = document.getElementById('wallet-demo-host');
+        if (h) h.style.display = 'none';
+      }, 150);
+    };
+  }, []);
+
+  return null;
+};

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -4076,3 +4076,134 @@ html.dark:has(#flow-builder-container) #navbar button[class*="h-14"][class*="tex
   color: var(--ls-gray-700);
 }
 
+
+/* ===========================================
+   Wallet demo page (global-accounts/demo)
+   Docs sidebar stays; content column is iframe-only, edge-to-edge.
+   =========================================== */
+
+#content-container:has(#wallet-demo-container) {
+  max-width: none !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Mintlify wraps content in max-w-5xl (1024px) — bust it for the demo */
+#content-container:has(#wallet-demo-container) > div.max-w-5xl,
+#content-container:has(#wallet-demo-container) > div[class*="max-w-5xl"] {
+  max-width: none !important;
+  width: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  gap: 0 !important;
+}
+
+#content-area:has(#wallet-demo-container) {
+  width: 100% !important;
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  contain: none !important;
+  display: flex !important;
+  flex-direction: column !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  /* navbar (64px bar + 48px tabs = 112px) */
+  min-height: calc(100dvh - 112px) !important;
+}
+
+/* Hide everything in the content column except the embed */
+#content-area:has(#wallet-demo-container) > header#header,
+#content-area:has(#wallet-demo-container) > #pagination,
+#content-area:has(#wallet-demo-container) > footer#footer,
+#content-area:has(#wallet-demo-container) > div.sticky {
+  display: none !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  visibility: hidden !important;
+}
+
+#content-container:has(#wallet-demo-container) #content-side-layout {
+  display: none !important;
+}
+
+#content-area:has(#wallet-demo-container) > #content {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  max-width: none !important;
+  min-height: 0 !important;
+  contain: none !important;
+}
+
+#content:has(#wallet-demo-container) .prose,
+.prose:has(#wallet-demo-container) {
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Placeholder that defines the embed's box. The actual iframe lives in
+   #wallet-demo-host on <body> (so theme toggles don't reload it) and is glued
+   to this box's position by the embed script. */
+#wallet-demo-container {
+  width: 100%;
+  height: calc(100dvh - 112px);
+  margin: 0;
+  padding: 0;
+  line-height: 0;
+  background: var(--ls-gray-100);
+}
+
+html.dark #wallet-demo-container {
+  background: var(--ls-gray-975);
+}
+
+/* Persistent iframe host — body-mounted, positioned over the placeholder. */
+#wallet-demo-host {
+  background: var(--ls-gray-100);
+}
+
+html.dark #wallet-demo-host {
+  background: var(--ls-gray-975);
+}
+
+#wallet-demo-iframe {
+  width: 100% !important;
+  height: 100% !important;
+  min-height: 0 !important;
+  border: none !important;
+  display: block !important;
+  aspect-ratio: unset !important;
+}
+
+/* Flatten Mintlify's iframe aspect-ratio wrapper */
+#wallet-demo-container > div,
+#wallet-demo-container > [style*="aspect-ratio"] {
+  aspect-ratio: unset !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+@media (max-width: 1023px) {
+  #content-area:has(#wallet-demo-container) {
+    min-height: calc(100dvh - 120px) !important;
+  }
+
+  #wallet-demo-container {
+    height: calc(100dvh - 120px);
+  }
+}
+
+/* Prevent outer page scroll when the wallet demo is present */
+html:has(#wallet-demo-container),
+html:has(#wallet-demo-container) body {
+  overflow: hidden !important;
+}
+


### PR DESCRIPTION
## Summary

Adds the **Playground** page (`global-accounts/demo`) that embeds the interactive Grid wallet demo, plus its nav entry and full-bleed page styling.

- The demo is a separate Next.js app hosted on Vercel (**https://grid-wallet-demo.vercel.app**), mounted as a position-synced iframe over `#wallet-demo-container` with docs theme sync.
- Split out of the large app-code branch (`pat/wallet-demo-country-banks`, PR #580) so Mintlify can build a clean preview for review.

## Purpose

Staging preview so the team can try the demo **in docs context** and give feedback before we ship. Not for merge yet.

Made with [Cursor](https://cursor.com)