### PR TITLE
fix(samples/kotlin): send customer email for USDB embedded wallets

### DIFF
--- a/samples/frontend/src/steps/CreateCustomer.tsx
+++ b/samples/frontend/src/steps/CreateCustomer.tsx
@@ -7,6 +7,9 @@ const DEFAULT_BODY = JSON.stringify({
   platformCustomerId: `cust_${Math.random().toString(36).slice(2, 10)}`,
   customerType: "INDIVIDUAL",
   fullName: "Jack Doe",
+  // Must be a real, deliverable address (the API validates the domain's MX records).
+  // Required when the platform supports USDB embedded wallets.
+  email: `jack.doe+${Math.random().toString(36).slice(2, 10)}@gmail.com`,
   birthDate: "1992-03-25",
   address: {
     line1: "123 Pine Street",

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
@@ -29,6 +29,7 @@ fun Route.customerRoutes() {
                     .apply {
                         json.optText("platformCustomerId")?.let { platformCustomerId(it) }
                         json.optText("fullName")?.let { fullName(it) }
+                        json.optText("email")?.let { email(it) }
                         json.optText("nationality")?.let { nationality(it) }
                         json.optText("birthDate")?.let { birthDate(LocalDate.parse(it)) }
                         json.get("address")?.takeIf { !it.isNull }?.let { addrNode ->


### PR DESCRIPTION
The platform requires a customer email when it supports USDB embedded
wallets. Wire `email` through the customer create builder and add it to
the sample's default request body. The Grid API validates domain
deliverability, so the default uses a real domain (gmail.com).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>