### PR TITLE
docs(openapi): split Card processorRef (Lithic) from issuerRef (Lead)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -19317,6 +19317,11 @@ components:
           type: string
           description: Platform-specific card identifier. Optional on create — system-generated if omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
+        processorRef:
+          type: string
+          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
+          example: card_b81c2a4f
+          readOnly: true
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
@@ -19362,8 +19367,8 @@ components:
           readOnly: true
         issuerRef:
           type: string
-          description: Opaque identifier for the card on the underlying issuer. Useful for cross-referencing in issuer dashboards; not used for any Grid request routing.
-          example: lithic_card_4f8d3a2b1c
+          description: Opaque identifier for the card on the issuer of record (e.g. the Lead Bank account/card identifier). Useful for cross-referencing in issuer dashboards; not used for any Grid request routing.
+          example: lead_card_7a1b9c3d
           readOnly: true
         createdAt:
           type: string

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8511,7 +8511,8 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     currency: USD
-                    issuerRef: lithic_card_4f8d3a2b1c
+                    processorRef: card_b81c2a4f
+                    issuerRef: lead_card_7a1b9c3d
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:11:00Z'
               issuerRejected:
@@ -19317,11 +19318,6 @@ components:
           type: string
           description: Platform-specific card identifier. Optional on create — system-generated if omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
-        processorRef:
-          type: string
-          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
-          example: card_b81c2a4f
-          readOnly: true
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
@@ -19350,7 +19346,7 @@ components:
         panEmbedUrl:
           type: string
           format: uri
-          description: URL of the card issuer's iframe that securely displays the PAN, CVV, and expiry to the cardholder. The full PAN and CVV never cross Grid's servers — render this URL in an iframe in your client to reveal card details.
+          description: URL of the card processor's iframe that securely displays the PAN, CVV, and expiry to the cardholder. The full PAN and CVV never cross Grid's servers — render this URL in an iframe in your client to reveal card details.
           example: https://embed.lithic.com/iframe/...?t=...
         fundingSources:
           type: array
@@ -19364,6 +19360,11 @@ components:
           type: string
           description: Currency the card transacts in (ISO 4217 for fiat, tickers for crypto). Derived from the funding sources at issue time — all funding sources bound to a card must be denominated in the same card-eligible currency.
           example: USD
+          readOnly: true
+        processorRef:
+          type: string
+          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
+          example: card_b81c2a4f
           readOnly: true
         issuerRef:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19317,6 +19317,11 @@ components:
           type: string
           description: Platform-specific card identifier. Optional on create — system-generated if omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
+        processorRef:
+          type: string
+          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
+          example: card_b81c2a4f
+          readOnly: true
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
@@ -19362,8 +19367,8 @@ components:
           readOnly: true
         issuerRef:
           type: string
-          description: Opaque identifier for the card on the underlying issuer. Useful for cross-referencing in issuer dashboards; not used for any Grid request routing.
-          example: lithic_card_4f8d3a2b1c
+          description: Opaque identifier for the card on the issuer of record (e.g. the Lead Bank account/card identifier). Useful for cross-referencing in issuer dashboards; not used for any Grid request routing.
+          example: lead_card_7a1b9c3d
           readOnly: true
         createdAt:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8511,7 +8511,8 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     currency: USD
-                    issuerRef: lithic_card_4f8d3a2b1c
+                    processorRef: card_b81c2a4f
+                    issuerRef: lead_card_7a1b9c3d
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:11:00Z'
               issuerRejected:
@@ -19317,11 +19318,6 @@ components:
           type: string
           description: Platform-specific card identifier. Optional on create — system-generated if omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
-        processorRef:
-          type: string
-          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
-          example: card_b81c2a4f
-          readOnly: true
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
@@ -19350,7 +19346,7 @@ components:
         panEmbedUrl:
           type: string
           format: uri
-          description: URL of the card issuer's iframe that securely displays the PAN, CVV, and expiry to the cardholder. The full PAN and CVV never cross Grid's servers — render this URL in an iframe in your client to reveal card details.
+          description: URL of the card processor's iframe that securely displays the PAN, CVV, and expiry to the cardholder. The full PAN and CVV never cross Grid's servers — render this URL in an iframe in your client to reveal card details.
           example: https://embed.lithic.com/iframe/...?t=...
         fundingSources:
           type: array
@@ -19364,6 +19360,11 @@ components:
           type: string
           description: Currency the card transacts in (ISO 4217 for fiat, tickers for crypto). Derived from the funding sources at issue time — all funding sources bound to a card must be denominated in the same card-eligible currency.
           example: USD
