### PR TITLE
docs(openapi): keep pending auth on funding source

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -5100,6 +5100,7 @@ paths:
                   value:
                     id: DelegatedKey:019542f5-b3e7-1d02-0000-000000000021
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+                    fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
                     accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     publicKey: 02a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
                     nickname: Card payments key
@@ -6838,9 +6839,9 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for the card, the card remains in `state: "PENDING_AUTH"` and cannot transact.
+        If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
 
-        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. Cards that require delegated signing authorization move from `PENDING_AUTH` to `PROCESSING` after delegated-key creation is complete. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
       operationId: createCard
       tags:
         - Cards
@@ -6863,7 +6864,7 @@ paths:
                     - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
       responses:
         '201':
-          description: Card created successfully. Cards funded by an Embedded Wallet internal account may be returned in `PENDING_AUTH` until delegated signing authorization is completed with `POST /auth/delegated-keys`; otherwise newly-created cards start in `PROCESSING` while the issuer provisions them.
+          description: Card created successfully. Newly-created cards start in `PROCESSING` while the issuer provisions them. Cards funded by an Embedded Wallet internal account also require an active delegated key for that funding source before Authorization Decisioning can use it.
           content:
             application/json:
               schema:
@@ -18662,13 +18663,14 @@ components:
       required:
         - id
         - cardId
+        - fundingSourceId
         - accountId
         - publicKey
         - nickname
         - status
         - createdAt
         - updatedAt
-      description: A delegated signing key for a card backed by an Embedded Wallet internal account. Returned from `POST /auth/delegated-keys` (on activation), `GET /auth/delegated-keys` (list), and `GET /auth/delegated-keys/{id}`. The keypair is generated and custodied by Grid; the private key is never returned. While `ACTIVE`, Grid may use the key to authorize Spark token-transaction signing for the card's Embedded Wallet funding account in place of a session keypair. `publicKey` is informational metadata identifying the credential.
+      description: A delegated signing key for a card funding source backed by an Embedded Wallet internal account. Returned from `POST /auth/delegated-keys` (on activation), `GET /auth/delegated-keys` (list), and `GET /auth/delegated-keys/{id}`. The keypair is generated and custodied by Grid; the private key is never returned. While `ACTIVE`, Grid may use the key to authorize Spark token-transaction signing for the card funding source's Embedded Wallet funding account in place of a session keypair. `publicKey` is informational metadata identifying the credential.
       properties:
         id:
           type: string
@@ -18678,9 +18680,13 @@ components:
           type: string
           description: The card this key is delegated for.
           example: Card:019542f5-b3e7-1d02-0000-000000000010
+        fundingSourceId:
+          type: string
+          description: The card funding source this key is delegated for.
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
         accountId:
           type: string
-          description: The Embedded Wallet internal account this key is delegated for, derived from the card's funding sources.
+          description: The Embedded Wallet internal account this key is delegated for, derived from the card funding source.
           example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
         publicKey:
           type: string
@@ -19240,7 +19246,6 @@ components:
       type: string
       enum:
         - PENDING_KYC
-        - PENDING_AUTH
         - PROCESSING
         - ACTIVE
         - FROZEN
@@ -19251,7 +19256,6 @@ components:
         | State | Description |
         |-------|-------------|
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-        | `PENDING_AUTH` | The card has been created with an Embedded Wallet funding source, but the cardholder has not yet completed card-specific delegated signing authorization with `POST /auth/delegated-keys`. Cards in this state cannot transact. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5100,6 +5100,7 @@ paths:
                   value:
                     id: DelegatedKey:019542f5-b3e7-1d02-0000-000000000021
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+                    fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
                     accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     publicKey: 02a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
                     nickname: Card payments key
@@ -6838,9 +6839,9 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for the card, the card remains in `state: "PENDING_AUTH"` and cannot transact.
+        If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
 
-        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. Cards that require delegated signing authorization move from `PENDING_AUTH` to `PROCESSING` after delegated-key creation is complete. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
       operationId: createCard
       tags:
         - Cards
