### PR TITLE
feat: add TransactionFeeConfig schema (AT-5613)

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -101,6 +101,8 @@ resources:
       platform_config: '#/components/schemas/PlatformConfig'
       embedded_wallet_config: "#/components/schemas/EmbeddedWalletConfig"
       platform_config_update_request: '#/components/schemas/PlatformConfigUpdateRequest'
+      transaction_fee_config: '#/components/schemas/TransactionFeeConfig'
+      transaction_fee_event_type: '#/components/schemas/TransactionFeeEventType'
     methods:
       retrieve: get /config
       update: patch /config

--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -102,6 +102,7 @@ resources:
       embedded_wallet_config: "#/components/schemas/EmbeddedWalletConfig"
       platform_config_update_request: '#/components/schemas/PlatformConfigUpdateRequest'
       transaction_fee_config: '#/components/schemas/TransactionFeeConfig'
+      transaction_fee_config_input: '#/components/schemas/TransactionFeeConfigInput'
       transaction_fee_event_type: '#/components/schemas/TransactionFeeEventType'
     methods:
       retrieve: get /config

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8914,7 +8914,7 @@ components:
           $ref: '#/components/schemas/CurrencyAmount'
         isActive:
           type: boolean
-          description: Whether this row is currently active. Reads return only active rows unless explicitly filtered otherwise.
+          description: Whether this row is currently active. Reads return only active rows; inactive rows are never returned by this endpoint.
           readOnly: true
           example: true
     PlatformConfig:
@@ -9047,6 +9047,31 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    TransactionFeeConfigInput:
+      type: object
+      description: 'Write-side variant of a platform transaction fee config, used in the merge-by-key upsert on `PATCH /config`. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. The system-generated `id` and the derived `isActive` flag are read-only and are therefore omitted here.'
+      required:
+        - feeEventType
+        - sourceCurrency
+        - variableFeeBps
+        - fixedFee
+      properties:
+        feeEventType:
+          $ref: '#/components/schemas/TransactionFeeEventType'
+        sourceCurrency:
+          type: string
+          description: ISO 4217 (fiat) or ticker (crypto) code of the source-side currency this fee applies to. Cross-currency fees are charged in the sending side's currency.
+          example: USD
+        variableFeeBps:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+          description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
+          example: 30
+        fixedFee:
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
+          $ref: '#/components/schemas/CurrencyAmount'
     PlatformConfigUpdateRequest:
       type: object
       properties:
@@ -9070,7 +9095,7 @@ components:
         transactionFeeConfigs:
           type: array
           items:
-            $ref: '#/components/schemas/TransactionFeeConfig'
+            $ref: '#/components/schemas/TransactionFeeConfigInput'
           description: |
             Merge-by-key upsert of platform transaction fee configs. Each item is
             keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8886,10 +8886,12 @@ components:
       type: object
       description: 'Platform-collected transaction fee charged on top of corridor fees. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.'
       required:
+        - id
         - feeEventType
         - sourceCurrency
         - variableFeeBps
         - fixedFee
+        - isActive
       properties:
         id:
           type: string
@@ -9071,7 +9073,12 @@ components:
           example: 30
         fixedFee:
           description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
-          $ref: '#/components/schemas/CurrencyAmount'
+          allOf:
+            - $ref: '#/components/schemas/CurrencyAmount'
+            - type: object
+              properties:
+                amount:
+                  minimum: 0
     PlatformConfigUpdateRequest:
       type: object
       properties:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8910,7 +8910,7 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
           example: 30
         fixedFee:
