### PR TITLE
feat(samples/kotlin): support GRID_API_BASE_URL override

### DIFF
--- a/samples/kotlin/src/main/kotlin/com/grid/sample/Config.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/Config.kt
@@ -13,9 +13,16 @@ object Config {
     val apiClientSecret: String = getEnvVar("GRID_CLIENT_SECRET")
     val webhookPublicKey: String = getEnvVar("GRID_WEBHOOK_PUBKEY").replace("\\n", "\n")
 
+    // Optional override for the Grid API base URL (e.g. a dev/RC environment).
+    // When unset, the SDK uses its default (production) base URL.
+    val apiBaseUrl: String? = getEnvVarOrNull("GRID_API_BASE_URL")
+
     private fun getEnvVar(key: String): String =
+        getEnvVarOrNull(key)
+            ?: throw IllegalStateException("$key environment variable not set")
+
+    private fun getEnvVarOrNull(key: String): String? =
         System.getProperty(key)
             ?: dotenv[key]
             ?: System.getenv(key)
-            ?: throw IllegalStateException("$key environment variable not set")
 }

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/GridClientBuilder.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/GridClientBuilder.kt
@@ -8,6 +8,7 @@ object GridClientBuilder {
         LightsparkGridOkHttpClient.builder()
             .username(Config.apiTokenId)
             .password(Config.apiClientSecret)
+            .apply { Config.apiBaseUrl?.let { baseUrl(it) } }
             .build()
     }
 }


### PR DESCRIPTION
Add an optional GRID_API_BASE_URL environment variable so the Kotlin
sample can target a non-production Grid API base path (e.g. a dev/RC
environment). When unset, the SDK's default base URL is used.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>