### PR TITLE
docs(openapi): correct exchangeRate example to match documented basis (PROD-54)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -229,7 +229,7 @@ paths:
                           symbol: ₹
                         destinationPaymentRail: UPI
                         receivingAmount: 825000
-                        exchangeRate: 82.5
+                        exchangeRate: 0.012121
                         fees:
                           fixed: 100
                           total: 150
@@ -248,8 +248,8 @@ paths:
                           name: Euro
                           symbol: €
                         destinationPaymentRail: SEPA_INSTANT
-                        receivingAmount: 18500
-                        exchangeRate: 0.925
+                        receivingAmount: 9250
+                        exchangeRate: 1.081081
                         fees:
                           fixed: 10
                           total: 15
@@ -9260,7 +9260,7 @@ components:
           type: number
           description: Number of sending currency units per receiving currency unit.
           exclusiveMinimum: 0
-          example: 82.5
+          example: 0.012121
         fees:
           $ref: '#/components/schemas/ExchangeRateFees'
         updatedAt:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -229,7 +229,7 @@ paths:
                           symbol: ₹
                         destinationPaymentRail: UPI
                         receivingAmount: 825000
-                        exchangeRate: 82.5
+                        exchangeRate: 0.012121
                         fees:
                           fixed: 100
                           total: 150
@@ -248,8 +248,8 @@ paths:
                           name: Euro
                           symbol: €
                         destinationPaymentRail: SEPA_INSTANT
-                        receivingAmount: 18500
-                        exchangeRate: 0.925
+                        receivingAmount: 9250
+                        exchangeRate: 1.081081
                         fees:
                           fixed: 10
                           total: 15
@@ -9260,7 +9260,7 @@ components:
           type: number
           description: Number of sending currency units per receiving currency unit.
           exclusiveMinimum: 0
-          example: 82.5
+          example: 0.012121
         fees:
           $ref: '#/components/schemas/ExchangeRateFees'
         updatedAt:

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -49,7 +49,7 @@ properties:
     type: number
     description: Number of sending currency units per receiving currency unit.
     exclusiveMinimum: 0
-    example: 82.50
+    example: 0.012121
   fees:
     $ref: ./ExchangeRateFees.yaml
   updatedAt:

--- a/openapi/paths/exchange-rates/exchange_rates.yaml
+++ b/openapi/paths/exchange-rates/exchange_rates.yaml
@@ -73,7 +73,7 @@ get:
                       symbol: "₹"
                     destinationPaymentRail: UPI
                     receivingAmount: 825000
-                    exchangeRate: 82.50
+                    exchangeRate: 0.012121
                     fees:
                       fixed: 100
                       total: 150
@@ -92,8 +92,8 @@ get:
                       name: Euro
                       symbol: "€"
                     destinationPaymentRail: SEPA_INSTANT
-                    receivingAmount: 18500
-                    exchangeRate: 0.925
+                    receivingAmount: 9250
+                    exchangeRate: 1.081081
                     fees:
                       fixed: 10
                       total: 15


### PR DESCRIPTION
## Summary

The `exchangeRate` field on the `/exchange-rates` `ExchangeRate` schema is documented as **"Number of sending currency units per receiving currency unit"**, but the examples were showing the inverse (destination-per-source) direction — contradicting both the field description and the live API:

- `ExchangeRate.yaml` schema example: USD→INR `82.50`
- `allRatesFromUSD` response example: USD→INR `82.50`, USD→EUR `0.925`

The live API returns `~0.01` for USD→INR, confirming the field is sending-units-per-receiving-unit. This is a docs-only example fix — the API itself is correct (confirmed by the ticket owner on PROD-54).

## Changes

Corrected the examples to the documented basis, keeping each response example internally consistent with its `sendingAmount`/`receivingAmount`:

| Corridor | Before | After | Basis check |
|----------|--------|-------|-------------|
| USD→INR `exchangeRate` | `82.50` | `0.012121` | `1/82.50`; $100 → ₹8,250 (receivingAmount 825000) ✓ |
| USD→EUR `exchangeRate` | `0.925` | `1.081081` | `1/0.925`; $100 → €92.50 |
| USD→EUR `receivingAmount` | `18500` | `9250` | €92.50 at the corrected rate ✓ |

Files:
- `openapi/components/schemas/exchange_rates/ExchangeRate.yaml`
- `openapi/paths/exchange-rates/exchange_rates.yaml`
- `openapi.yaml` + `mintlify/openapi.yaml` (regenerated via `make build`)

## Scope note

PROD-54 was split out of PROD-50 (the broader exchange-rate basis cleanup). The many `exchangeRate` examples in the narrative Mintlify docs (`0.92`, `17.25`, etc.) share the same directional inconsistency but are tracked under PROD-50 and intentionally **out of scope** here. The `Quote.yaml` `exchangeRate` field shares the same description but has no example, so nothing to fix there.

## Test plan
- `make build` — rebundles cleanly
- `make lint-openapi` — 0 errors (pre-existing warnings/infos on unrelated schemas only)
- Verified each corrected example is internally consistent with its `sendingAmount`/`receivingAmount`

Fixes PROD-54

Slack thread: https://lightsparkgroup.slack.com/archives/D0AHP8H9E13/p1782750571018079

---
🤖 [volatile-relay](https://zeus.dev.dev.sparkinfra.net/#/arc?id=volatile-relay)[(#1)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=volatile-relay) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/630