-          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`.
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
           $ref: '#/components/schemas/CurrencyAmount'
         isActive:
           type: boolean

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8835,6 +8835,88 @@ components:
           maxLength: 512
           description: URL to a PNG logo for the OTP email. Resized to 340x124px.
           example: https://acme.com/logo.png
+    TransactionFeeEventType:
+      type: string
+      enum:
+        - CROSS_CURRENCY_TRANSACTION
+        - TRANSFER_OUT_TRANSACTION
+      description: |-
+        The kind of transaction this fee applies to.
+        - `CROSS_CURRENCY_TRANSACTION` — fee charged on a cross-currency Grid send
+          (source currency differs from destination currency).
+
+        - `TRANSFER_OUT_TRANSACTION` — fee charged on a Grid Transfer Out
+          operation.
+
+        Note: only `CROSS_CURRENCY_TRANSACTION` is accepted by `PATCH /config` today. Reads always return the full set, so configurations created by Lightspark operators (e.g. Transfer Out rows) are still visible.
+    Currency:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
+        name:
+          type: string
+          description: Full name of the currency
+          example: United States Dollar
+        symbol:
+          type: string
+          description: Symbol of the currency
+          example: $
+        decimals:
+          type: integer
+          description: Number of decimal places for the currency
+          minimum: 0
+          example: 2
+    CurrencyAmount:
+      type: object
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
+        currency:
+          $ref: '#/components/schemas/Currency'
+    TransactionFeeConfig:
+      type: object
+      description: 'Platform-collected transaction fee charged on top of corridor fees. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.'
+      required:
+        - feeEventType
+        - sourceCurrency
+        - variableFeeBps
+        - fixedFee
+      properties:
+        id:
+          type: string
+          description: System-generated unique identifier.
+          readOnly: true
+          example: GridPlatformTransactionFeeConfig:019ef5bf-a77e-93be-0000-479e9268bca9
+        feeEventType:
+          $ref: '#/components/schemas/TransactionFeeEventType'
+        sourceCurrency:
+          type: string
+          description: ISO 4217 (fiat) or ticker (crypto) code of the source-side currency this fee applies to. Cross-currency fees are charged in the sending side's currency.
+          example: USD
+        variableFeeBps:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+          description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
+          example: 30
+        fixedFee:
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`.
+          $ref: '#/components/schemas/CurrencyAmount'
+        isActive:
+          type: boolean
+          description: Whether this row is currently active. Reads return only active rows unless explicitly filtered otherwise.
+          readOnly: true
+          example: true
     PlatformConfig:
       type: object
       properties:
@@ -8876,6 +8958,15 @@ components:
             Embedded-wallet branding and OTP settings for this platform. Present
             only when the platform has configured embedded-wallet support;
             omitted otherwise.
+        transactionFeeConfigs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionFeeConfig'
+          description: |
+            Platform-collected transaction fees, keyed uniquely by
+            `(feeEventType, sourceCurrency)`. Returned in reads regardless of
+            `feeEventType` so that operator-created rows (e.g. Transfer Out) are
+            visible even before the corresponding write path is enabled.
         createdAt:
           type: string
           format: date-time
@@ -8976,6 +9067,18 @@ components:
             Fields omitted from the nested object are left unchanged. Omit this
             field at the top level to leave the embedded-wallet configuration
             unchanged entirely.
+        transactionFeeConfigs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionFeeConfig'
+          description: |
+            Merge-by-key upsert of platform transaction fee configs. Each item is
+            keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send
+            the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. Only
+            `feeEventType: CROSS_CURRENCY_TRANSACTION` and `sourceCurrency: USD`
+            are accepted by this endpoint today; other values return a 400 error.
+            Omit this field at the top level to leave all transaction fee configs
+            unchanged.
     Error400:
       type: object
       required:
@@ -9106,26 +9209,6 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
-    Currency:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-          example: USD
-        name:
-          type: string
-          description: Full name of the currency
-          example: United States Dollar
-        symbol:
-          type: string
-          description: Symbol of the currency
-          example: $
-        decimals:
-          type: integer
-          description: Number of decimal places for the currency
-          minimum: 0
-          example: 2
     PaymentRail:
       type: string
       enum:
@@ -10264,19 +10347,6 @@ components:
         - `CLOSED`: The account cannot send or receive payments. A customer can initiate the closing of an internal account, after which the account transitions to this status.
         - `FROZEN`: The account cannot send or receive payments. Grid may freeze an account in response to compliance or fraud signals; payments are blocked while the account remains frozen.
       example: ACTIVE
-    CurrencyAmount:
-      type: object
-      required:
-        - amount
-        - currency
-      properties:
-        amount:
-          type: integer
-          format: int64
-          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-          example: 12550
-        currency:
-          $ref: '#/components/schemas/Currency'
     PaymentAccountType:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8914,7 +8914,7 @@ components:
           $ref: '#/components/schemas/CurrencyAmount'
         isActive:
           type: boolean
-          description: Whether this row is currently active. Reads return only active rows unless explicitly filtered otherwise.
+          description: Whether this row is currently active. Reads return only active rows; inactive rows are never returned by this endpoint.
           readOnly: true
           example: true
     PlatformConfig:
