### PR TITLE
feat(samples/kotlin): add exchange-rates lookup flow

### DIFF
--- a/samples/frontend/src/App.tsx
+++ b/samples/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Sidebar, { FlowKey } from './components/Sidebar'
 import WebhookStream from './components/WebhookStream'
 import PayoutFlow from './flows/PayoutFlow'
 import UsdcPayoutFlow from './flows/UsdcPayoutFlow'
+import ExchangeRatesFlow from './flows/ExchangeRatesFlow'
 import EmbeddedWalletFlow from './flows/EmbeddedWalletFlow'
 
 const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
@@ -14,6 +15,10 @@ const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
     title: 'Send USDC to a Wallet',
     subtitle: 'Send USDC on-chain to an external wallet, funded with USD',
   },
+  'exchange-rates': {
+    title: 'Exchange Rates',
+    subtitle: 'Look up FX rates and fees for a corridor',
+  },
   'embedded-wallet': {
     title: 'Global Account',
     subtitle: 'Issue a self-custody dollar account and withdraw on behalf of a user',
@@ -21,7 +26,7 @@ const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
 }
 
 export default function App() {
-  const [activeFlow, setActiveFlow] = useState<FlowKey>('payout')
+  const [activeFlow, setActiveFlow] = useState<FlowKey>('exchange-rates')
   const meta = FLOW_META[activeFlow]
 
   return (
@@ -36,6 +41,7 @@ export default function App() {
           <h2 className="text-lg font-semibold mb-4">{meta.title}</h2>
           {activeFlow === 'payout' && <PayoutFlow key="payout" />}
           {activeFlow === 'usdc-payout' && <UsdcPayoutFlow key="usdc-payout" />}
+          {activeFlow === 'exchange-rates' && <ExchangeRatesFlow key="exchange-rates" />}
           {activeFlow === 'embedded-wallet' && <EmbeddedWalletFlow key="embedded-wallet" />}
         </main>
       </div>

--- a/samples/frontend/src/components/Sidebar.tsx
+++ b/samples/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-export type FlowKey = 'payout' | 'usdc-payout' | 'embedded-wallet'
+export type FlowKey = 'payout' | 'usdc-payout' | 'exchange-rates' | 'embedded-wallet'
 
 interface FlowEntry {
   key: FlowKey
@@ -7,6 +7,11 @@ interface FlowEntry {
 }
 
 const FLOWS: FlowEntry[] = [
+  {
+    key: 'exchange-rates',
+    label: 'Exchange Rates',
+    description: 'Look up FX rates and fees for a corridor',
+  },
   {
     key: 'payout',
     label: 'Payout to Bank Account',

--- a/samples/frontend/src/flows/ExchangeRatesFlow.tsx
+++ b/samples/frontend/src/flows/ExchangeRatesFlow.tsx
@@ -1,0 +1,9 @@
+import GetExchangeRate from '../steps/GetExchangeRate'
+
+export default function ExchangeRatesFlow() {
+  return (
+    <div className="rounded-lg border border-blue-600 bg-gray-900 p-4">
+      <GetExchangeRate />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/GetExchangeRate.tsx
+++ b/samples/frontend/src/steps/GetExchangeRate.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+import ResponsePanel from '../components/ResponsePanel'
+import { apiGet } from '../lib/api'
+
+const CURRENCIES = ['USD', 'USDC', 'MXN', 'BRL', 'INR', 'EUR', 'GBP', 'PHP', 'CAD']
+
+export default function GetExchangeRate() {
+  const [sourceCurrency, setSourceCurrency] = useState('USD')
+  const [destinationCurrency, setDestinationCurrency] = useState('USDC')
+  const [sendingAmount, setSendingAmount] = useState('100000')
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    try {
+      const params = new URLSearchParams({ sourceCurrency, destinationCurrency })
+      if (sendingAmount) params.set('sendingAmount', sendingAmount)
+      const data = await apiGet<Record<string, unknown>>(`/api/exchange-rates?${params.toString()}`)
+      setResponse(JSON.stringify(data, null, 2))
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const selectClass =
+    'w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-100 focus:outline-none focus:border-blue-500'
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-3">
+        Look up the cached FX rate, fees, and receiving amount for a currency corridor.
+      </p>
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div>
+          <label htmlFor="src-currency" className="block text-sm font-medium text-gray-300 mb-1">Source Currency</label>
+          <select id="src-currency" value={sourceCurrency} onChange={(e) => setSourceCurrency(e.target.value)} disabled={loading} className={selectClass}>
+            {CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="dst-currency" className="block text-sm font-medium text-gray-300 mb-1">Destination Currency</label>
+          <select id="dst-currency" value={destinationCurrency} onChange={(e) => setDestinationCurrency(e.target.value)} disabled={loading} className={selectClass}>
+            {CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="mb-3">
+        <label htmlFor="sending-amount" className="block text-sm font-medium text-gray-300 mb-1">Sending Amount</label>
+        <input
+          id="sending-amount"
+          type="number"
+          min="0"
+          value={sendingAmount}
+          onChange={(e) => setSendingAmount(e.target.value)}
+          disabled={loading}
+          className={selectClass}
+        />
+        <p className="text-xs text-gray-500 mt-1">In the smallest unit of the source currency (e.g. cents). 100000 = 1,000.00 USD.</p>
+      </div>
+      <button
+        onClick={submit}
+        disabled={loading}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Fetching...' : 'Get Exchange Rate'}
+      </button>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/Application.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/Application.kt
@@ -41,6 +41,7 @@ fun Application.module() {
         internalAccountRoutes()
         authCredentialRoutes()
         quoteRoutes()
+        exchangeRateRoutes()
         sandboxRoutes()
         webhookRoutes()
         sseRoutes()

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/ExchangeRates.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/ExchangeRates.kt
@@ -1,0 +1,52 @@
+package com.grid.sample.routes
+
+import com.lightspark.grid.models.exchangerates.ExchangeRateListParams
+import com.grid.sample.GridClientBuilder
+import com.grid.sample.JsonUtils
+import com.grid.sample.Log
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun Route.exchangeRateRoutes() {
+    route("/api/exchange-rates") {
+        get {
+            try {
+                val sourceCurrency = call.request.queryParameters["sourceCurrency"]
+                    ?: return@get call.respondText(
+                        """{"error": "sourceCurrency is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+                val destinationCurrency = call.request.queryParameters["destinationCurrency"]
+                val amount = call.request.queryParameters["sendingAmount"]?.toLongOrNull()
+                Log.incoming(
+                    "GET",
+                    "/api/exchange-rates?sourceCurrency=$sourceCurrency&destinationCurrency=$destinationCurrency&sendingAmount=$amount"
+                )
+
+                val params = ExchangeRateListParams.builder()
+                    .sourceCurrency(sourceCurrency)
+                    .apply {
+                        destinationCurrency?.let { addDestinationCurrency(it) }
+                        amount?.let { sendingAmount(it) }
+                    }
+                    .build()
+
+                Log.gridRequest("exchangeRates.list", "source=$sourceCurrency dest=$destinationCurrency amount=$amount")
+                val response = GridClientBuilder.client.exchangeRates().list(params)
+                val responseJson = JsonUtils.prettyPrint(response)
+                Log.gridResponse("exchangeRates.list", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("exchangeRates.list", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an "Exchange Rates" flow that looks up the cached FX rate, fees, and
receiving amount for a corridor. Backend: GET /api/exchange-rates proxies
to client.exchangeRates().list(). Frontend: a GetExchangeRate form
(source/destination currency + sending amount) and ExchangeRatesFlow,
wired into the sidebar.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>