### PR TITLE
Rename card status `PENDING_ISSUE` → `PROCESSING`

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -6326,7 +6326,7 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        New cards start in `state: "PENDING_ISSUE"` while the card issuer provisions the card. The `card.state_change` webhook fires on the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
       operationId: createCard
       tags:
         - Cards
@@ -7812,7 +7812,7 @@ webhooks:
     post:
       summary: Card state change
       description: |
-        Webhook that is called when a card's lifecycle state changes. Fires on `PENDING_ISSUE → ACTIVE`, on `PENDING_ISSUE → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
+        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
 
         This endpoint should be implemented by clients of the Grid API.
 
@@ -7839,7 +7839,7 @@ webhooks:
               $ref: '#/components/schemas/CardStateChangeWebhook'
             examples:
               activated:
-                summary: Card transitioned from PENDING_ISSUE to ACTIVE
+                summary: Card transitioned from PROCESSING to ACTIVE
                 value:
                   id: Webhook:019542f5-b3e7-1d02-0000-000000000020
                   type: CARD.STATE_CHANGE
@@ -18442,7 +18442,7 @@ components:
       type: string
       enum:
         - PENDING_KYC
-        - PENDING_ISSUE
+        - PROCESSING
         - ACTIVE
         - FROZEN
         - CLOSED
@@ -18452,7 +18452,7 @@ components:
         | State | Description |
         |-------|-------------|
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-        | `PENDING_ISSUE` | The card has been requested and is being provisioned with the issuer. |
+        | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
         | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |
@@ -18469,7 +18469,7 @@ components:
 
         | Reason | Description |
         |--------|-------------|
-        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PENDING_ISSUE`. |
+        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
         | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
         | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |
     CardBrand:

--- a/mintlify/snippets/cards/implementation-overview.mdx
+++ b/mintlify/snippets/cards/implementation-overview.mdx
@@ -46,7 +46,7 @@ balance before approving each auth, so:
 ## Issuing and lifecycle
 
 Issuance is a single `POST /cards` call. New cards start in
-`PENDING_ISSUE` while the issuer provisions them and transition to
+`PROCESSING` while the issuer provisions them and transition to
 `ACTIVE` automatically — you observe both transitions via the
 `CARD.STATE_CHANGE` webhook. Day-to-day operational changes are:
 

--- a/mintlify/snippets/cards/intro.mdx
+++ b/mintlify/snippets/cards/intro.mdx
@@ -25,7 +25,7 @@ A card moves through five states:
 | State | Meaning |
 |-------|---------|
 | `PENDING_KYC` | Cardholder has not finished KYC; the card cannot transact yet. |
-| `PENDING_ISSUE` | Card has been requested and is being provisioned with the issuer. |
+| `PROCESSING` | Card has been requested and is being provisioned with the issuer. |
 | `ACTIVE` | Card is live and can authorize transactions. |
 | `FROZEN` | Card is temporarily disabled. New authorizations are declined; in-flight settlements continue. |
 | `CLOSED` | Card is permanently closed. Terminal, irreversible. |

--- a/mintlify/snippets/cards/issuing-cards.mdx
+++ b/mintlify/snippets/cards/issuing-cards.mdx
@@ -32,7 +32,7 @@ one currency.
 ## The lifecycle
 
 ```text
-PENDING_ISSUE ──► ACTIVE ──► FROZEN ──► ACTIVE ──► CLOSED
+PROCESSING    ──► ACTIVE ──► FROZEN ──► ACTIVE ──► CLOSED
        │             │                              ▲
        │             └──────────────────────────────┘
        │
@@ -41,7 +41,7 @@ PENDING_ISSUE ──► ACTIVE ──► FROZEN ──► ACTIVE ──► CLOSE
 
 | State | When you see it |
 |-------|-----------------|
-| `PENDING_ISSUE` | Returned synchronously from `POST /cards`. The card cannot transact yet. |
+| `PROCESSING` | Returned synchronously from `POST /cards`. The card cannot transact yet. |
 | `ACTIVE` | Issuer provisioned the card. Reached via `CARD.STATE_CHANGE` webhook. |
 | `FROZEN` | You called `PATCH /cards/{id}` with `state: "FROZEN"`. |
 | `CLOSED` | You called `PATCH /cards/{id}` with `state: "CLOSED"` (or the issuer rejected provisioning). Terminal. |
@@ -51,7 +51,7 @@ issuance is gated on KYC up front.
 
 ## After issuance
 
-`POST /cards` returns immediately with `state: "PENDING_ISSUE"`. The
+`POST /cards` returns immediately with `state: "PROCESSING"`. The
 issuer provisions the card asynchronously; on success a
 `CARD.STATE_CHANGE` webhook fires with the activated `Card` resource
 including the populated `last4`, `expMonth`, `expYear`, and

