### PR TITLE
docs(openapi): use fundingSourceId for delegated keys

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5044,17 +5044,17 @@ paths:
     post:
       summary: Create a delegated signing key
       description: |
-        Delegate Spark token-transaction signing authority for a card backed by an Embedded Wallet internal account to a Grid-custodied P-256 API key. Grid derives the wallet funding account from the card's funding sources, generates the keypair server-side, creates a non-root Turnkey user holding the public key, then a policy granting that user signing authority. The private key is custodied by Grid and never returned. Both activities must be authorized by the wallet owner, so creation is a three-leg signed-retry flow:
+        Delegate Spark token-transaction signing authority for a card funding source backed by an Embedded Wallet internal account to a Grid-custodied P-256 API key. Grid uses the requested card funding source to identify the wallet funding account, generates the keypair server-side, creates a non-root Turnkey user holding the public key, then a policy granting that user signing authority. The private key is custodied by Grid and never returned. Both activities must be authorized by the wallet owner, so creation is a three-leg signed-retry flow:
 
         1. Call `POST /auth/delegated-keys` with no signature headers. Grid generates the delegated keypair and the response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
 
-        2. Use the session API keypair of a verified credential on the card's Embedded Wallet funding account to build an API-key stamp over `payloadToSign`, then retry the same request with that full stamp as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The response is a second `202` with a new `payloadToSign`, `requestId`, and `expiresAt`.
+        2. Use the session API keypair of a verified credential on the card funding source's Embedded Wallet funding account to build an API-key stamp over `payloadToSign`, then retry the same request with that full stamp as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The response is a second `202` with a new `payloadToSign`, `requestId`, and `expiresAt`.
 
         3. Stamp the new `payloadToSign` with the same session keypair and retry once more with the new `Request-Id`. The signed retry returns `201` with the created `DelegatedKey` in `ACTIVE` status.
 
-        The same request body must be sent on all three legs. A flow abandoned after the second leg leaves the key in `PENDING` status: the delegated user exists but holds no policy, so it cannot sign. After activation, Grid uses the custodied key to authorize signing for that card's Embedded Wallet funding account in place of a session keypair; the platform never handles the key material.
+        The same request body must be sent on all three legs. A flow abandoned after the second leg leaves the key in `PENDING` status: the delegated user exists but holds no policy, so it cannot sign. After activation, Grid uses the custodied key to authorize signing for that card funding source's Embedded Wallet funding account in place of a session keypair; the platform never handles the key material.
 
-        Each card may have at most one non-revoked delegated key (`ACTIVE` or `PENDING`) for its Embedded Wallet funding account; revoke the existing key before creating a new one. A delegated key authorizes raw-payload signing for the wallet and cannot be scoped to amounts or recipients by Turnkey. Revoke it with `DELETE /auth/delegated-keys/{id}` when no longer needed.
+        Each card funding source may have at most one non-revoked delegated key (`ACTIVE` or `PENDING`) for its Embedded Wallet funding account; revoke the existing key before creating a new one. A delegated key authorizes raw-payload signing for the wallet and cannot be scoped to amounts or recipients by Turnkey. Revoke it with `DELETE /auth/delegated-keys/{id}` when no longer needed.
       operationId: createDelegatedKey
       tags:
         - Embedded Wallet Auth
@@ -5085,11 +5085,11 @@ paths:
               create:
                 summary: Delegate signing to a Grid-custodied key
                 value:
-                  cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+                  fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
                   nickname: Card payments key
       responses:
         '201':
-          description: Delegated key created and policy granted. The key is `ACTIVE` and Grid may use it to stamp card-payment quote executions for this card's Embedded Wallet funding account.
+          description: Delegated key created and policy granted. The key is `ACTIVE` and Grid may use it to stamp card-payment quote executions for this card funding source's Embedded Wallet funding account.
           content:
             application/json:
               schema:
@@ -5125,13 +5125,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error401'
         '404':
-          description: Card or Embedded Wallet funding account not found
+          description: Card funding source or Embedded Wallet funding account not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
         '409':
-          description: A non-revoked delegated key (`ACTIVE` or `PENDING`) already exists for this card. Revoke it with `DELETE /auth/delegated-keys/{id}` before creating a new one.
+          description: A non-revoked delegated key (`ACTIVE` or `PENDING`) already exists for this card funding source. Revoke it with `DELETE /auth/delegated-keys/{id}` before creating a new one.
           content:
             application/json:
               schema:
@@ -5144,7 +5144,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
     get:
       summary: List delegated signing keys
-      description: List delegated signing keys for an Embedded Wallet internal account, a card, or both, including `PENDING` keys (user created but policy leg never completed) and `REVOKED` keys. At least one of `accountId` or `cardId` must be supplied.
+      description: List delegated signing keys for an Embedded Wallet internal account, a card funding source, or both, including `PENDING` keys (user created but policy leg never completed) and `REVOKED` keys. At least one of `accountId` or `fundingSourceId` must be supplied.
       operationId: listDelegatedKeys
       tags:
         - Embedded Wallet Auth
