### PR TITLE
Drop "Grid" and the trailing period from the Playground intro copy

### DIFF
--- a/components/grid-wallet-demo/src/components/PlaygroundIntro/PlaygroundIntro.tsx
+++ b/components/grid-wallet-demo/src/components/PlaygroundIntro/PlaygroundIntro.tsx
@@ -18,7 +18,7 @@ export function PlaygroundIntro() {
         <span className={styles.titleSecondary}>Playground</span>
       </div>
       <p className={styles.body}>
-        Create a Grid Global Account and watch the exact API calls fire as you go.
+        Create a Global Account and watch the exact API calls fire as you go
       </p>
     </section>
   );


### PR DESCRIPTION
## Summary

Copy-only tweak to the Configure panel intro (left side of the Playground):

- "Create a **Grid** Global Account and watch the exact API calls fire as you go**.**"
- → "Create a Global Account and watch the exact API calls fire as you go"

Drops "Grid" and the trailing period. Page metadata (OG/description) intentionally left unchanged.

## Test plan

- [ ] Configure panel intro reads "Create a Global Account and watch the exact API calls fire as you go" (no period).

Made with [Cursor](https://cursor.com)