### PR TITLE
Add bankName as a required field to GTQ and JMD account types

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12254,6 +12254,7 @@ components:
         - accountType
         - accountNumber
         - bankAccountType
+        - bankName
       properties:
         accountType:
           type: string
@@ -12270,10 +12271,17 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
+          example: Banco GYT Continental
       example:
         accountType: GTQ_ACCOUNT
         accountNumber: '1234567890'
         bankAccountType: CHECKING
+        bankName: Banco GYT Continental
     GtqAccountInfo:
       allOf:
         - $ref: '#/components/schemas/GtqAccountInfoBase'
@@ -12353,6 +12361,7 @@ components:
         - accountNumber
         - branchCode
         - bankAccountType
+        - bankName
       properties:
         accountType:
           type: string
@@ -12375,11 +12384,18 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
+          example: Bank of Nova Scotia
       example:
         accountType: JMD_ACCOUNT
         accountNumber: '1234567890'
         branchCode: '11111'
         bankAccountType: CHECKING
+        bankName: Bank of Nova Scotia
     JmdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/JmdAccountInfoBase'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12254,6 +12254,7 @@ components:
         - accountType
         - accountNumber
         - bankAccountType
+        - bankName
       properties:
         accountType:
           type: string
@@ -12270,10 +12271,17 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
+          example: Banco GYT Continental
       example:
         accountType: GTQ_ACCOUNT
         accountNumber: '1234567890'
         bankAccountType: CHECKING
+        bankName: Banco GYT Continental
     GtqAccountInfo:
       allOf:
         - $ref: '#/components/schemas/GtqAccountInfoBase'
@@ -12353,6 +12361,7 @@ components:
         - accountNumber
         - branchCode
         - bankAccountType
+        - bankName
       properties:
         accountType:
           type: string
@@ -12375,11 +12384,18 @@ components:
           enum:
             - CHECKING
             - SAVINGS
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
+          example: Bank of Nova Scotia
       example:
         accountType: JMD_ACCOUNT
         accountNumber: '1234567890'
         branchCode: '11111'
         bankAccountType: CHECKING
+        bankName: Bank of Nova Scotia
     JmdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/JmdAccountInfoBase'

--- a/openapi/components/schemas/common/GtqAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/GtqAccountInfoBase.yaml
@@ -3,6 +3,7 @@ required:
 - accountType
 - accountNumber
 - bankAccountType
+- bankName
 properties:
   accountType:
     type: string
@@ -19,7 +20,14 @@ properties:
     enum:
     - CHECKING
     - SAVINGS
+  bankName:
+    type: string
+    description: The name of the bank
+    minLength: 1
+    maxLength: 255
+    example: Banco GYT Continental
 example:
   accountType: GTQ_ACCOUNT
   accountNumber: '1234567890'
   bankAccountType: CHECKING
+  bankName: Banco GYT Continental

--- a/openapi/components/schemas/common/JmdAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/JmdAccountInfoBase.yaml
@@ -4,6 +4,7 @@ required:
 - accountNumber
 - branchCode
 - bankAccountType
+- bankName
 properties:
   accountType:
     type: string
@@ -26,8 +27,15 @@ properties:
     enum:
     - CHECKING
     - SAVINGS
+  bankName:
+    type: string
+    description: The name of the bank
+    minLength: 1
+    maxLength: 255
+    example: Bank of Nova Scotia
 example:
   accountType: JMD_ACCOUNT
   accountNumber: '1234567890'
   branchCode: '11111'
   bankAccountType: CHECKING
+  bankName: Bank of Nova Scotia


### PR DESCRIPTION
## Reason

GTQ (Guatemala) and JMD (Jamaica) corridors have **multiple bank payers**, so the destination bank must be disambiguated during payout discovery (same as PHP/NGN/IDR/etc.). The receiving side already advertises `payeeBankName` as required for these corridors, but the account schema had no `bankName` field — so callers couldn't supply it and quotes failed with `"payeeBankName is not a sender key this API accepts."`

## Change

- Add `bankName` (string, 1–255 chars) as a **required** field on `GtqAccountInfoBase` and `JmdAccountInfoBase`. Derived create/info types inherit it via `allOf`.
- Rebundled `openapi.yaml` (+ mintlify copy).

## Follow-up

After this merges, the webdev monorepo regenerates `grid-api/grid_api/models/*.py` (via `update_schema.sh`) so `bank_name` is parsed into the account model, paired with the sparkcore mapping in lightsparkdev/webdev#29480.