@@ -6863,7 +6864,7 @@ paths:
                     - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
       responses:
         '201':
-          description: Card created successfully. Cards funded by an Embedded Wallet internal account may be returned in `PENDING_AUTH` until delegated signing authorization is completed with `POST /auth/delegated-keys`; otherwise newly-created cards start in `PROCESSING` while the issuer provisions them.
+          description: Card created successfully. Newly-created cards start in `PROCESSING` while the issuer provisions them. Cards funded by an Embedded Wallet internal account also require an active delegated key for that funding source before Authorization Decisioning can use it.
           content:
             application/json:
               schema:
@@ -18662,13 +18663,14 @@ components:
       required:
         - id
         - cardId
+        - fundingSourceId
         - accountId
         - publicKey
         - nickname
         - status
         - createdAt
         - updatedAt
-      description: A delegated signing key for a card backed by an Embedded Wallet internal account. Returned from `POST /auth/delegated-keys` (on activation), `GET /auth/delegated-keys` (list), and `GET /auth/delegated-keys/{id}`. The keypair is generated and custodied by Grid; the private key is never returned. While `ACTIVE`, Grid may use the key to authorize Spark token-transaction signing for the card's Embedded Wallet funding account in place of a session keypair. `publicKey` is informational metadata identifying the credential.
+      description: A delegated signing key for a card funding source backed by an Embedded Wallet internal account. Returned from `POST /auth/delegated-keys` (on activation), `GET /auth/delegated-keys` (list), and `GET /auth/delegated-keys/{id}`. The keypair is generated and custodied by Grid; the private key is never returned. While `ACTIVE`, Grid may use the key to authorize Spark token-transaction signing for the card funding source's Embedded Wallet funding account in place of a session keypair. `publicKey` is informational metadata identifying the credential.
       properties:
         id:
           type: string
@@ -18678,9 +18680,13 @@ components:
           type: string
           description: The card this key is delegated for.
           example: Card:019542f5-b3e7-1d02-0000-000000000010
+        fundingSourceId:
+          type: string
+          description: The card funding source this key is delegated for.
+          example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
         accountId:
           type: string
-          description: The Embedded Wallet internal account this key is delegated for, derived from the card's funding sources.
+          description: The Embedded Wallet internal account this key is delegated for, derived from the card funding source.
           example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
         publicKey:
           type: string
@@ -19240,7 +19246,6 @@ components:
       type: string
       enum:
         - PENDING_KYC
-        - PENDING_AUTH
         - PROCESSING
         - ACTIVE
         - FROZEN
@@ -19251,7 +19256,6 @@ components:
         | State | Description |
         |-------|-------------|
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-        | `PENDING_AUTH` | The card has been created with an Embedded Wallet funding source, but the cardholder has not yet completed card-specific delegated signing authorization with `POST /auth/delegated-keys`. Cards in this state cannot transact. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |

--- a/openapi/components/schemas/auth/DelegatedKey.yaml
+++ b/openapi/components/schemas/auth/DelegatedKey.yaml
@@ -3,6 +3,7 @@ type: object
 required:
   - id
   - cardId
+  - fundingSourceId
   - accountId
   - publicKey
   - nickname
@@ -10,14 +11,14 @@ required:
   - createdAt
   - updatedAt
 description: >-
-  A delegated signing key for a card backed by an Embedded Wallet internal
-  account. Returned from `POST /auth/delegated-keys` (on activation),
+  A delegated signing key for a card funding source backed by an Embedded Wallet
+  internal account. Returned from `POST /auth/delegated-keys` (on activation),
   `GET /auth/delegated-keys` (list), and `GET /auth/delegated-keys/{id}`.
   The keypair is generated and custodied by Grid; the private key is never
   returned. While `ACTIVE`, Grid may use the key to authorize Spark
-  token-transaction signing for the card's Embedded Wallet funding account in
-  place of a session keypair. `publicKey` is informational metadata
-  identifying the credential.
+  token-transaction signing for the card funding source's Embedded Wallet
+  funding account in place of a session keypair. `publicKey` is informational
+  metadata identifying the credential.
 properties:
   id:
     type: string