@@ -9047,6 +9047,31 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
+    TransactionFeeConfigInput:
+      type: object
+      description: 'Write-side variant of a platform transaction fee config, used in the merge-by-key upsert on `PATCH /config`. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. The system-generated `id` and the derived `isActive` flag are read-only and are therefore omitted here.'
+      required:
+        - feeEventType
+        - sourceCurrency
+        - variableFeeBps
+        - fixedFee
+      properties:
+        feeEventType:
+          $ref: '#/components/schemas/TransactionFeeEventType'
+        sourceCurrency:
+          type: string
+          description: ISO 4217 (fiat) or ticker (crypto) code of the source-side currency this fee applies to. Cross-currency fees are charged in the sending side's currency.
+          example: USD
+        variableFeeBps:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+          description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
+          example: 30
+        fixedFee:
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
+          $ref: '#/components/schemas/CurrencyAmount'
     PlatformConfigUpdateRequest:
       type: object
       properties:
@@ -9070,7 +9095,7 @@ components:
         transactionFeeConfigs:
           type: array
           items:
-            $ref: '#/components/schemas/TransactionFeeConfig'
+            $ref: '#/components/schemas/TransactionFeeConfigInput'
           description: |
             Merge-by-key upsert of platform transaction fee configs. Each item is
             keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8886,10 +8886,12 @@ components:
       type: object
       description: 'Platform-collected transaction fee charged on top of corridor fees. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.'
       required:
+        - id
         - feeEventType
         - sourceCurrency
         - variableFeeBps
         - fixedFee
+        - isActive
       properties:
         id:
           type: string
@@ -9071,7 +9073,12 @@ components:
           example: 30
         fixedFee:
           description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
-          $ref: '#/components/schemas/CurrencyAmount'
+          allOf:
+            - $ref: '#/components/schemas/CurrencyAmount'
+            - type: object
+              properties:
+                amount:
+                  minimum: 0
     PlatformConfigUpdateRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8910,7 +8910,7 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
           example: 30
         fixedFee:
-          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`.
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount` must be non-negative.
           $ref: '#/components/schemas/CurrencyAmount'
         isActive:
           type: boolean

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8835,6 +8835,88 @@ components:
           maxLength: 512
           description: URL to a PNG logo for the OTP email. Resized to 340x124px.
           example: https://acme.com/logo.png
