### PR TITLE
docs: require embedding full End User Terms text in disclosures guide

### DIFF
--- a/mintlify/payouts-and-b2b/onboarding/disclosures.mdx
+++ b/mintlify/payouts-and-b2b/onboarding/disclosures.mdx
@@ -13,7 +13,7 @@ Exposing the End User Terms and collecting consent is a **launch precondition**.
 
 ## Include the End User Terms in your terms
 
-Copy Lightspark's End User Terms and append your own terms of service to them, so each end user accepts a single combined document:
+Copy Lightspark's End User Terms and append them to your own terms of service, so each end user accepts a single combined document. Including the URL to our End User Terms is not sufficient — you must embed the full text, available at:
 
 - **End User Terms:** [https://www.lightspark.com/legal/grid/enduserterms](https://www.lightspark.com/legal/grid/enduserterms)
 


### PR DESCRIPTION
Clarify that platforms append Lightspark's End User Terms to their own
terms of service and must embed the full text — linking to the URL is
not sufficient.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>