### PR TITLE
Refine the wallet demo's mobile touch feel and passkey fallback

### DIFF
--- a/components/grid-wallet-demo/src/app/page.module.scss
+++ b/components/grid-wallet-demo/src/app/page.module.scss
@@ -17,7 +17,8 @@
 
 /* Mobile-only controls — hidden everywhere except the mobile breakpoint. */
 .exploreBtn,
-.backPill {
+.backPill,
+.exploreFade {
   display: none;
 }
 
@@ -113,6 +114,73 @@
     overflow: visible;
   }
 
+  /* Progressive blur tray behind the sticky CTA — content scrolls UP under the
+     button and frosts + fades into the panel bg, feathering out 40px above it.
+     pointer-events: none (inherited by the layers too) so the rows it overlaps
+     stay tappable. Same 3-layer ramp as the wallet scroll-edge, flipped to anchor
+     at the bottom; no corner clipping needed here (page-level, square). */
+  .exploreFade {
+    --explore-fade-bg: var(--surface-primary);
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    /* button bottom inset + button height (52px) + 40px feather above it */
+    height: calc(var(--spacing-xl) + 52px + 40px);
+    z-index: 99; /* just under the button (z 100) */
+    pointer-events: none;
+
+    :global([data-theme='dark']) & {
+      --explore-fade-bg: var(--color-gray-950);
+    }
+  }
+
+  /* Each layer ups the blur radius + is masked to a band, so the blur RAMPS from
+     full at the bottom to 0 up top (one uniform blur leaves a hard edge; the
+     crossfade removes it). The parent has no overflow/clip/isolation so the blur
+     samples the scrolling panel beneath. Knobs: blur px + mask stops. */
+  .fadeBlur {
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.01); /* hairline fill kicks compositing on */
+    -webkit-backdrop-filter: blur(var(--fade-blur));
+    backdrop-filter: blur(var(--fade-blur));
+    mask-image: var(--fade-mask);
+    -webkit-mask-image: var(--fade-mask);
+
+    :global([data-theme='dark']) & {
+      background: rgba(0, 0, 0, 0.01);
+    }
+  }
+
+  .fadeBlurStrong {
+    --fade-blur: 8px;
+    --fade-mask: linear-gradient(to top, #000 0%, #000 16%, transparent 46%);
+  }
+
+  .fadeBlurMid {
+    --fade-blur: 4px;
+    --fade-mask: linear-gradient(to top, #000 0%, #000 34%, transparent 68%);
+  }
+
+  .fadeBlurSoft {
+    --fade-blur: 2px;
+    --fade-mask: linear-gradient(to top, #000 0%, #000 56%, transparent 100%);
+  }
+
+  /* bg-color tint over the blur — solid panel bg behind/below the button, melting
+     to transparent 40px above so the blurred content shows through up top. */
+  .fadeTint {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to top,
+      var(--explore-fade-bg) 0%,
+      color-mix(in srgb, var(--explore-fade-bg) 50%, transparent) 50%,
+      transparent 100%
+    );
+  }
+
   /* Sticky primary CTA in Configure → Playground. */
   .exploreBtn {
     @include label;
@@ -133,15 +201,22 @@
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     box-shadow: var(--shadow-lg);
-    transition: transform 150ms ease;
+    transition: transform 150ms ease, background-color 150ms ease;
 
     :global([data-theme='dark']) & {
       background: var(--color-gray-050);
       color: var(--color-gray-950);
     }
 
+    // Tap fill — lifts the dark button toward charcoal on press (and the light
+    // button toward gray in dark mode); resets on release.
     &:active {
       transform: scale(0.98);
+      background: color-mix(in srgb, var(--color-gray-950) 88%, white);
+
+      :global([data-theme='dark']) & {
+        background: color-mix(in srgb, var(--color-gray-050) 90%, black);
+      }
     }
 
     svg path {
@@ -173,7 +248,13 @@
     white-space: nowrap;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-    transition: transform 200ms ease;
+    transition: transform 200ms ease, background-color 200ms ease;
+
+    /* Keep the translateX(-50%) centering while pressing in; fill a touch more solid. */
+    &:active {
+      transform: translateX(-50%) scale(0.98);
+      background: color-mix(in srgb, var(--surface-primary) 90%, transparent);
+    }
 
     svg path {
       vector-effect: non-scaling-stroke;
@@ -187,6 +268,10 @@
   /* Show the right control for the active view. */
   .layout[data-mobile-view='configure'] .exploreBtn {
     display: flex;
+  }
+
+  .layout[data-mobile-view='configure'] .exploreFade {
+    display: block;
   }
 
   .layout[data-mobile-view='playground'] .backPill {

--- a/components/grid-wallet-demo/src/app/page.tsx
+++ b/components/grid-wallet-demo/src/app/page.tsx
@@ -161,6 +161,13 @@ export default function Page() {
       </div>
 
       {/* Mobile-only controls (hidden on desktop via CSS). */}
+      {/* Progressive blur tray behind the sticky CTA (configure view). */}
+      <div className={styles.exploreFade} aria-hidden>
+        <div className={clsx(styles.fadeBlur, styles.fadeBlurStrong)} />
+        <div className={clsx(styles.fadeBlur, styles.fadeBlurMid)} />
+        <div className={clsx(styles.fadeBlur, styles.fadeBlurSoft)} />
+        <div className={styles.fadeTint} />
+      </div>
       <button type="button" className={styles.exploreBtn} onClick={goPlayground}>
         Explore playground
         <IconArrowRight size={16} />

--- a/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
@@ -51,7 +51,19 @@
     opacity: 0.55;
   }
 
-  &:not(:disabled):hover {
+  // Hover only with a real pointer — avoids the fill sticking after a tap on touch.
+  @media (hover: hover) {
+    &:not(:disabled):hover {
+      background: color-mix(in srgb, var(--surface-base) 98%, black);
+
+      :global([data-theme='dark']) & {
+        background: var(--color-alpha-white-04);
+      }
+    }
+  }
+
+  // Tap/press feedback — works on touch and resets on release (unlike :hover).
+  &:not(:disabled):active {
     background: color-mix(in srgb, var(--surface-base) 98%, black);
 
     :global([data-theme='dark']) & {

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
@@ -26,6 +26,12 @@
     height: 100dvh;
     border-right: none;
   }
+
+  // Hide the "Configure" header bar on mobile — the content has its own heading,
+  // so the panel goes straight to it (the body's 24px top padding matches the sides).
+  .panel .headerBar {
+    display: none;
+  }
 }
 
 .body {
@@ -39,10 +45,12 @@
     padding: $layout-laptop-content-padding;
   }
 
-  // Mobile: tighter 24px padding + room for the fixed "Explore playground"
-  // button. Declared after the base padding so it wins at equal specificity.
+  // Mobile: tighter 24px padding (32px on top for breathing room under the navbar)
+  // + room for the fixed "Explore playground" button. Declared after the base
+  // padding so it wins at equal specificity.
   @media (max-width: $breakpoint-layout-mobile) {
     padding: var(--spacing-xl);
+    padding-top: var(--spacing-2xl);
     padding-bottom: 96px;
   }
 }
@@ -79,8 +87,10 @@
   cursor: pointer;
   transition: color 150ms ease;
 
-  &:hover:not(:disabled) {
-    color: var(--text-primary);
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      color: var(--text-primary);
+    }
   }
 
   &:disabled {

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.tsx
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.tsx
@@ -40,7 +40,11 @@ export function ConfigurePanel({
   // others can hook in here later.
   return (
     <aside className={styles.panel}>
-      <PanelHeader icon={<IconSettingsSliderHor size={20} />} title="Configure" />
+      <PanelHeader
+        icon={<IconSettingsSliderHor size={20} />}
+        title="Configure"
+        className={styles.headerBar}
+      />
       <div className={styles.body}>
         <div className={styles.content}>
           <PlaygroundIntro />

--- a/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
@@ -39,9 +39,21 @@
 .optionEnabled {
   cursor: pointer;
 
-  &:hover {
-    // Opaque equivalent of alpha-black-02 on surface-base — transparent tokens
-    // composite differently depending on parent bg (see use case/auth vs flow).
+  // Hover only with a real pointer — avoids the fill sticking after a tap on touch.
+  @media (hover: hover) {
+    &:hover {
+      // Opaque equivalent of alpha-black-02 on surface-base — transparent tokens
+      // composite differently depending on parent bg (see use case/auth vs flow).
+      background: color-mix(in srgb, var(--surface-base) 98%, black);
+
+      :global([data-theme='dark']) & {
+        background: var(--color-alpha-white-04);
+      }
+    }
+  }
+
+  // Tap/press feedback — works on touch and resets on release (unlike :hover).
+  &:active {
     background: color-mix(in srgb, var(--surface-base) 98%, black);
 
     :global([data-theme='dark']) & {

--- a/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
+++ b/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
@@ -81,7 +81,21 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
     opacity: 0.55;
   }
 
-  &:not(:disabled):not(.cardSelected):hover {
+  // Hover only on devices with a real pointer — otherwise the fill sticks after a
+  // tap on touch (mobile emulates :hover until you tap elsewhere).
+  @media (hover: hover) {
+    &:not(:disabled):not(.cardSelected):hover {
+      background: color-mix(in srgb, var(--surface-base) 98%, black);
+
+      :global([data-theme='dark']) & {
+        background: var(--color-alpha-white-04);
+      }
+    }
+  }
+
+  // Tap/press feedback — applies on touch too and resets on release (unlike
+  // :hover, which sticks after a tap). Same fill as the hover state.
+  &:not(:disabled):not(.cardSelected):active {
     background: color-mix(in srgb, var(--surface-base) 98%, black);
 
     :global([data-theme='dark']) & {
@@ -182,12 +196,15 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
     filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.35));
   }
 
-  .card:not(:disabled):hover & {
-    transform: scale(1.05);
+  @media (hover: hover) {
+    .card:not(:disabled):hover & {
+      transform: scale(1.05);
+    }
   }
 
+  // Pop on press — visible on tap (touch, no hover baseline) and resets on release.
   .card:not(:disabled):active & {
-    transform: scale(1);
+    transform: scale(1.08);
     transition-duration: 120ms;
   }
 }

--- a/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.tsx
+++ b/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.tsx
@@ -91,6 +91,10 @@ export function UseCasePicker({ selected, onSelect }: UseCasePickerProps) {
   const tag = useAnimationControls();
   const overUnbuilt = useRef(false);
   const lastClient = useRef({ x: -1, y: -1 });
+  // Touch/pen have no hover model, so the cursor-following tag would get stranded
+  // on screen (revealed with nothing to dismiss it). Track whether the active
+  // pointer is a mouse and gate the follow + auto-reappear on it.
+  const pointerIsMouse = useRef(true);
   // While a tag is mid-fall, hold the live tag back so it doesn't reappear over
   // the falling one (the "pause").
   const suppressed = useRef(false);
@@ -121,6 +125,9 @@ export function UseCasePicker({ selected, onSelect }: UseCasePickerProps) {
   };
 
   const handleMove = (e: PointerEvent<HTMLDivElement>) => {
+    pointerIsMouse.current = e.pointerType === 'mouse';
+    // Touch/pen have no hover, so the follow tag would never get dismissed — skip it.
+    if (!pointerIsMouse.current) return;
     lastClient.current = { x: e.clientX, y: e.clientY };
     const over = Boolean((e.target as Element).closest?.('[data-unbuilt]'));
     if (over && !overUnbuilt.current && !suppressed.current) {
@@ -131,6 +138,12 @@ export function UseCasePicker({ selected, onSelect }: UseCasePickerProps) {
     }
     mx.set(e.clientX + TAG_OFFSET_X);
     my.set(e.clientY + TAG_OFFSET_Y);
+  };
+
+  // A tap can fire no pointermove, so capture the pointer kind on press too — the
+  // click handler uses it to run the auto-reappear on mouse only.
+  const handleDown = (e: PointerEvent<HTMLDivElement>) => {
+    pointerIsMouse.current = e.pointerType === 'mouse';
   };
 
   const handleLeave = () => {
@@ -148,6 +161,10 @@ export function UseCasePicker({ selected, onSelect }: UseCasePickerProps) {
     setFallers((list) => [...list, { id, x: fx, y: fy }]);
     overUnbuilt.current = false;
     tag.set(TAG_HIDDEN);
+    // Touch/pen: no hover, so the auto-reappear below would re-show the tag at the
+    // stale tap point with nothing to dismiss it (it sticks on screen). The flicked
+    // copy still falls; we just don't bring the live tag back.
+    if (!pointerIsMouse.current) return;
     // Pause: hold the live tag back until the flicked-off one has (mostly) fallen.
     suppressed.current = true;
     clearTimeout(suppressTimer.current);
@@ -166,7 +183,12 @@ export function UseCasePicker({ selected, onSelect }: UseCasePickerProps) {
 
   return (
     <LayoutGroup>
-      <div className={styles.group} onPointerMove={handleMove} onPointerLeave={handleLeave}>
+      <div
+        className={styles.group}
+        onPointerDown={handleDown}
+        onPointerMove={handleMove}
+        onPointerLeave={handleLeave}
+      >
         {USE_CASES.map((opt) => {
           const isSelected = selected === opt.id;
           return (

--- a/components/grid-wallet-demo/src/lib/auth.ts
+++ b/components/grid-wallet-demo/src/lib/auth.ts
@@ -189,11 +189,42 @@ export function applePopup(): Promise<string> {
   });
 }
 
+/** Safari/WebKit (desktop + every iOS browser) exposes the non-standard
+ *  GestureEvent; Blink (Chrome/Edge) and Gecko (Firefox) don't. */
+function isWebKit(): boolean {
+  if (typeof window === 'undefined') return false;
+  if ('GestureEvent' in window) return true;
+  const ua = navigator.userAgent || '';
+  return /iP(hone|ad|od)/.test(ua) || (/Mac/.test(ua) && navigator.maxTouchPoints > 1);
+}
+
+/** Running inside an iframe (the docs embed) vs. opened top-level. */
+function inIframe(): boolean {
+  return typeof window !== 'undefined' && window.self !== window.top;
+}
+
+/**
+ * Safari/WebKit can't run WebAuthn registration (`create()`) inside a
+ * cross-origin iframe and exposes no way to turn it on (the
+ * `publickey-credentials-create` permission token is ignored). In the embed we
+ * skip the real ceremony so the passkey flow doesn't dead-end — it falls through
+ * to the simulated Face ID gesture (the credential is throwaway anyway). Real
+ * Touch ID / passkeys still run on Chrome/Firefox in the embed, and on Safari
+ * opened top-level (standalone).
+ */
+function passkeyCreateBlocked(): boolean {
+  return isWebKit() && inIframe();
+}
+
 /**
  * Real WebAuthn prompt (Touch ID / Face ID) so passkey sign-in feels genuine.
- * The created credential isn't kept — it's purely the device gesture.
+ * The created credential isn't kept — it's purely the device gesture. On
+ * Safari/WebKit in the embed it can't run (see passkeyCreateBlocked), so we
+ * resolve and let the demo play the simulated Face ID instead.
  */
 export async function passkeyCeremony(): Promise<void> {
+  if (passkeyCreateBlocked()) return;
+
   if (!('credentials' in navigator) || !window.PublicKeyCredential) {
     throw new Error('This browser does not support passkeys (WebAuthn).');
   }

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -4214,3 +4214,22 @@ html:has(#wallet-demo-container) body {
   overflow: hidden !important;
 }
 
+/* Wallet demo mobile breadcrumb — hide text + chevron, keep hamburger, show
+   (0, 0, 0) on the right (matches the flow-builder tab). */
+html:has(#wallet-demo-container) #navbar button[class*="h-14"][class*="text-left"] > *:not(:first-child) {
+  display: none !important;
+}
+
+html:has(#wallet-demo-container) #navbar button[class*="h-14"][class*="text-left"]::after {
+  content: "(0, 0, 0)";
+  margin-left: auto;
+  font-family: "Suisse Intl Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px !important;
+  font-weight: 400;
+  color: var(--ls-gray-400);
+}
+
+html.dark:has(#wallet-demo-container) #navbar button[class*="h-14"][class*="text-left"]::after {
+  color: var(--ls-gray-700);
+}
+


### PR DESCRIPTION
## Summary

Mobile/touch polish for the Global Accounts Playground demo, plus a Safari passkey fallback. One commit on top of `main` (follows #580).

- **Progressive blur tray** behind the sticky "Explore playground" CTA (mobile Configure view), feathering out 40px above it.
- **Tap feedback on both mobile buttons** — the "Explore playground" CTA and the "← Configure" back pill get a press scale + background fill on `:active`.
- **Fixed sticky `:hover` on touch** — gated the tile / auth-row / flow-row / reset hovers behind `@media (hover: hover)`, and added `:active` feedback (fill + an icon pop on the tiles) that plays on tap and resets on release.
- **Fixed the stranded "Coming soon" tag** — on touch there's no hover, so the cursor-following tag no longer reveals or auto-reappears (it was sticking on screen).
- **Removed the "Configure" header bar on mobile** — the panel opens straight to the content with even 24px insets (32px on top).
- **Docs breadcrumb override** for the Playground tab — hides the breadcrumb text and shows "(0, 0, 0)" on the right, mirroring the flow-builder embed.
- **Safari/WebKit passkey fallback** — WebKit can't run WebAuthn `create()` in a cross-origin iframe, so in the embed the passkey step falls through to the simulated Face ID instead of dead-ending. Chrome/Firefox keep the real passkey; Safari opened standalone still gets the real one.

## Test plan

- [ ] Mobile (≤767px): Configure view has no "Configure" header, 32px top inset, and a blur tray behind the sticky CTA.
- [ ] Tap use-case tiles / auth rows / flow rows on a touch device — fill (+ tile icon pop) on press, resets on release, no stuck hover.
- [ ] Tap an unbuilt use-case tile on mobile — "Coming soon" flicks off and falls; nothing sticks.
- [ ] Both mobile buttons show a press scale + fill on tap.
- [ ] Passkey: real Touch ID on Chrome/Firefox; completes via simulated Face ID on Safari (desktop + iOS) in the embed.
- [ ] Playground docs tab on mobile shows "(0, 0, 0)" in the breadcrumb bar.
- [ ] Desktop/laptop unchanged.

Made with [Cursor](https://cursor.com)