--- a/mintlify/snippets/cards/quickstart.mdx
+++ b/mintlify/snippets/cards/quickstart.mdx
@@ -49,7 +49,7 @@ curl -X POST "$GRID_BASE_URL/cards" \
   }'
 ```
 
-The card comes back in `state: "PENDING_ISSUE"` while the issuer
+The card comes back in `state: "PROCESSING"` while the issuer
 provisions it. In Sandbox, activation is near-instant for any
 `platformCardId` whose last three characters aren't a magic suffix —
 see the [Sandbox testing guide](/cards/platform-tools/sandbox-testing)

--- a/mintlify/snippets/cards/sandbox-testing.mdx
+++ b/mintlify/snippets/cards/sandbox-testing.mdx
@@ -20,7 +20,7 @@ The last three characters of `platformCardId` (or `cardholderId` when
 
 | Suffix | Behavior |
 |--------|----------|
-| `001` | Stays `PENDING_ISSUE` indefinitely (test the polling path) |
+| `001` | Stays `PROCESSING` indefinitely (test the polling path) |
 | `002` | Issuer provisioning rejected → `state: CLOSED`, `stateReason: "ISSUER_REJECTED"` |
 | `005` | Delayed activation (~30s) before the `CARD.STATE_CHANGE` webhook fires |
 | any other | Instant activation → `state: ACTIVE`, `last4` deterministic from the suffix |

--- a/mintlify/snippets/cards/webhooks.mdx
+++ b/mintlify/snippets/cards/webhooks.mdx
@@ -12,7 +12,7 @@ extends the Transaction model with a card destination type).
 
 | Type | Fires on |
 |------|----------|
-| `CARD.STATE_CHANGE` | `PENDING_ISSUE → ACTIVE`, `→ CLOSED (ISSUER_REJECTED)`, and every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition. |
+| `CARD.STATE_CHANGE` | `PROCESSING → ACTIVE`, `→ CLOSED (ISSUER_REJECTED)`, and every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition. |
 | `CARD.FUNDING_SOURCE_CHANGE` | Whenever `PATCH /cards/{id}` updates the `fundingSources` array. |
 
 All three carry the standard envelope:
@@ -60,7 +60,7 @@ activation after issuance:
 
 Common branches to handle in your consumer:
 
-- `state: "ACTIVE"` after `PENDING_ISSUE` — the card is live; surface
+- `state: "ACTIVE"` after `PROCESSING` — the card is live; surface
   `panEmbedUrl` to the cardholder.
 - `state: "CLOSED"`, `stateReason: "ISSUER_REJECTED"` — the issuer
   rejected provisioning; offer to issue a new card.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6326,7 +6326,7 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        New cards start in `state: "PENDING_ISSUE"` while the card issuer provisions the card. The `card.state_change` webhook fires on the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
       operationId: createCard
       tags:
         - Cards
@@ -7812,7 +7812,7 @@ webhooks:
     post:
       summary: Card state change
       description: |
-        Webhook that is called when a card's lifecycle state changes. Fires on `PENDING_ISSUE → ACTIVE`, on `PENDING_ISSUE → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
+        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
 
         This endpoint should be implemented by clients of the Grid API.
 
@@ -7839,7 +7839,7 @@ webhooks:
               $ref: '#/components/schemas/CardStateChangeWebhook'
             examples:
               activated:
-                summary: Card transitioned from PENDING_ISSUE to ACTIVE
+                summary: Card transitioned from PROCESSING to ACTIVE
                 value:
                   id: Webhook:019542f5-b3e7-1d02-0000-000000000020
                   type: CARD.STATE_CHANGE
@@ -18442,7 +18442,7 @@ components:
       type: string
       enum:
         - PENDING_KYC
-        - PENDING_ISSUE
+        - PROCESSING
         - ACTIVE
         - FROZEN
         - CLOSED
@@ -18452,7 +18452,7 @@ components:
         | State | Description |
         |-------|-------------|
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-        | `PENDING_ISSUE` | The card has been requested and is being provisioned with the issuer. |
+        | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
         | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |
@@ -18469,7 +18469,7 @@ components:
 
         | Reason | Description |
         |--------|-------------|