+    TransactionFeeEventType:
+      type: string
+      enum:
+        - CROSS_CURRENCY_TRANSACTION
+        - TRANSFER_OUT_TRANSACTION
+      description: |-
+        The kind of transaction this fee applies to.
+        - `CROSS_CURRENCY_TRANSACTION` — fee charged on a cross-currency Grid send
+          (source currency differs from destination currency).
+
+        - `TRANSFER_OUT_TRANSACTION` — fee charged on a Grid Transfer Out
+          operation.
+
+        Note: only `CROSS_CURRENCY_TRANSACTION` is accepted by `PATCH /config` today. Reads always return the full set, so configurations created by Lightspark operators (e.g. Transfer Out rows) are still visible.
+    Currency:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
+        name:
+          type: string
+          description: Full name of the currency
+          example: United States Dollar
+        symbol:
+          type: string
+          description: Symbol of the currency
+          example: $
+        decimals:
+          type: integer
+          description: Number of decimal places for the currency
+          minimum: 0
+          example: 2
+    CurrencyAmount:
+      type: object
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
+          example: 12550
+        currency:
+          $ref: '#/components/schemas/Currency'
+    TransactionFeeConfig:
+      type: object
+      description: 'Platform-collected transaction fee charged on top of corridor fees. Keyed uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.'
+      required:
+        - feeEventType
+        - sourceCurrency
+        - variableFeeBps
+        - fixedFee
+      properties:
+        id:
+          type: string
+          description: System-generated unique identifier.
+          readOnly: true
+          example: GridPlatformTransactionFeeConfig:019ef5bf-a77e-93be-0000-479e9268bca9
+        feeEventType:
+          $ref: '#/components/schemas/TransactionFeeEventType'
+        sourceCurrency:
+          type: string
+          description: ISO 4217 (fiat) or ticker (crypto) code of the source-side currency this fee applies to. Cross-currency fees are charged in the sending side's currency.
+          example: USD
+        variableFeeBps:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+          description: Variable fee in basis points (1 bps = 0.01%). Multiplied by the transaction's source-currency amount.
+          example: 30
+        fixedFee:
+          description: Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`. `fixedFee.currency.code` must match `sourceCurrency`.
+          $ref: '#/components/schemas/CurrencyAmount'
+        isActive:
+          type: boolean
+          description: Whether this row is currently active. Reads return only active rows unless explicitly filtered otherwise.
+          readOnly: true
+          example: true
     PlatformConfig:
       type: object
       properties:
@@ -8876,6 +8958,15 @@ components:
             Embedded-wallet branding and OTP settings for this platform. Present
             only when the platform has configured embedded-wallet support;
             omitted otherwise.
+        transactionFeeConfigs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionFeeConfig'
+          description: |
+            Platform-collected transaction fees, keyed uniquely by
+            `(feeEventType, sourceCurrency)`. Returned in reads regardless of
+            `feeEventType` so that operator-created rows (e.g. Transfer Out) are
+            visible even before the corresponding write path is enabled.
         createdAt:
           type: string
           format: date-time
@@ -8976,6 +9067,18 @@ components:
             Fields omitted from the nested object are left unchanged. Omit this
             field at the top level to leave the embedded-wallet configuration
             unchanged entirely.
+        transactionFeeConfigs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionFeeConfig'
+          description: |
+            Merge-by-key upsert of platform transaction fee configs. Each item is
+            keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send
+            the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. Only
+            `feeEventType: CROSS_CURRENCY_TRANSACTION` and `sourceCurrency: USD`
+            are accepted by this endpoint today; other values return a 400 error.
+            Omit this field at the top level to leave all transaction fee configs
+            unchanged.
     Error400:
       type: object
       required:
@@ -9106,26 +9209,6 @@ components:
           type: object
           description: Additional error details
           additionalProperties: true
-    Currency:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Three-letter currency code (ISO 4217) for fiat currencies. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-          example: USD
-        name:
-          type: string
-          description: Full name of the currency
-          example: United States Dollar
-        symbol:
-          type: string
-          description: Symbol of the currency
-          example: $
-        decimals:
-          type: integer
-          description: Number of decimal places for the currency
-          minimum: 0
-          example: 2
     PaymentRail:
       type: string
       enum:
@@ -10264,19 +10347,6 @@ components:
         - `CLOSED`: The account cannot send or receive payments. A customer can initiate the closing of an internal account, after which the account transitions to this status.
         - `FROZEN`: The account cannot send or receive payments. Grid may freeze an account in response to compliance or fraud signals; payments are blocked while the account remains frozen.
       example: ACTIVE
-    CurrencyAmount:
-      type: object
-      required:
-        - amount
-        - currency
-      properties:
-        amount:
-          type: integer
-          format: int64
-          description: Amount in the smallest unit of the currency (e.g., cents for USD/EUR, satoshis for BTC)
-          example: 12550
-        currency:
-          $ref: '#/components/schemas/Currency'
     PaymentAccountType:
       type: string
       enum:

--- a/openapi/components/schemas/config/PlatformConfig.yaml
+++ b/openapi/components/schemas/config/PlatformConfig.yaml
@@ -38,6 +38,15 @@ properties:
       Embedded-wallet branding and OTP settings for this platform. Present
       only when the platform has configured embedded-wallet support;
       omitted otherwise.
+  transactionFeeConfigs:
+    type: array
+    items:
+      $ref: ./TransactionFeeConfig.yaml
+    description: |
+      Platform-collected transaction fees, keyed uniquely by
+      `(feeEventType, sourceCurrency)`. Returned in reads regardless of
+      `feeEventType` so that operator-created rows (e.g. Transfer Out) are
+      visible even before the corresponding write path is enabled.
   createdAt:
     type: string
     format: date-time

--- a/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
+++ b/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
@@ -17,3 +17,15 @@ properties:
       Fields omitted from the nested object are left unchanged. Omit this
       field at the top level to leave the embedded-wallet configuration
       unchanged entirely.
+  transactionFeeConfigs:
+    type: array
+    items:
+      $ref: ./TransactionFeeConfig.yaml
+    description: |
+      Merge-by-key upsert of platform transaction fee configs. Each item is
+      keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send
+      the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. Only
+      `feeEventType: CROSS_CURRENCY_TRANSACTION` and `sourceCurrency: USD`
+      are accepted by this endpoint today; other values return a 400 error.
+      Omit this field at the top level to leave all transaction fee configs
+      unchanged.

--- a/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
+++ b/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
@@ -20,7 +20,7 @@ properties:
   transactionFeeConfigs:
     type: array
     items:
-      $ref: ./TransactionFeeConfig.yaml
+      $ref: ./TransactionFeeConfigInput.yaml
     description: |
       Merge-by-key upsert of platform transaction fee configs. Each item is
       keyed by `(feeEventType, sourceCurrency)`. To deactivate a fee, send

--- a/openapi/components/schemas/config/TransactionFeeConfig.yaml
+++ b/openapi/components/schemas/config/TransactionFeeConfig.yaml
@@ -35,7 +35,8 @@ properties:
   fixedFee:
     description: >-
       Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`.