@@ -5158,13 +5158,13 @@ paths:
           schema:
             type: string
           example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-        - name: cardId
+        - name: fundingSourceId
           in: query
           required: false
-          description: The id of the card whose delegated keys to list.
+          description: The id of the card funding source whose delegated keys to list.
           schema:
             type: string
-          example: Card:019542f5-b3e7-1d02-0000-000000000010
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
       responses:
         '200':
           description: Delegated keys matching the supplied filters. Returns an empty `data` array when no matching delegated keys are visible to the caller.
@@ -18717,13 +18717,13 @@ components:
       title: Delegated Key Create Request
       type: object
       required:
-        - cardId
+        - fundingSourceId
         - nickname
       properties:
-        cardId:
+        fundingSourceId:
           type: string
-          description: The id of the card that will use this delegated signing key. Grid derives the Embedded Wallet funding source from the card and creates the key for that card's wallet funding account.
-          example: Card:019542f5-b3e7-1d02-0000-000000000010
+          description: The id of the card funding source that will use this delegated signing key. Grid creates the key for that funding source's Embedded Wallet internal account.
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
         nickname:
           type: string
           minLength: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5044,17 +5044,17 @@ paths:
     post:
       summary: Create a delegated signing key
       description: |
-        Delegate Spark token-transaction signing authority for a card backed by an Embedded Wallet internal account to a Grid-custodied P-256 API key. Grid derives the wallet funding account from the card's funding sources, generates the keypair server-side, creates a non-root Turnkey user holding the public key, then a policy granting that user signing authority. The private key is custodied by Grid and never returned. Both activities must be authorized by the wallet owner, so creation is a three-leg signed-retry flow:
+        Delegate Spark token-transaction signing authority for a card funding source backed by an Embedded Wallet internal account to a Grid-custodied P-256 API key. Grid uses the requested card funding source to identify the wallet funding account, generates the keypair server-side, creates a non-root Turnkey user holding the public key, then a policy granting that user signing authority. The private key is custodied by Grid and never returned. Both activities must be authorized by the wallet owner, so creation is a three-leg signed-retry flow:
 
         1. Call `POST /auth/delegated-keys` with no signature headers. Grid generates the delegated keypair and the response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
 
-        2. Use the session API keypair of a verified credential on the card's Embedded Wallet funding account to build an API-key stamp over `payloadToSign`, then retry the same request with that full stamp as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The response is a second `202` with a new `payloadToSign`, `requestId`, and `expiresAt`.
+        2. Use the session API keypair of a verified credential on the card funding source's Embedded Wallet funding account to build an API-key stamp over `payloadToSign`, then retry the same request with that full stamp as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The response is a second `202` with a new `payloadToSign`, `requestId`, and `expiresAt`.
 
         3. Stamp the new `payloadToSign` with the same session keypair and retry once more with the new `Request-Id`. The signed retry returns `201` with the created `DelegatedKey` in `ACTIVE` status.
 
-        The same request body must be sent on all three legs. A flow abandoned after the second leg leaves the key in `PENDING` status: the delegated user exists but holds no policy, so it cannot sign. After activation, Grid uses the custodied key to authorize signing for that card's Embedded Wallet funding account in place of a session keypair; the platform never handles the key material.
+        The same request body must be sent on all three legs. A flow abandoned after the second leg leaves the key in `PENDING` status: the delegated user exists but holds no policy, so it cannot sign. After activation, Grid uses the custodied key to authorize signing for that card funding source's Embedded Wallet funding account in place of a session keypair; the platform never handles the key material.
 
-        Each card may have at most one non-revoked delegated key (`ACTIVE` or `PENDING`) for its Embedded Wallet funding account; revoke the existing key before creating a new one. A delegated key authorizes raw-payload signing for the wallet and cannot be scoped to amounts or recipients by Turnkey. Revoke it with `DELETE /auth/delegated-keys/{id}` when no longer needed.
+        Each card funding source may have at most one non-revoked delegated key (`ACTIVE` or `PENDING`) for its Embedded Wallet funding account; revoke the existing key before creating a new one. A delegated key authorizes raw-payload signing for the wallet and cannot be scoped to amounts or recipients by Turnkey. Revoke it with `DELETE /auth/delegated-keys/{id}` when no longer needed.
       operationId: createDelegatedKey
       tags:
         - Embedded Wallet Auth
@@ -5085,11 +5085,11 @@ paths:
               create:
                 summary: Delegate signing to a Grid-custodied key
                 value:
-                  cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+                  fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
                   nickname: Card payments key
       responses:
         '201':