@@ -27,11 +28,15 @@ properties:
     type: string
     description: The card this key is delegated for.
     example: Card:019542f5-b3e7-1d02-0000-000000000010
+  fundingSourceId:
+    type: string
+    description: The card funding source this key is delegated for.
+    example: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
   accountId:
     type: string
     description: >-
       The Embedded Wallet internal account this key is delegated for,
-      derived from the card's funding sources.
+      derived from the card funding source.
     example: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
   publicKey:
     type: string

--- a/openapi/components/schemas/cards/CardState.yaml
+++ b/openapi/components/schemas/cards/CardState.yaml
@@ -1,7 +1,6 @@
 type: string
 enum:
   - PENDING_KYC
-  - PENDING_AUTH
   - PROCESSING
   - ACTIVE
   - FROZEN
@@ -12,7 +11,6 @@ description: |
   | State | Description |
   |-------|-------------|
   | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
-  | `PENDING_AUTH` | The card has been created with an Embedded Wallet funding source, but the cardholder has not yet completed card-specific delegated signing authorization with `POST /auth/delegated-keys`. Cards in this state cannot transact. |
   | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
   | `ACTIVE` | The card is live and can authorize transactions. |
   | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |

--- a/openapi/paths/auth/auth_delegated-keys.yaml
+++ b/openapi/paths/auth/auth_delegated-keys.yaml
@@ -99,6 +99,7 @@ post:
               value:
                 id: DelegatedKey:019542f5-b3e7-1d02-0000-000000000021
                 cardId: Card:019542f5-b3e7-1d02-0000-000000000010
+                fundingSourceId: CardFundingSource:019542f5-b3e7-1d02-0000-000000000011
                 accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 publicKey: 02a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90
                 nickname: Card payments key

--- a/openapi/paths/cards/cards.yaml
+++ b/openapi/paths/cards/cards.yaml
@@ -9,17 +9,16 @@ post:
 
     If any funding source is an Embedded Wallet internal account, the
     cardholder must authorize Grid to sign Spark token transactions for that
-    card by completing the delegated-key creation flow with
-    `POST /auth/delegated-keys`. Until an active delegated key exists for the
-    card, the card remains in `state: "PENDING_AUTH"` and cannot transact.
+    card funding source by completing the delegated-key creation flow with
+    `POST /auth/delegated-keys`. Until an active delegated key exists for that
+    funding source, Authorization Decisioning cannot use it to fund card
+    transactions.
 
 
     New cards start in `state: "PROCESSING"` while the card issuer
-    provisions the card. Cards that require delegated signing authorization
-    move from `PENDING_AUTH` to `PROCESSING` after delegated-key creation is
-    complete. The `card.state_change` webhook fires on each state transition,
-    including the transition to `ACTIVE` (or to `CLOSED` with `stateReason:
-    "ISSUER_REJECTED"` if provisioning fails).
+    provisions the card. The `card.state_change` webhook fires on each state
+    transition, including the transition to `ACTIVE` (or to `CLOSED` with
+    `stateReason: "ISSUER_REJECTED"` if provisioning fails).
   operationId: createCard
   tags:
     - Cards
@@ -43,11 +42,10 @@ post:
   responses:
     '201':
       description: >-
-        Card created successfully. Cards funded by an Embedded Wallet internal
-        account may be returned in `PENDING_AUTH` until delegated signing
-        authorization is completed with `POST /auth/delegated-keys`; otherwise
-        newly-created cards start in `PROCESSING` while the issuer provisions
-        them.
+        Card created successfully. Newly-created cards start in `PROCESSING`
+        while the issuer provisions them. Cards funded by an Embedded Wallet
+        internal account also require an active delegated key for that funding
+        source before Authorization Decisioning can use it.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary
- remove card-level PENDING_AUTH from CardState
- describe embedded-wallet delegated authorization as a funding-source prerequisite
- include fundingSourceId in DelegatedKey responses/examples

## Validation
- npm run lint:openapi