### PR TITLE
Fix Grid wallet playground API responses

### DIFF
--- a/components/grid-wallet-demo/src/data/apiCalls.ts
+++ b/components/grid-wallet-demo/src/data/apiCalls.ts
@@ -88,20 +88,43 @@ export function otpRequestCall(method: 'email_otp' | 'sms', contact?: string): A
   };
 }
 
-/** OTP verify — fires when the code is submitted. */
+function otpVerifyRequestBody(method: 'email_otp' | 'sms'): Record<string, unknown> {
+  return {
+    type: method === 'sms' ? 'SMS_OTP' : 'EMAIL_OTP',
+    encryptedOtpBundle: '<HPKE encrypted OTP bundle>',
+  };
+}
+
+/** OTP verify — first leg after the code is submitted. */
 export function otpVerifyCall(method: 'email_otp' | 'sms'): ApiCall {
   return {
     method: 'POST',
     path: `/auth/credentials/${AUTH_METHOD}/verify`,
     title: 'Verify OTP',
-    reqBody: {
-      type: method === 'sms' ? 'SMS_OTP' : 'EMAIL_OTP',
-      otp: '000000',
-      clientPublicKey: PUBKEY,
-    },
-    status: '200 OK',
-    note: 'Returns the HPKE-sealed session signing key + 15-min expiry.',
+    reqBody: otpVerifyRequestBody(method),
+    status: '202 Accepted',
+    note: 'Returns a verificationToken to sign with the TEK keypair.',
   };
+}
+
+/** OTP verify — signed retry that issues the auth session. */
+export function otpSessionIssueCall(method: 'email_otp' | 'sms'): ApiCall {
+  return {
+    method: 'POST',
+    path: `/auth/credentials/${AUTH_METHOD}/verify`,
+    title: 'Issue auth session',
+    headers: {
+      'Grid-Wallet-Signature': '<TEK signature>',
+      'Request-Id': '<requestId>',
+    },
+    reqBody: otpVerifyRequestBody(method),
+    status: '200 OK',
+    note: 'Signed retry issues the session; the TEK private key is the session signing key.',
+  };
+}
+
+export function otpVerifyCalls(method: 'email_otp' | 'sms'): ApiCall[] {
+  return [otpVerifyCall(method), otpSessionIssueCall(method)];
 }
 
 /** Passkey challenge — fires when the passkey ceremony starts. */
@@ -125,7 +148,7 @@ export function passkeyVerifyCall(): ApiCall {
     headers: { 'Request-Id': '<requestId>' },
     reqBody: { type: 'PASSKEY', assertion: '<webauthn assertion>' },
     status: '200 OK',
-    note: 'Assertion verified; session signing key returned.',
+    note: 'Assertion verified; encryptedSessionSigningKey returned.',
   };
 }
 
@@ -141,14 +164,14 @@ export function oauthVerifyCall(method: 'oauth' | 'apple'): ApiCall {
       clientPublicKey: PUBKEY,
     },
     status: '200 OK',
-    note: 'Fresh OIDC token verified; session signing key returned.',
+    note: 'Fresh OIDC token verified; encryptedSessionSigningKey returned.',
   };
 }
 
 /** Full sign-in sequence for a method — used for the fast-forward setup group. */
 export function signInCalls(method: AuthMethod, contact?: string): ApiCall[] {
-  if (method === 'email_otp') return [otpRequestCall('email_otp', contact), otpVerifyCall('email_otp')];
-  if (method === 'sms') return [otpRequestCall('sms', contact), otpVerifyCall('sms')];
+  if (method === 'email_otp') return [otpRequestCall('email_otp', contact), ...otpVerifyCalls('email_otp')];
+  if (method === 'sms') return [otpRequestCall('sms', contact), ...otpVerifyCalls('sms')];
   if (method === 'passkey') return [passkeyChallengeCall(), passkeyVerifyCall()];
   return [oauthVerifyCall(method)];
 }