-          description: Delegated key created and policy granted. The key is `ACTIVE` and Grid may use it to stamp card-payment quote executions for this card's Embedded Wallet funding account.
+          description: Delegated key created and policy granted. The key is `ACTIVE` and Grid may use it to stamp card-payment quote executions for this card funding source's Embedded Wallet funding account.
           content:
             application/json:
               schema:
@@ -5125,13 +5125,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error401'
         '404':
-          description: Card or Embedded Wallet funding account not found
+          description: Card funding source or Embedded Wallet funding account not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
         '409':
-          description: A non-revoked delegated key (`ACTIVE` or `PENDING`) already exists for this card. Revoke it with `DELETE /auth/delegated-keys/{id}` before creating a new one.
+          description: A non-revoked delegated key (`ACTIVE` or `PENDING`) already exists for this card funding source. Revoke it with `DELETE /auth/delegated-keys/{id}` before creating a new one.
           content:
             application/json:
               schema:
@@ -5144,7 +5144,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
     get:
       summary: List delegated signing keys
-      description: List delegated signing keys for an Embedded Wallet internal account, a card, or both, including `PENDING` keys (user created but policy leg never completed) and `REVOKED` keys. At least one of `accountId` or `cardId` must be supplied.
+      description: List delegated signing keys for an Embedded Wallet internal account, a card funding source, or both, including `PENDING` keys (user created but policy leg never completed) and `REVOKED` keys. At least one of `accountId` or `fundingSourceId` must be supplied.
       operationId: listDelegatedKeys
       tags:
         - Embedded Wallet Auth
@@ -5158,13 +5158,13 @@ paths:
           schema:
             type: string
           example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-        - name: cardId
+        - name: fundingSourceId
           in: query
           required: false
-          description: The id of the card whose delegated keys to list.
+          description: The id of the card funding source whose delegated keys to list.
           schema:
             type: string
-          example: Card:019542f5-b3e7-1d02-0000-000000000010
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
       responses:
         '200':
           description: Delegated keys matching the supplied filters. Returns an empty `data` array when no matching delegated keys are visible to the caller.
@@ -18717,13 +18717,13 @@ components:
       title: Delegated Key Create Request
       type: object
       required:
-        - cardId
+        - fundingSourceId
         - nickname
       properties:
-        cardId:
+        fundingSourceId:
           type: string
-          description: The id of the card that will use this delegated signing key. Grid derives the Embedded Wallet funding source from the card and creates the key for that card's wallet funding account.
-          example: Card:019542f5-b3e7-1d02-0000-000000000010
+          description: The id of the card funding source that will use this delegated signing key. Grid creates the key for that funding source's Embedded Wallet internal account.
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
         nickname:
           type: string
           minLength: 1

--- a/openapi/components/schemas/auth/DelegatedKeyCreateRequest.yaml
+++ b/openapi/components/schemas/auth/DelegatedKeyCreateRequest.yaml
@@ -1,16 +1,16 @@
 title: Delegated Key Create Request
 type: object
 required:
-  - cardId
+  - fundingSourceId
   - nickname
 properties:
-  cardId:
+  fundingSourceId:
     type: string
     description: >-
-      The id of the card that will use this delegated signing key. Grid
-      derives the Embedded Wallet funding source from the card and creates
-      the key for that card's wallet funding account.
-    example: Card:019542f5-b3e7-1d02-0000-000000000010
+      The id of the card funding source that will use this delegated signing
+      key. Grid creates the key for that funding source's Embedded Wallet
+      internal account.
+    example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
   nickname:
     type: string
     minLength: 1

--- a/openapi/paths/auth/auth_delegated-keys.yaml
+++ b/openapi/paths/auth/auth_delegated-keys.yaml
@@ -1,14 +1,14 @@
 post:
   summary: Create a delegated signing key
   description: >
-    Delegate Spark token-transaction signing authority for a card backed by
-    an Embedded Wallet internal account to a Grid-custodied P-256 API key.
-    Grid derives the wallet funding account from the card's funding sources,
-    generates the keypair server-side, creates a non-root Turnkey user
-    holding the public key, then a policy granting that user signing
-    authority. The private key is custodied by Grid and never returned. Both
-    activities must be authorized by the wallet owner, so creation is a
-    three-leg signed-retry flow:
+    Delegate Spark token-transaction signing authority for a card funding
+    source backed by an Embedded Wallet internal account to a
+    Grid-custodied P-256 API key. Grid uses the requested card funding
+    source to identify the wallet funding account, generates the keypair
+    server-side, creates a non-root Turnkey user holding the public key, then
+    a policy granting that user signing authority. The private key is
+    custodied by Grid and never returned. Both activities must be authorized
+    by the wallet owner, so creation is a three-leg signed-retry flow:
 
 
     1. Call `POST /auth/delegated-keys` with no signature headers. Grid