-      `fixedFee.currency.code` must match `sourceCurrency`.
+      `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount`
+      must be non-negative.
     $ref: ../common/CurrencyAmount.yaml
   isActive:
     type: boolean

--- a/openapi/components/schemas/config/TransactionFeeConfig.yaml
+++ b/openapi/components/schemas/config/TransactionFeeConfig.yaml
@@ -4,10 +4,12 @@ description: >-
   uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate
   a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.
 required:
+  - id
   - feeEventType
   - sourceCurrency
   - variableFeeBps
   - fixedFee
+  - isActive
 properties:
   id:
     type: string

--- a/openapi/components/schemas/config/TransactionFeeConfig.yaml
+++ b/openapi/components/schemas/config/TransactionFeeConfig.yaml
@@ -1,0 +1,46 @@
+type: object
+description: >-
+  Platform-collected transaction fee charged on top of corridor fees. Keyed
+  uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate
+  a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.
+required:
+  - feeEventType
+  - sourceCurrency
+  - variableFeeBps
+  - fixedFee
+properties:
+  id:
+    type: string
+    description: System-generated unique identifier.
+    readOnly: true
+    example: GridPlatformTransactionFeeConfig:019ef5bf-a77e-93be-0000-479e9268bca9
+  feeEventType:
+    $ref: ./TransactionFeeEventType.yaml
+  sourceCurrency:
+    type: string
+    description: >-
+      ISO 4217 (fiat) or ticker (crypto) code of the source-side currency this
+      fee applies to. Cross-currency fees are charged in the sending side's
+      currency.
+    example: USD
+  variableFeeBps:
+    type: integer
+    format: int32
+    minimum: 0
+    maximum: 10000
+    description: >-
+      Variable fee in basis points (1 bps = 0.01%). Multiplied by the
+      transaction's source-currency amount.
+    example: 30
+  fixedFee:
+    description: >-
+      Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`.
+      `fixedFee.currency.code` must match `sourceCurrency`.
+    $ref: ../common/CurrencyAmount.yaml
+  isActive:
+    type: boolean
+    description: >-
+      Whether this row is currently active. Reads return only active rows
+      unless explicitly filtered otherwise.
+    readOnly: true
+    example: true

--- a/openapi/components/schemas/config/TransactionFeeConfigInput.yaml
+++ b/openapi/components/schemas/config/TransactionFeeConfigInput.yaml
@@ -1,19 +1,17 @@
 type: object
 description: >-
-  Platform-collected transaction fee charged on top of corridor fees. Keyed
-  uniquely by `(feeEventType, sourceCurrency)` within a platform. To deactivate
-  a fee, send the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.
+  Write-side variant of a platform transaction fee config, used in the
+  merge-by-key upsert on `PATCH /config`. Keyed uniquely by
+  `(feeEventType, sourceCurrency)` within a platform. To deactivate a fee, send
+  the same key with `variableFeeBps: 0` and `fixedFee.amount: 0`. The
+  system-generated `id` and the derived `isActive` flag are read-only and are
+  therefore omitted here.
 required:
   - feeEventType
   - sourceCurrency
   - variableFeeBps
   - fixedFee
 properties:
-  id:
-    type: string
-    description: System-generated unique identifier.
-    readOnly: true
-    example: GridPlatformTransactionFeeConfig:019ef5bf-a77e-93be-0000-479e9268bca9
   feeEventType:
     $ref: ./TransactionFeeEventType.yaml
   sourceCurrency:
@@ -38,10 +36,3 @@ properties:
       `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount`
       must be non-negative.
     $ref: ../common/CurrencyAmount.yaml
-  isActive:
-    type: boolean
-    description: >-
-      Whether this row is currently active. Reads return only active rows;
-      inactive rows are never returned by this endpoint.
-    readOnly: true
-    example: true

--- a/openapi/components/schemas/config/TransactionFeeConfigInput.yaml
+++ b/openapi/components/schemas/config/TransactionFeeConfigInput.yaml
@@ -35,4 +35,9 @@ properties:
       Fixed fee charged per transaction, in the smallest unit of `sourceCurrency`.
       `fixedFee.currency.code` must match `sourceCurrency`, and `fixedFee.amount`
       must be non-negative.
-    $ref: ../common/CurrencyAmount.yaml
+    allOf:
+      - $ref: ../common/CurrencyAmount.yaml
+      - type: object
+        properties:
+          amount:
+            minimum: 0

--- a/openapi/components/schemas/config/TransactionFeeEventType.yaml
+++ b/openapi/components/schemas/config/TransactionFeeEventType.yaml
@@ -1,0 +1,16 @@
+type: string
+enum:
+  - CROSS_CURRENCY_TRANSACTION
+  - TRANSFER_OUT_TRANSACTION
+description: >-
+  The kind of transaction this fee applies to.
+
+  - `CROSS_CURRENCY_TRANSACTION` — fee charged on a cross-currency Grid send
+    (source currency differs from destination currency).
+
+  - `TRANSFER_OUT_TRANSACTION` — fee charged on a Grid Transfer Out
+    operation.
+
+  Note: only `CROSS_CURRENCY_TRANSACTION` is accepted by `PATCH /config`
+  today. Reads always return the full set, so configurations created by
+  Lightspark operators (e.g. Transfer Out rows) are still visible.


### PR DESCRIPTION
## Reason

Ships **[AT-5613](https://lightspark.atlassian.net/browse/AT-5613)** (Xc) of the [Platform Fee Config: Cross Currency](https://lightspark.atlassian.net/browse/AT-5610) epic — Grid API OpenAPI schemas for platform-collected transaction fees.

This is the API-surface ticket that the sparkcore PATCH `/config` handler (AT-5614) and the Grid API SDKs will consume.

## Overview

Two new schemas + extensions to two existing ones:

- **`TransactionFeeConfig.yaml`** — `{ id, feeEventType, sourceCurrency, variableFeeBps, fixedFee, isActive }`. `id` and `isActive` are read-only. Required: `feeEventType`, `sourceCurrency`, `variableFeeBps`, `fixedFee`.
- **`TransactionFeeEventType.yaml`** — enum `{ CROSS_CURRENCY_TRANSACTION, TRANSFER_OUT_TRANSACTION }`. **Intentionally broad** — sparkcore enforces a narrower v0 whitelist (`CROSS_CURRENCY_TRANSACTION` only) at the handler layer (AT-5614) so the Transfer Out fast-follow does not need an SDK regen.
- **`PlatformConfig.yaml`** — adds optional `transactionFeeConfigs: array`. Reads return all active rows regardless of `feeEventType`, so operator-planted Transfer Out rows are visible to platforms before the write path is enabled.
- **`PlatformConfigUpdateRequest.yaml`** — same field. Documented as merge-by-key upsert on `(feeEventType, sourceCurrency)`; "deactivate" = same key with `variableFeeBps: 0` and `fixedFee.amount: 0`.

## Test Plan

- **Bundle**: `npm run build:openapi` clean — both new schemas auto-discovered into `openapi.yaml` (lines 8857 + 8904) and the `mintlify/openapi.yaml` mirror.
- **Redocly lint**: validates clean (`Your API description is valid 🎉`). The pre-existing 33 warnings are all on unrelated webhook example schemas (none on the files this PR touches). Confirmed by running `npm run lint` against `main` first — same 33.
- **Spectral**: pre-existing `spectral: command not found` issue on `main` — the npm script tries `npx spectral` which resolves to a 0.0.0 placeholder package, not `@stoplight/spectral-cli`. Not introduced by this PR; tracking separately.
- **Stainless**: regen kicks in on merge.

## Manual SDK-shape check (post-Stainless regen)

After Stainless picks this up, the generated TS SDK should expose:
- `TransactionFeeConfig` type with the shape above
- `TransactionFeeEventType` union including **both** `CROSS_CURRENCY_TRANSACTION` and `TRANSFER_OUT_TRANSACTION`
- `PlatformConfig.transactionFeeConfigs?: TransactionFeeConfig[]`
- `PlatformConfigUpdateRequest.transactionFeeConfigs?: TransactionFeeConfig[]`

## Blocked on

Nothing — this lands in parallel with AT-5611/AT-5612 sparkcore work.

## Unblocks

- **AT-5614** — sparkcore PATCH `/config` handler that consumes `transactionFeeConfigs` and enforces v0 validation
- All downstream API consumers


[AT-5613]: https://lightspark.atlassian.net/browse/AT-5613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