### PR TITLE
Add required totalBalance field to InternalAccount

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3911,6 +3911,13 @@ paths:
                         name: United States Dollar
                         symbol: $
                         decimals: 2
+                    totalBalance:
+                      amount: 12550
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
                     fundingPaymentInstructions: []
                     privateEnabled: true
                     createdAt: '2026-04-08T15:30:00Z'
@@ -7662,6 +7669,13 @@ webhooks:
                         name: United States Dollar
                         symbol: $
                         decimals: 2
+                    totalBalance:
+                      amount: 12500
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
                     fundingPaymentInstructions: []
                     createdAt: '2025-08-01T10:00:00Z'
                     updatedAt: '2025-08-15T14:32:00Z'
@@ -7677,6 +7691,13 @@ webhooks:
                     type: INTERNAL_FIAT
                     status: FROZEN
                     balance:
+                      amount: 10000
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
+                    totalBalance:
                       amount: 10000
                       currency:
                         code: USD
@@ -12852,24 +12873,31 @@ components:
           type: string
           enum:
             - INDIVIDUAL
+          example: INDIVIDUAL
         fullName:
           type: string
           description: The full name of the beneficiary
+          example: Jane Smith
         birthDate:
           type: string
           description: The birth date of the beneficiary
+          example: '1990-01-15'
         nationality:
           type: string
           description: The nationality of the beneficiary
+          example: GB
         email:
           type: string
           description: The email of the beneficiary
+          example: jane.smith@example.com
         phoneNumber:
           type: string
           description: The phone number of the beneficiary
+          example: '+447700900123'
         countryOfResidence:
           type: string
           description: The country of residence of the beneficiary
+          example: GB
         address:
           $ref: '#/components/schemas/Address'
     GbpExternalAccountInfo:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12061,6 +12061,7 @@ components:
         - type
         - status
         - balance
+        - totalBalance
         - fundingPaymentInstructions
         - createdAt
         - updatedAt
@@ -12079,6 +12080,10 @@ components:
           $ref: '#/components/schemas/InternalAccountStatus'
         balance:
           $ref: '#/components/schemas/CurrencyAmount'
+          description: The balance available to spend, excluding pending and held funds
+        totalBalance:
+          $ref: '#/components/schemas/CurrencyAmount'
+          description: The total balance, including pending and held funds
         fundingPaymentInstructions:
           type: array
           description: Payment instructions for funding the account

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3911,6 +3911,13 @@ paths:
                         name: United States Dollar
                         symbol: $
                         decimals: 2
+                    totalBalance:
+                      amount: 12550
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
                     fundingPaymentInstructions: []
                     privateEnabled: true
                     createdAt: '2026-04-08T15:30:00Z'
@@ -7662,6 +7669,13 @@ webhooks:
                         name: United States Dollar
                         symbol: $
                         decimals: 2
+                    totalBalance:
+                      amount: 12500
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
                     fundingPaymentInstructions: []
                     createdAt: '2025-08-01T10:00:00Z'
                     updatedAt: '2025-08-15T14:32:00Z'
@@ -7677,6 +7691,13 @@ webhooks:
                     type: INTERNAL_FIAT
                     status: FROZEN
                     balance:
+                      amount: 10000
+                      currency:
+                        code: USD
+                        name: United States Dollar
+                        symbol: $
+                        decimals: 2
+                    totalBalance:
                       amount: 10000
                       currency:
                         code: USD
@@ -12852,24 +12873,31 @@ components:
           type: string
           enum:
             - INDIVIDUAL
+          example: INDIVIDUAL
         fullName:
           type: string
           description: The full name of the beneficiary
+          example: Jane Smith
         birthDate:
           type: string
           description: The birth date of the beneficiary
+          example: '1990-01-15'
         nationality:
           type: string
           description: The nationality of the beneficiary
+          example: GB
         email:
           type: string
           description: The email of the beneficiary
+          example: jane.smith@example.com
         phoneNumber:
           type: string
           description: The phone number of the beneficiary
+          example: '+447700900123'
         countryOfResidence:
           type: string
           description: The country of residence of the beneficiary
+          example: GB
         address:
           $ref: '#/components/schemas/Address'
     GbpExternalAccountInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12061,6 +12061,7 @@ components:
         - type
         - status
         - balance
+        - totalBalance
         - fundingPaymentInstructions
         - createdAt
         - updatedAt