+          readOnly: true
+        processorRef:
+          type: string
+          description: Opaque processor-side reference for the card (e.g. the Lithic card token). Useful for cross-referencing in the processor's dashboards; not used for any Grid request routing.
+          example: card_b81c2a4f
           readOnly: true
         issuerRef:
           type: string

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -23,6 +23,14 @@ properties:
       Platform-specific card identifier. Optional on create — system-generated
       if omitted, mirroring `platformCustomerId` semantics.
     example: card-emp-aary-001
+  processorRef:
+    type: string
+    description: >-
+      Opaque processor-side reference for the card (e.g. the Lithic card token).
+      Useful for cross-referencing in the processor's dashboards; not used for
+      any Grid request routing.
+    example: card_b81c2a4f
+    readOnly: true
   state:
     $ref: ./CardState.yaml
   stateReason:
@@ -81,10 +89,10 @@ properties:
   issuerRef:
     type: string
     description: >-
-      Opaque identifier for the card on the underlying issuer. Useful for
-      cross-referencing in issuer dashboards; not used for any Grid request
-      routing.
-    example: lithic_card_4f8d3a2b1c
+      Opaque identifier for the card on the issuer of record (e.g. the Lead Bank
+      account/card identifier). Useful for cross-referencing in issuer
+      dashboards; not used for any Grid request routing.
+    example: lead_card_7a1b9c3d
     readOnly: true
   createdAt:
     type: string

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -23,14 +23,6 @@ properties:
       Platform-specific card identifier. Optional on create — system-generated
       if omitted, mirroring `platformCustomerId` semantics.
     example: card-emp-aary-001
-  processorRef:
-    type: string
-    description: >-
-      Opaque processor-side reference for the card (e.g. the Lithic card token).
-      Useful for cross-referencing in the processor's dashboards; not used for
-      any Grid request routing.
-    example: card_b81c2a4f
-    readOnly: true
   state:
     $ref: ./CardState.yaml
   stateReason:
@@ -62,7 +54,7 @@ properties:
     type: string
     format: uri
     description: >-
-      URL of the card issuer's iframe that securely displays the PAN, CVV,
+      URL of the card processor's iframe that securely displays the PAN, CVV,
       and expiry to the cardholder. The full PAN and CVV never cross Grid's
       servers — render this URL in an iframe in your client to reveal card
       details.
@@ -85,6 +77,14 @@ properties:
       Derived from the funding sources at issue time — all funding sources
       bound to a card must be denominated in the same card-eligible currency.
     example: USD
+    readOnly: true
+  processorRef:
+    type: string
+    description: >-
+      Opaque processor-side reference for the card (e.g. the Lithic card token).
+      Useful for cross-referencing in the processor's dashboards; not used for
+      any Grid request routing.
+    example: card_b81c2a4f
     readOnly: true
   issuerRef:
     type: string

--- a/openapi/webhooks/card-state-change.yaml
+++ b/openapi/webhooks/card-state-change.yaml
@@ -62,7 +62,8 @@ post:
                 fundingSources:
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 currency: USD
-                issuerRef: lithic_card_4f8d3a2b1c
+                processorRef: card_b81c2a4f
+                issuerRef: lead_card_7a1b9c3d
                 createdAt: '2026-05-08T14:10:00Z'
                 updatedAt: '2026-05-08T14:11:00Z'
           issuerRejected:


### PR DESCRIPTION
## Summary

Companion docs change to the card-id standardization (webdev#29318).

- Adds **`processorRef`** to the `Card` schema — the Lithic card token, parallel to `CardTransaction.issuerTransactionToken`. This is the field the implementation now returns alongside the `Card:<uuid>` id (the spec's `id` was already `Card:<uuid>`; the implementation was the side that diverged).
- Corrects **`issuerRef`**: its example was a Lithic token (`lithic_card_...`), but Lithic is the card *processor* — the issuer of record is Lead Bank. `issuerRef` now describes the Lead identifier; the Lithic ref lives in `processorRef`. This matches the data model (`processor_ref` = Lithic, `issuer_ref` = Lead).

## Test plan

- `make build` (rebundles `openapi.yaml` + `mintlify/openapi.yaml`)
- `make lint-openapi` → exit 0 (no new findings on the `Card` schema)

Proof-of-concept companion to the implementation PR; leaving as a draft.

Slack thread: https://lightsparkgroup.slack.com/archives/D0AJJH3A4J1/p1782347206097239

---
🤖 [sovereign-reactor-4](https://zeus.dev.dev.sparkinfra.net/#/arc?id=sovereign-reactor)[(#4)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=sovereign-reactor-4) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/619