### PR TITLE
Add high-limit payment rails to PaymentRail enum

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8472,18 +8472,26 @@ components:
       type: string
       enum:
         - ACH
+        - ACH_COLOMBIA
         - BANK_TRANSFER
+        - BRE_B
+        - CIPS
         - FAST
         - FASTER_PAYMENTS
         - FEDNOW
+        - INSTAPAY
         - MOBILE_MONEY
+        - NEFT
         - PAYNOW
+        - PESONET
         - PIX
+        - RTGS
         - RTP
         - SEPA
         - SEPA_INSTANT
         - SPEI
         - SWIFT
+        - UNIONPAY
         - UPI
         - WIRE
       description: The payment rail used for the transfer. Payment rails represent the underlying payment network or system used to move funds between accounts.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8472,18 +8472,26 @@ components:
       type: string
       enum:
         - ACH
+        - ACH_COLOMBIA
         - BANK_TRANSFER
+        - BRE_B
+        - CIPS
         - FAST
         - FASTER_PAYMENTS
         - FEDNOW
+        - INSTAPAY
         - MOBILE_MONEY
+        - NEFT
         - PAYNOW
+        - PESONET
         - PIX
+        - RTGS
         - RTP
         - SEPA
         - SEPA_INSTANT
         - SPEI
         - SWIFT
+        - UNIONPAY
         - UPI
         - WIRE
       description: The payment rail used for the transfer. Payment rails represent the underlying payment network or system used to move funds between accounts.

--- a/openapi/components/schemas/common/PaymentRail.yaml
+++ b/openapi/components/schemas/common/PaymentRail.yaml
@@ -1,18 +1,26 @@
 type: string
 enum:
   - ACH
+  - ACH_COLOMBIA
   - BANK_TRANSFER
+  - BRE_B
+  - CIPS
   - FAST
   - FASTER_PAYMENTS
   - FEDNOW
+  - INSTAPAY
   - MOBILE_MONEY
+  - NEFT
   - PAYNOW
+  - PESONET
   - PIX
+  - RTGS
   - RTP
   - SEPA
   - SEPA_INSTANT
   - SPEI
   - SWIFT
+  - UNIONPAY
   - UPI
   - WIRE
 description: >-


### PR DESCRIPTION
## Summary

Adds 8 new payment rail enum values to `components.schemas.PaymentRail`, keeping the existing alphabetical ordering and formatting:

- `ACH_COLOMBIA`
- `BRE_B`
- `CIPS`
- `INSTAPAY`
- `NEFT`
- `PESONET`
- `RTGS`
- `UNIONPAY`

The source enum (`openapi/components/schemas/common/PaymentRail.yaml`) was edited and the spec rebundled via `make build`, regenerating `openapi.yaml` and `mintlify/openapi.yaml` so the repo stays internally consistent. No other changes — the `payment_rail` field on `AccountDestination` already references this shared enum, so it picks up the new values automatically.

## Why

This keeps the spec in parity with **lightsparkdev/webdev#28108** ("[M0.6] support explicit rail selection in Grid quote endpoint"), which hand-added these 8 `PaymentRail` values to webdev's vendored mirror of this spec.

## ⚠️ Merge-order requirement

This must merge **before (or in lockstep with)** webdev#28108. webdev re-syncs its vendored copy from this repo (via `grid-api/update_schema.sh`, which clones this repo as the source of truth). If webdev re-syncs before these values land upstream, the next sync would silently drop the hand-added rails and break webdev's typecheck.

https://claude.ai/code/session_01KtztB3MumSMo7V4qZpioew

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtztB3MumSMo7V4qZpioew)_