### PR TITLE
feat(openapi): add rail + settlement-timing fields to OutgoingTransaction

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -17259,7 +17259,7 @@ components:
               anyOf:
                 - $ref: '#/components/schemas/PaymentRail'
                 - type: 'null'
-              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null until a rail is resolved.
+              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null when no external rail is used (e.g. instant or intra-network transfers, or non-direct-destination transactions) or before a rail is resolved.
             railSelectionMode:
               anyOf:
                 - $ref: '#/components/schemas/RailSelectionMode'
@@ -17270,7 +17270,7 @@ components:
                 - string
                 - 'null'
               format: date-time
-              description: Expected settlement time at the beneficiary. Null when not yet known (e.g. instant rails, or before a rail is resolved).
+              description: Expected settlement time at the beneficiary. Null for instant rails (settlement is immediate) and before a rail with deferred settlement is resolved.
             settlementTimelineSeconds:
               type:
                 - integer

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Grid API
   description: |
     API for managing global payments on the open Money Grid. Built by Lightspark. See the full documentation at https://docs.lightspark.com/.
-  version: '2026-06-25'
+  version: '2026-06-29'
   contact:
     name: Lightspark Support
     email: support@lightspark.com
@@ -17176,6 +17176,13 @@ components:
         - FUNDING_AMOUNT_MISMATCH
         - COUNTERPARTY_POST_TX_FAILED
       description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+    RailSelectionMode:
+      type: string
+      enum:
+        - AUTO
+        - MANUAL
+      description: How the payment rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it.
+      example: AUTO
     OutgoingTransaction:
       title: Outgoing Transaction
       allOf:
@@ -17248,6 +17255,27 @@ components:
             failureReason:
               $ref: '#/components/schemas/OutgoingTransactionFailureReason'
               description: If the transaction failed, this field provides the reason for failure.
+            paymentRail:
+              anyOf:
+                - $ref: '#/components/schemas/PaymentRail'
+                - type: 'null'
+              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null until a rail is resolved.
+            railSelectionMode:
+              anyOf:
+                - $ref: '#/components/schemas/RailSelectionMode'
+                - type: 'null'
+              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it. Null when no rail is resolved.
+            expectedSettlementAt:
+              type:
+                - string
+                - 'null'
+              format: date-time
+              description: Expected settlement time at the beneficiary. Null when not yet known (e.g. instant rails, or before a rail is resolved).
+            settlementTimelineSeconds:
+              type:
+                - integer
+                - 'null'
+              description: Expected number of seconds from quote creation to settlement. Null when not yet known.
     CardTransactionStatus:
       type: string
       enum:

--- a/mintlify/ramps/platform-tools/webhooks.mdx
+++ b/mintlify/ramps/platform-tools/webhooks.mdx
@@ -37,7 +37,11 @@ Grid sends webhooks for key events in the ramp lifecycle:
       "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
       "settledAt": "2025-10-03T15:02:30Z",
       "exchangeRate": 9.5,
-      "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006"
+      "quoteId": "Quote:019542f5-b3e7-1d02-0000-000000000006",
+      "paymentRail": "ACH",
+      "railSelectionMode": "AUTO",
+      "expectedSettlementAt": "2025-10-04T15:00:00Z",
+      "settlementTimelineSeconds": 86400
     }
   }
   ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17259,7 +17259,7 @@ components:
               anyOf:
                 - $ref: '#/components/schemas/PaymentRail'
                 - type: 'null'
-              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null until a rail is resolved.
+              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null when no external rail is used (e.g. instant or intra-network transfers, or non-direct-destination transactions) or before a rail is resolved.
             railSelectionMode:
               anyOf:
                 - $ref: '#/components/schemas/RailSelectionMode'
@@ -17270,7 +17270,7 @@ components:
                 - string
                 - 'null'
               format: date-time
-              description: Expected settlement time at the beneficiary. Null when not yet known (e.g. instant rails, or before a rail is resolved).
+              description: Expected settlement time at the beneficiary. Null for instant rails (settlement is immediate) and before a rail with deferred settlement is resolved.
             settlementTimelineSeconds:
               type:
                 - integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Grid API
   description: |
     API for managing global payments on the open Money Grid. Built by Lightspark. See the full documentation at https://docs.lightspark.com/.
-  version: '2026-06-25'
+  version: '2026-06-29'
   contact:
     name: Lightspark Support
     email: support@lightspark.com
@@ -17176,6 +17176,13 @@ components:
         - FUNDING_AMOUNT_MISMATCH
         - COUNTERPARTY_POST_TX_FAILED
       description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+    RailSelectionMode:
+      type: string
+      enum:
+        - AUTO
+        - MANUAL
+      description: How the payment rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it.
+      example: AUTO
     OutgoingTransaction:
       title: Outgoing Transaction
       allOf:
@@ -17248,6 +17255,27 @@ components:
             failureReason:
               $ref: '#/components/schemas/OutgoingTransactionFailureReason'
               description: If the transaction failed, this field provides the reason for failure.
+            paymentRail:
+              anyOf:
+                - $ref: '#/components/schemas/PaymentRail'
+                - type: 'null'
+              description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null until a rail is resolved.
+            railSelectionMode:
+              anyOf:
+                - $ref: '#/components/schemas/RailSelectionMode'
+                - type: 'null'
+              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it. Null when no rail is resolved.
+            expectedSettlementAt:
+              type:
+                - string
+                - 'null'
+              format: date-time
+              description: Expected settlement time at the beneficiary. Null when not yet known (e.g. instant rails, or before a rail is resolved).
+            settlementTimelineSeconds:
+              type:
+                - integer
+                - 'null'
+              description: Expected number of seconds from quote creation to settlement. Null when not yet known.
     CardTransactionStatus:
       type: string
       enum:

--- a/openapi/components/schemas/common/RailSelectionMode.yaml
+++ b/openapi/components/schemas/common/RailSelectionMode.yaml
@@ -1,0 +1,8 @@
+type: string
+enum:
+  - AUTO
+  - MANUAL
+description: >-
+  How the payment rail was chosen — MANUAL when the platform specified a
+  paymentRail on the destination, AUTO when Lightspark selects it.
+example: AUTO

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -73,3 +73,34 @@ allOf:
       failureReason:
         $ref: ./OutgoingTransactionFailureReason.yaml
         description: If the transaction failed, this field provides the reason for failure.
+      paymentRail:
+        anyOf:
+          - $ref: ../common/PaymentRail.yaml
+          - type: 'null'
+        description: >-
+          The payment rail used to settle this transaction (e.g. ACH, WIRE,
+          NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent
+          on quote requests. Null until a rail is resolved.
+      railSelectionMode:
+        anyOf:
+          - $ref: ../common/RailSelectionMode.yaml
+          - type: 'null'
+        description: >-
+          How the rail was chosen — MANUAL when the platform specified a
+          paymentRail on the destination, AUTO when Lightspark selects it. Null
+          when no rail is resolved.
+      expectedSettlementAt:
+        type:
+          - string
+          - 'null'
+        format: date-time
+        description: >-
+          Expected settlement time at the beneficiary. Null when not yet known
+          (e.g. instant rails, or before a rail is resolved).
+      settlementTimelineSeconds:
+        type:
+          - integer
+          - 'null'
+        description: >-
+          Expected number of seconds from quote creation to settlement. Null
+          when not yet known.

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -80,7 +80,9 @@ allOf:
         description: >-
           The payment rail used to settle this transaction (e.g. ACH, WIRE,
           NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent
-          on quote requests. Null until a rail is resolved.
+          on quote requests. Null when no external rail is used (e.g. instant
+          or intra-network transfers, or non-direct-destination transactions)
+          or before a rail is resolved.
       railSelectionMode:
         anyOf:
           - $ref: ../common/RailSelectionMode.yaml
@@ -95,8 +97,9 @@ allOf:
           - 'null'
         format: date-time
         description: >-
-          Expected settlement time at the beneficiary. Null when not yet known
-          (e.g. instant rails, or before a rail is resolved).
+          Expected settlement time at the beneficiary. Null for instant rails
+          (settlement is immediate) and before a rail with deferred settlement
+          is resolved.
       settlementTimelineSeconds:
         type:
           - integer

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: Grid API
   description: >
     API for managing global payments on the open Money Grid. Built by Lightspark. See the full documentation at https://docs.lightspark.com/.
-  version: "2026-06-25"
+  version: "2026-06-29"
   contact:
     name: Lightspark Support
     email: support@lightspark.com


### PR DESCRIPTION
## Summary

Adds four optional, nullable fields to the `OutgoingTransaction` schema so the rail and settlement-timing data that sparkcore already emits on `outgoing_payment.*` webhooks (today as a raw-JSON post-process, webdev #29090) becomes first-class in the typed API model. This makes the fields show up in generated clients/SDKs and the public webhook docs. The change is purely additive and backward-compatible.

## Fields added

| Field | Type | Nullable encoding |
|---|---|---|
| `paymentRail` | `PaymentRail` enum ref | `anyOf: [$ref, {type: 'null'}]` |
| `railSelectionMode` | new `RailSelectionMode` enum (`AUTO`/`MANUAL`) | `anyOf: [$ref, {type: 'null'}]` |
| `expectedSettlementAt` | string, `format: date-time` | `type: [string, 'null']` |
| `settlementTimelineSeconds` | integer | `type: [integer, 'null']` |

All four are **not** added to `required` and are nullable — they are null for instant rails, AUTO mode before a rail is resolved, and non-direct-destination transactions.

## Changes

- `openapi/components/schemas/transactions/OutgoingTransaction.yaml` — the four new properties.
- `openapi/components/schemas/common/RailSelectionMode.yaml` — new named enum schema (placed alongside `PaymentRail.yaml`, matching the repo's one-enum-per-file convention).
- `openapi/openapi.yaml` — version bump `2026-06-25` → `2026-06-29` (date-based release convention).
- `openapi.yaml` + `mintlify/openapi.yaml` — regenerated bundles (`npm run build:openapi`).
- `mintlify/ramps/platform-tools/webhooks.mdx` — surfaced the new fields in the `OUTGOING_PAYMENT` webhook payload example. Other webhook docs render the model via `$ref` and pick up the fields automatically.

## Conventions followed

- Nullable idioms match existing repo usage: `anyOf` + `type: 'null'` for refs (as in `Card.yaml`), and `type: [..., 'null']` lists for scalars (as in `AgentSpendingLimits.yaml`).
- The `paymentRail` value is the grid-api `PaymentRail` name (e.g. `FASTER_PAYMENTS`), matching the enum exactly — no internal aliases.

## Verification

- `redocly` validation: ✅ valid (warnings are all pre-existing and unrelated).
- `spectral lint --fail-severity=error`: ✅ exit 0, no errors.
- Confirmed `required` is unchanged (still only `type`, `sentAmount`, `source`) and the regenerated `OutgoingTransaction` model includes all four fields as optional/nullable. The only non-additive line across the bundles is the version bump.

## Follow-up

Downstream webdev change is tracked as **AT-5666**: once a new grid-api package version is published, bump the pinned version, regenerate the client, and move sparkcore's webhook enrichment out of the raw-dict post-process into the typed model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTtfvC6Qcsh3M62jVaCT1Y)_