@@ -12079,6 +12080,10 @@ components:
           $ref: '#/components/schemas/InternalAccountStatus'
         balance:
           $ref: '#/components/schemas/CurrencyAmount'
+          description: The balance available to spend, excluding pending and held funds
+        totalBalance:
+          $ref: '#/components/schemas/CurrencyAmount'
+          description: The total balance, including pending and held funds
         fundingPaymentInstructions:
           type: array
           description: Payment instructions for funding the account

--- a/openapi/components/schemas/common/GbpBeneficiary.yaml
+++ b/openapi/components/schemas/common/GbpBeneficiary.yaml
@@ -8,23 +8,30 @@ properties:
     type: string
     enum:
     - INDIVIDUAL
+    example: INDIVIDUAL
   fullName:
     type: string
     description: The full name of the beneficiary
+    example: Jane Smith
   birthDate:
     type: string
     description: The birth date of the beneficiary
+    example: '1990-01-15'
   nationality:
     type: string
     description: The nationality of the beneficiary
+    example: GB
   email:
     type: string
     description: The email of the beneficiary
+    example: jane.smith@example.com
   phoneNumber:
     type: string
     description: The phone number of the beneficiary
+    example: '+447700900123'
   countryOfResidence:
     type: string
     description: The country of residence of the beneficiary
+    example: GB
   address:
     $ref: ./Address.yaml

--- a/openapi/components/schemas/customers/InternalAccount.yaml
+++ b/openapi/components/schemas/customers/InternalAccount.yaml
@@ -4,6 +4,7 @@ required:
   - type
   - status
   - balance
+  - totalBalance
   - fundingPaymentInstructions
   - createdAt
   - updatedAt
@@ -22,6 +23,10 @@ properties:
     $ref: ./InternalAccountStatus.yaml
   balance:
     $ref: ../common/CurrencyAmount.yaml
+    description: The balance available to spend, excluding pending and held funds
+  totalBalance:
+    $ref: ../common/CurrencyAmount.yaml
+    description: The total balance, including pending and held funds
   fundingPaymentInstructions:
     type: array
     description: Payment instructions for funding the account

--- a/openapi/paths/internal_accounts/internal_accounts_{id}.yaml
+++ b/openapi/paths/internal_accounts/internal_accounts_{id}.yaml
@@ -90,6 +90,13 @@ patch:
                     name: United States Dollar
                     symbol: $
                     decimals: 2
+                totalBalance:
+                  amount: 12550
+                  currency:
+                    code: USD
+                    name: United States Dollar
+                    symbol: $
+                    decimals: 2
                 fundingPaymentInstructions: []
                 privateEnabled: true
                 createdAt: '2026-04-08T15:30:00Z'

--- a/openapi/webhooks/internal-account-status.yaml
+++ b/openapi/webhooks/internal-account-status.yaml
@@ -69,6 +69,13 @@ post:
                     name: United States Dollar
                     symbol: $
                     decimals: 2
+                totalBalance:
+                  amount: 12500
+                  currency:
+                    code: USD
+                    name: United States Dollar
+                    symbol: $
+                    decimals: 2
                 fundingPaymentInstructions: []
                 createdAt: '2025-08-01T10:00:00Z'
                 updatedAt: '2025-08-15T14:32:00Z'
@@ -84,6 +91,13 @@ post:
                 type: INTERNAL_FIAT
                 status: FROZEN
                 balance:
+                  amount: 10000
+                  currency:
+                    code: USD
+                    name: United States Dollar
+                    symbol: $
+                    decimals: 2
+                totalBalance:
                   amount: 10000
                   currency:
                     code: USD


### PR DESCRIPTION
## Summary
Adds a new **`totalBalance`** field to the Grid internal account schema, alongside the existing `balance`:

- **`balance`** — the balance available to spend, excluding pending and held funds
- **`totalBalance`** — the total balance, including pending and held funds

`totalBalance` is marked **required** in the response. Both fields now carry descriptions distinguishing them. Spec rebundled (`openapi.yaml` + `mintlify/openapi.yaml`).

## Rollout note
This marks `totalBalance` as a required response field in the public contract. The Grid API server (webdev) should be deployed returning `total_balance` **before** this spec change is published, so external clients regenerating from the spec never expect a field the server isn't yet returning. Server-side wiring is in the companion webdev PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)