--- a/components/grid-wallet-demo/src/hooks/useWalletDemoLogic.ts
+++ b/components/grid-wallet-demo/src/hooks/useWalletDemoLogic.ts
@@ -17,7 +17,7 @@ import {
   externalAccountCreateCall,
   oauthVerifyCall,
   otpRequestCall,
-  otpVerifyCall,
+  otpVerifyCalls,
   passkeyChallengeCall,
   passkeyVerifyCall,
   receivePaymentCalls,
@@ -309,7 +309,7 @@ export function useWalletDemoLogic() {
         // Code accepted → verify fires; then let the sheet's dismiss VISIBLY
         // finish (transient clears first so the auth screen is back underneath
         // the departing sheet) before the wallet flip starts the intro.
-        pushCalls([otpVerifyCall(m)], 'Sign in', gid);
+        pushCalls(otpVerifyCalls(m), 'Sign in', gid);
         setTransient(null);
         await sleep(400);
       } else if (m === 'passkey') {

--- a/components/grid-wallet-demo/src/lib/apiCodeFormat.tsx
+++ b/components/grid-wallet-demo/src/lib/apiCodeFormat.tsx
@@ -52,60 +52,323 @@ function isRealtimeFundingQuote(entry: ApiCall): boolean {
   return objectField(objectField(entry.reqBody, 'source'), 'sourceType') === 'REALTIME_FUNDING';
 }
 
+function isQuoteCreate(entry: ApiCall): boolean {
+  return entry.method === 'POST' && entry.path.endsWith('/quotes');
+}
+
+function isQuoteExecute(entry: ApiCall): boolean {
+  return entry.method === 'POST' && /\/quotes\/[^/]+\/execute$/.test(entry.path);
+}
+
+function quoteIdFromPath(path: string): string {
+  const match = path.match(/\/quotes\/([^/]+)\/execute$/);
+  return match?.[1] ?? 'Quote:019e8f49-3c8f-5246-0000-4d75f9a6d1d1';
+}
+
 function quoteFundingCurrency(entry: ApiCall): string {
   const currency = objectField(objectField(entry.reqBody, 'source'), 'currency');
   return typeof currency === 'string' ? currency : 'USD';
 }
 
-export function stubResponseBody(entry: ApiCall): Record<string, unknown> {
-  if (entry.path.includes('/verify')) {
+function currencyResponse(code: string): Record<string, unknown> {
+  const currencies: Record<string, Record<string, unknown>> = {
+    USDB: { code: 'USDB', name: 'USD Balance', symbol: '$', decimals: 6 },
+    USD: { code: 'USD', name: 'United States Dollar', symbol: '$', decimals: 2 },
+    EUR: { code: 'EUR', name: 'Euro', symbol: '\u20ac', decimals: 2 },
+    BTC: { code: 'BTC', name: 'Bitcoin', symbol: 'BTC', decimals: 8 },
+    USDC: { code: 'USDC', name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+  };
+  return currencies[code] ?? { code, name: code, symbol: code, decimals: 2 };
+}
+
+function quoteSource(entry: ApiCall): unknown {
+  return (
+    objectField(entry.reqBody, 'source') ?? {
+      sourceType: 'ACCOUNT',
+      accountId: 'InternalAccount:019e8f48-1135-438c-0000-8b9d28990463',
+    }
+  );
+}
+
+function quoteDestination(entry: ApiCall): unknown {
+  return (
+    objectField(entry.reqBody, 'destination') ?? {
+      destinationType: 'ACCOUNT',
+      accountId: 'ExternalAccount:019e8f4a-781d-7e0c-0000-a0d9afbf1314',
+      currency: 'USD',
+    }
+  );
+}
+
+function quoteCurrencyCodes(entry: ApiCall): { sending: string; receiving: string } {
+  const source = quoteSource(entry);
+  const destination = quoteDestination(entry);
+  const sourceType = objectField(source, 'sourceType');
+
+  if (sourceType === 'REALTIME_FUNDING') {
     return {
-      sessionSigningKey: '<HPKE sealed key>',
-      expiresAt: '2026-06-05T12:15:00Z',
+      sending: typeof objectField(source, 'currency') === 'string' ? (objectField(source, 'currency') as string) : 'USD',
+      receiving: 'USDB',
     };
   }
-  if (entry.path.endsWith('/quotes') && entry.method === 'POST') {
-    if (isRealtimeFundingQuote(entry)) {
-      const fundingCurrency = quoteFundingCurrency(entry);
+
+  const destinationCurrency = objectField(destination, 'currency');
+  return {
+    sending: 'USDB',
+    receiving: typeof destinationCurrency === 'string' ? destinationCurrency : 'USD',
+  };
+}
+
+function quoteAmount(entry: ApiCall): number {
+  const amount = objectField(entry.reqBody, 'lockedCurrencyAmount');
+  return typeof amount === 'number' ? amount : 20000;
+}
+
+function quotePaymentInstructions(entry: ApiCall): Record<string, unknown>[] {
+  if (isRealtimeFundingQuote(entry)) {
+    const fundingCurrency = quoteFundingCurrency(entry);
+    return [
+      {
+        instructionsNotes: 'Include the reference code in the transfer memo',
+        accountOrWalletInfo: {
+          accountType: `${fundingCurrency}_ACCOUNT`,
+          reference: 'PAYIN-8F49',
+          accountNumber: '9876543210',
+          routingNumber: '021000021',
+          bankName: 'JP Morgan Chase',
+          accountHolderName: 'Lightspark Payments FBO Customer',
+        },
+      },
+    ];
+  }
+
+  return [
+    {
+      accountOrWalletInfo: {
+        accountType: 'EMBEDDED_WALLET',
+        payloadToSign:
+          '{"type":"ACTIVITY_TYPE_SIGN_TRANSACTION_V2","timestampMs":"1770408000000","organizationId":"org_abc123","parameters":{"signWith":"wallet_abc123","unsignedTransaction":"<unsigned transaction>"},"generateAppProofs":true}',
+      },
+    },
+  ];
+}
+
+function quoteResponse(entry: ApiCall, status: 'PENDING' | 'PROCESSING'): Record<string, unknown> {
+  const { sending, receiving } = quoteCurrencyCodes(entry);
+  const amount = quoteAmount(entry);
+
+  return {
+    id: quoteIdFromPath(entry.path),
+    status,
+    createdAt: '2026-06-05T12:00:00Z',
+    expiresAt: '2026-06-05T12:05:00Z',
+    source: quoteSource(entry),
+    destination: quoteDestination(entry),
+    sendingCurrency: currencyResponse(sending),
+    receivingCurrency: currencyResponse(receiving),
+    totalSendingAmount: amount,
+    totalReceivingAmount: amount,
+    exchangeRate: 1,
+    feesIncluded: 0,
+    paymentInstructions: quotePaymentInstructions(entry),
+    transactionId: 'Transaction:019e8f49-3ca4-b78f-0000-1d3e9a411168',
+  };
+}
+
+function transactionIdFromPath(path: string): string {
+  const match = path.match(/\/transactions\/([^/?]+)/);
+  return match?.[1] ?? 'Transaction:019e8f49-3ca4-b78f-0000-1d3e9a411168';
+}
+
+function isTransactionGet(entry: ApiCall): boolean {
+  return entry.method === 'GET' && /\/transactions\/[^/?]+$/.test(entry.path);
+}
+
+function transactionResponse(entry: ApiCall): Record<string, unknown> {
+  return {
+    id: transactionIdFromPath(entry.path),
+    status: 'COMPLETED',
+    type: 'OUTGOING',
+    source: {
+      sourceType: 'ACCOUNT',
+      accountId: 'InternalAccount:019e8f48-1135-438c-0000-8b9d28990463',
+      currency: 'USDB',
+    },
+    destination: {
+      destinationType: 'ACCOUNT',
+      accountId: 'ExternalAccount:019e8f4a-781d-7e0c-0000-a0d9afbf1314',
+      currency: 'USD',
+    },
+    customerId: 'Customer:019e8f47-2a3d-1d02-0000-6b1f0c4e2a91',
+    platformCustomerId: 'customer_demo_001',
+    createdAt: '2026-06-05T12:00:05Z',
+    updatedAt: '2026-06-05T12:00:12Z',
+    settledAt: '2026-06-05T12:00:12Z',
+    quoteId: 'Quote:019e8f49-3c8f-5246-0000-4d75f9a6d1d1',
+    sentAmount: {
+      amount: 20000,
+      currency: currencyResponse('USDB'),
+    },
+    receivedAmount: {
+      amount: 20000,
+      currency: currencyResponse('USD'),
+    },
+    exchangeRate: 1,
+    fees: 0,
+  };
+}
+
+function authCredentialIdFromPath(path: string): string {
+  const match = path.match(/\/auth\/credentials\/([^/]+)\/challenge$/);
+  return match?.[1] ?? 'AuthMethod:019e8f48-11a8-0dca-0000-947363f18d5a';
+}
+
+function isAuthCredentialChallenge(entry: ApiCall): boolean {
+  return (
+    entry.method === 'POST' &&
+    /\/auth\/credentials\/[^/]+\/challenge$/.test(entry.path)
+  );
+}
+
+function isPasskeyChallenge(entry: ApiCall): boolean {
+  return typeof objectField(entry.reqBody, 'clientPublicKey') === 'string';
+}
+
+function isAuthCredentialVerify(entry: ApiCall): boolean {
+  return (
+    entry.method === 'POST' &&
+    /\/auth\/credentials\/[^/]+\/verify$/.test(entry.path)
+  );
+}
+
+function credentialVerifyType(entry: ApiCall): string {
+  const type = objectField(entry.reqBody, 'type');
+  return typeof type === 'string' ? type : 'OAUTH';
+}
+
+function isOtpVerifyType(type: string): boolean {
+  return type === 'EMAIL_OTP' || type === 'SMS_OTP';
+}
+
+function hasWalletSignature(entry: ApiCall): boolean {
+  return typeof entry.headers?.['Grid-Wallet-Signature'] === 'string';
+}
+
+function isExternalAccountCreate(entry: ApiCall): boolean {
+  return entry.method === 'POST' && entry.path === '/customers/external-accounts';
+}
+
+function isWalletAccountInfo(accountInfo: unknown): boolean {
+  const accountType = objectField(accountInfo, 'accountType');
+  return (
+    typeof objectField(accountInfo, 'address') === 'string' ||
+    (typeof accountType === 'string' && accountType.includes('WALLET'))
+  );
+}
+
+function externalAccountResponse(entry: ApiCall): Record<string, unknown> {
+  const accountInfo = objectField(entry.reqBody, 'accountInfo');
+  const platformAccountId =
+    objectField(entry.reqBody, 'platformAccountId') ?? objectField(accountInfo, 'platformAccountId');
+
+  return {
+    id: isWalletAccountInfo(accountInfo)
+      ? 'ExternalAccount:019e8f4a-9b2e-71f4-0000-3c5e7a2b9f08'
+      : 'ExternalAccount:019e8f4a-781d-7e0c-0000-a0d9afbf1314',
+    customerId: entry.reqBody?.customerId,
+    status: 'ACTIVE',
+    ...(typeof platformAccountId === 'string' ? { platformAccountId } : {}),
+    currency: entry.reqBody?.currency,
+    defaultUmaDepositAccount: false,
+    accountInfo,
+  };
+}
+
+function authSessionResponse(entry: ApiCall, includeEncryptedSessionKey: boolean): Record<string, unknown> {
+  const type = credentialVerifyType(entry);
+  const isPasskey = type === 'PASSKEY';
+  const isApple = objectField(entry.reqBody, 'oidcToken') === '<Apple id_token>';
+
+  return {
+    id: 'Session:019e8f48-11d2-7e48-0000-d9ac1f2a9f04',
+    accountId: 'InternalAccount:019e8f48-1135-438c-0000-8b9d28990463',
+    type,
+    ...(isPasskey
+      ? {
+          credentialId:
+            'KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew',
+        }
+      : {}),
+    nickname: isPasskey ? 'iPhone Face-ID' : isApple ? 'demo@privaterelay.appleid.com' : 'demo@lightspark.com',
+    createdAt: '2026-06-05T12:00:00Z',
+    updatedAt: '2026-06-05T12:00:00Z',
+    ...(includeEncryptedSessionKey
+      ? {
+          encryptedSessionSigningKey:
+            'w99a5xV6A75TfoAUkZn869fVyDYvgVsKrawMALZXmrauZd8hEv66EkPU1Z42CUaHESQjcA5bqd8dynTGBMLWB9ewtXWPEVbZvocB4Tw2K1vQVp7uwjf',
+        }
+      : {}),
+    expiresAt: '2026-06-05T12:15:00Z',
+  };
+}
+
+export function stubResponseBody(entry: ApiCall): Record<string, unknown> {
+  if (isExternalAccountCreate(entry)) {
+    return externalAccountResponse(entry);
+  }
+  if (isAuthCredentialChallenge(entry)) {
+    const id = authCredentialIdFromPath(entry.path);
+    const accountId = 'InternalAccount:019e8f48-1135-438c-0000-8b9d28990463';
+    const timestamps = {
+      createdAt: '2026-06-05T12:00:00Z',
+      updatedAt: '2026-06-05T12:00:00Z',
+    };
+
+    if (isPasskeyChallenge(entry)) {
       return {
-        id: 'Quote:019e8f49-3c8f-5246-0000-4d75f9a6d1d1',
-        status: 'PENDING',
-        source: entry.reqBody?.source,
-        destination: entry.reqBody?.destination,
-        sendingCurrency: { code: fundingCurrency, decimals: 2 },
-        receivingCurrency: { code: 'USDB', decimals: 6 },
-        paymentInstructions: [
-          {
-            instructionsNotes: 'Include the reference code in the transfer memo',
-            accountOrWalletInfo: {
-              accountType: `${fundingCurrency}_ACCOUNT`,
-              reference: 'PAYIN-8F49',
-              accountNumber: '9876543210',
-              routingNumber: '021000021',
-              bankName: 'JP Morgan Chase',
-              accountHolderName: 'Lightspark Payments FBO Customer',
-            },
-          },
-        ],
+        id,
+        accountId,
+        type: 'PASSKEY',
+        credentialId: 'KEbWNCc7NgaYnUyrNeFGX9_3Y-8oJ3KwzjnaiD1d1LVTxR7v3CaKfCz2Vy_g_MHSh7yJ8yL0Pxg6jo_o0hYiew',
+        nickname: 'iPhone Face-ID',
+        ...timestamps,
+        challenge: '6b35a4c41d9aa7a2a0e742f9f9e7a1c2d65a2db33a3fb748f6d4f1ce78d9a729',
+        requestId: 'Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21',
+        expiresAt: '2026-06-05T12:05:00Z',
       };
     }
+
     return {
-      id: 'Quote:019e8f49-3c8f-5246-0000-4d75f9a6d1d1',
-      status: 'PENDING',
-      payloadToSign: '<base64 payload>',
+      id,
+      accountId,
+      type: 'EMAIL_OTP',
+      nickname: 'demo@lightspark.com',
+      otpEncryptionTargetBundle:
+        '{"version":"v1.0.0","data":"7b227461726765745075626c6963...","dataSignature":"30450221...","enclaveQuorumPublic":"04a1b2c3..."}',
+      ...timestamps,
     };
   }
-  if (entry.path.includes('/execute')) {
-    return {
-      id: 'Transaction:019e8f49-3ca4-b78f-0000-1d3e9a411168',
-      status: 'PROCESSING',
-    };
+  if (isAuthCredentialVerify(entry)) {
+    const type = credentialVerifyType(entry);
+    if (isOtpVerifyType(type) && !hasWalletSignature(entry)) {
+      return {
+        type,
+        payloadToSign:
+          'eyJhbGciOiJFUzI1NiIsImtpZCI6InR1cm5rZXkifQ.eyJzdWIiOiJUWnk2NkVPa1RGYTd2NkpXZ0VxaVgyZGFXOENXc2pMQzVDVU9aRUlGY3hzIiwiaWF0IjoxNzc5NDA3MjIxLCJleHAiOjE3Nzk0MTA4MjF9.gKX9MWYGkw8Y55bgzsgrRftvUHFruIe8yu0w9Kpjp5qnrZnXcTV71WVoltGPsr015IY_oRTOkIFLHmiGNG9zBw',
+        requestId: 'Request:7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21',
+        expiresAt: '2026-06-05T12:05:00Z',
+      };
+    }
+    return authSessionResponse(entry, !isOtpVerifyType(type));
   }
-  if (entry.path.includes('/transactions/')) {
-    return {
-      id: 'Transaction:019e8f49-3ca4-b78f-0000-1d3e9a411168',
-      status: 'COMPLETED',
-    };
+  if (isQuoteCreate(entry)) {
+    return quoteResponse(entry, 'PENDING');
+  }
+  if (isQuoteExecute(entry)) {
+    return quoteResponse(entry, 'PROCESSING');
+  }
+  if (isTransactionGet(entry)) {
+    return transactionResponse(entry);
   }
   return { status: 'ok' };
 }


### PR DESCRIPTION
## Summary

Align the Grid Global Accounts playground API panel responses with the current OpenAPI shapes:

- Model auth credential challenge and verify responses instead of returning a generic sessionSigningKey body.
- Update OTP sign-in to use encryptedOtpBundle and show the two-step 202 Accepted challenge plus signed retry session issuance flow.
- Return ExternalAccount objects from POST /customers/external-accounts instead of a generic status response.
- Return Quote-shaped bodies for POST /quotes and POST /quotes/{quoteId}/execute, including paymentInstructions and transactionId.
- Return an OutgoingTransaction-shaped body from GET /transactions/{transactionId} with source, destination, customer ids, amounts, quoteId, rate, and fee fields.

## Testing

- npm run build
- Targeted tsx formatter checks for auth, external-account, quote execute, and transaction responses
- Verified local demo hot reload at http://localhost:4000/?embed=true&theme=dark

## Notes

npx tsc --noEmit still reports pre-existing unrelated type errors in AuroraWalletScreen.tsx, AppShell.tsx, and LiquidGlass.tsx.