-        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PENDING_ISSUE`. |
+        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
         | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
         | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |
     CardBrand:

--- a/openapi/components/schemas/cards/CardState.yaml
+++ b/openapi/components/schemas/cards/CardState.yaml
@@ -1,7 +1,7 @@
 type: string
 enum:
   - PENDING_KYC
-  - PENDING_ISSUE
+  - PROCESSING
   - ACTIVE
   - FROZEN
   - CLOSED
@@ -11,7 +11,7 @@ description: |
   | State | Description |
   |-------|-------------|
   | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-  | `PENDING_ISSUE` | The card has been requested and is being provisioned with the issuer. |
+  | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
   | `ACTIVE` | The card is live and can authorize transactions. |
   | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
   | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |

--- a/openapi/components/schemas/cards/CardStateReason.yaml
+++ b/openapi/components/schemas/cards/CardStateReason.yaml
@@ -10,6 +10,6 @@ description: |
 
   | Reason | Description |
   |--------|-------------|
-  | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PENDING_ISSUE`. |
+  | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
   | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
   | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |

--- a/openapi/paths/cards/cards.yaml
+++ b/openapi/paths/cards/cards.yaml
@@ -7,7 +7,7 @@ post:
     with `CARDHOLDER_KYC_NOT_APPROVED`.
 
 
-    New cards start in `state: "PENDING_ISSUE"` while the card issuer
+    New cards start in `state: "PROCESSING"` while the card issuer
     provisions the card. The `card.state_change` webhook fires on the
     transition to `ACTIVE` (or to `CLOSED` with `stateReason:
     "ISSUER_REJECTED"` if provisioning fails).

--- a/openapi/webhooks/card-state-change.yaml
+++ b/openapi/webhooks/card-state-change.yaml
@@ -2,7 +2,7 @@ post:
   summary: Card state change
   description: >
     Webhook that is called when a card's lifecycle state changes. Fires on
-    `PENDING_ISSUE → ACTIVE`, on `PENDING_ISSUE → CLOSED (ISSUER_REJECTED)`
+    `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)`
     when issuer provisioning fails, and on every subsequent
     `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
 
@@ -42,7 +42,7 @@ post:
           $ref: ../components/schemas/webhooks/CardStateChangeWebhook.yaml
         examples:
           activated:
-            summary: Card transitioned from PENDING_ISSUE to ACTIVE
+            summary: Card transitioned from PROCESSING to ACTIVE
             value:
               id: Webhook:019542f5-b3e7-1d02-0000-000000000020
               type: CARD.STATE_CHANGE


### PR DESCRIPTION
## Summary

Renames the Grid API card lifecycle state `PENDING_ISSUE` to `PROCESSING`.

Per the [Slack thread](https://lightsparkgroup.slack.com/archives/C0B21R3219Q/p1781643588222029), the `PENDING_*` states should consistently mean *waiting on user/platform action*, while `PROCESSING` means *Grid (or the issuer) is doing work* — matching the convention already used by the **quotes** and **transactions** resources. `PENDING_ISSUE` (card being provisioned by the issuer) is Grid-side work, so it becomes `PROCESSING`. This also makes room for Dhruv's upcoming `PENDING_AUTH` (delegated-auth setup pending on user+platform).

`PENDING_KYC` is intentionally unchanged — it waits on the cardholder.

## Changes

OpenAPI source (`openapi/`):
- `components/schemas/cards/CardState.yaml` — enum value + description table
- `components/schemas/cards/CardStateReason.yaml` — `ISSUER_REJECTED` description reference
- `paths/cards/cards.yaml` — `POST /cards` description
- `webhooks/card-state-change.yaml` — webhook description + example summary

Mintlify card doc snippets (`mintlify/snippets/cards/`): `intro`, `quickstart`, `issuing-cards` (incl. lifecycle diagram), `implementation-overview`, `webhooks`, `sandbox-testing`.

Regenerated bundles via `make build`: `openapi.yaml`, `mintlify/openapi.yaml`.

## Note: breaking change & follow-ups

This is a breaking change to the public `CardState` enum (affects `Card.state`, the `CARD.STATE_CHANGE` webhook, and the `GET /cards?state=` filter). It's safe to land as a clean rename rather than a dual-value migration because the API surface is early-stage and **no backend currently emits the `PENDING_ISSUE` string** — sparkcore's internal `CardStatus` enum is `ACTIVE/INACTIVE/SUSPENDED/CLOSED` and the public `CardState` values aren't produced yet.

Follow-up (separate repo, not run here — needs the custom OpenAPI generator toolchain): regenerate the Python SDK in `webdev/grid-api` via `update_schema.sh` once this merges.

## Verification

- `make build` — bundles regenerate cleanly; bundle diff is exactly the 6 rename occurrences, no reformatting.
- `make lint` — **0 errors** (pre-existing warnings/infos on unrelated beneficiary schemas only).
- `grep -rn PENDING_ISSUE` across the repo returns nothing.

---
🤖 [inverted-obsidian](https://zeus.dev.dev.sparkinfra.net/#/arc?id=inverted-obsidian)[(#1)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=inverted-obsidian) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/587