@@ -16,12 +16,12 @@ post:
     `payloadToSign`, `requestId`, and `expiresAt`.
 
 
-    2. Use the session API keypair of a verified credential on the card's
-    Embedded Wallet funding account to build an API-key stamp over
-    `payloadToSign`, then retry the same request with that full stamp as the
-    `Grid-Wallet-Signature` header and the `requestId` echoed back as the
-    `Request-Id` header. The response is a second `202` with a new
-    `payloadToSign`, `requestId`, and `expiresAt`.
+    2. Use the session API keypair of a verified credential on the card
+    funding source's Embedded Wallet funding account to build an API-key
+    stamp over `payloadToSign`, then retry the same request with that full
+    stamp as the `Grid-Wallet-Signature` header and the `requestId` echoed
+    back as the `Request-Id` header. The response is a second `202` with a
+    new `payloadToSign`, `requestId`, and `expiresAt`.
 
 
     3. Stamp the new `payloadToSign` with the same session keypair and retry
@@ -32,16 +32,16 @@ post:
     The same request body must be sent on all three legs. A flow abandoned
     after the second leg leaves the key in `PENDING` status: the delegated
     user exists but holds no policy, so it cannot sign. After activation,
-    Grid uses the custodied key to authorize signing for that card's
-    Embedded Wallet funding account in place of a session keypair; the
-    platform never handles the key material.
+    Grid uses the custodied key to authorize signing for that card funding
+    source's Embedded Wallet funding account in place of a session keypair;
+    the platform never handles the key material.
 
 
-    Each card may have at most one non-revoked delegated key (`ACTIVE` or
-    `PENDING`) for its Embedded Wallet funding account; revoke the existing
-    key before creating a new one. A delegated key authorizes raw-payload
-    signing for the wallet and cannot be scoped to amounts or recipients by
-    Turnkey. Revoke it with
+    Each card funding source may have at most one non-revoked delegated key
+    (`ACTIVE` or `PENDING`) for its Embedded Wallet funding account; revoke
+    the existing key before creating a new one. A delegated key authorizes
+    raw-payload signing for the wallet and cannot be scoped to amounts or
+    recipients by Turnkey. Revoke it with
     `DELETE /auth/delegated-keys/{id}` when no longer needed.
   operationId: createDelegatedKey
   tags:
@@ -81,14 +81,14 @@ post:
           create:
             summary: Delegate signing to a Grid-custodied key
             value:
-              cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+              fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
               nickname: Card payments key
   responses:
     '201':
       description: >-
         Delegated key created and policy granted. The key is `ACTIVE` and
         Grid may use it to stamp card-payment quote executions for this
-        card's Embedded Wallet funding account.
+        card funding source's Embedded Wallet funding account.
       content:
         application/json:
           schema:
@@ -130,7 +130,7 @@ post:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
     '404':
-      description: Card or Embedded Wallet funding account not found
+      description: Card funding source or Embedded Wallet funding account not found
       content:
         application/json:
           schema:
@@ -138,8 +138,8 @@ post:
     '409':
       description: >-
         A non-revoked delegated key (`ACTIVE` or `PENDING`) already exists
-        for this card. Revoke it with `DELETE /auth/delegated-keys/{id}`
-        before creating a new one.
+        for this card funding source. Revoke it with
+        `DELETE /auth/delegated-keys/{id}` before creating a new one.
       content:
         application/json:
           schema:
@@ -154,9 +154,9 @@ get:
   summary: List delegated signing keys
   description: >-
     List delegated signing keys for an Embedded Wallet internal account,
-    a card, or both, including `PENDING` keys (user created but policy leg
-    never completed) and `REVOKED` keys. At least one of `accountId` or
-    `cardId` must be supplied.
+    a card funding source, or both, including `PENDING` keys (user created
+    but policy leg never completed) and `REVOKED` keys. At least one of
+    `accountId` or `fundingSourceId` must be supplied.
   operationId: listDelegatedKeys
   tags:
     - Embedded Wallet Auth
@@ -170,13 +170,13 @@ get:
       schema:
         type: string
       example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-    - name: cardId
+    - name: fundingSourceId
       in: query
       required: false
-      description: The id of the card whose delegated keys to list.
+      description: The id of the card funding source whose delegated keys to list.
       schema:
         type: string
-      example: Card:019542f5-b3e7-1d02-0000-000000000010
+      example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
   responses:
     '200':
       description: >-


### PR DESCRIPTION
## Summary
- Change delegated-key create requests from `cardId` to `fundingSourceId`.
- Change delegated-key list filtering from `cardId` to `fundingSourceId`.
- Rebundle the generated OpenAPI specs, including the Mintlify copy.

## Validation
- `make build`
- `make lint`
