### PR TITLE
Add idType/identifier to IndividualCustomerCreateRequest (ENG-10686)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9960,7 +9960,8 @@ components:
               $ref: '#/components/schemas/IdentificationType'
             identifier:
               type: string
-              description: The individual's tax identification number (SSN or ITIN for a US account holder). Required to onboard the individual as a US account holder. Write-only — never returned in customer responses.
+              writeOnly: true
+              description: The individual's tax identification number. Required to onboard the individual as a US account holder. Only SSN and ITIN are currently accepted for an individual account holder; other identification types are rejected. Write-only — never returned in customer responses.
               example: 123-45-6789
     BusinessInfo:
       type: object

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9954,6 +9954,14 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
+        - type: object
+          properties:
+            idType:
+              $ref: '#/components/schemas/IdentificationType'
+            identifier:
+              type: string
+              description: The individual's tax identification number (SSN or ITIN for a US account holder). Required to onboard the individual as a US account holder. Write-only — never returned in customer responses.
+              example: 123-45-6789
     BusinessInfo:
       type: object
       description: Additional information required for business entities

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9960,7 +9960,8 @@ components:
               $ref: '#/components/schemas/IdentificationType'
             identifier:
               type: string
-              description: The individual's tax identification number (SSN or ITIN for a US account holder). Required to onboard the individual as a US account holder. Write-only — never returned in customer responses.
+              writeOnly: true
+              description: The individual's tax identification number. Required to onboard the individual as a US account holder. Only SSN and ITIN are currently accepted for an individual account holder; other identification types are rejected. Write-only — never returned in customer responses.
               example: 123-45-6789
     BusinessInfo:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9954,6 +9954,14 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
+        - type: object
+          properties:
+            idType:
+              $ref: '#/components/schemas/IdentificationType'
+            identifier:
+              type: string
+              description: The individual's tax identification number (SSN or ITIN for a US account holder). Required to onboard the individual as a US account holder. Write-only — never returned in customer responses.
+              example: 123-45-6789
     BusinessInfo:
       type: object
       description: Additional information required for business entities

--- a/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
@@ -8,8 +8,11 @@ allOf:
         $ref: ./IdentificationType.yaml
       identifier:
         type: string
+        writeOnly: true
         description: >-
-          The individual's tax identification number (SSN or ITIN for a US
-          account holder). Required to onboard the individual as a US account
-          holder. Write-only — never returned in customer responses.
+          The individual's tax identification number. Required to onboard the
+          individual as a US account holder. Only SSN and ITIN are currently
+          accepted for an individual account holder; other identification
+          types are rejected. Write-only — never returned in customer
+          responses.
         example: 123-45-6789

--- a/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
@@ -2,3 +2,14 @@ title: Individual Customer Create Request
 allOf:
   - $ref: ./CustomerCreateRequest.yaml
   - $ref: ./IndividualCustomerFields.yaml
+  - type: object
+    properties:
+      idType:
+        $ref: ./IdentificationType.yaml
+      identifier:
+        type: string
+        description: >-
+          The individual's tax identification number (SSN or ITIN for a US
+          account holder). Required to onboard the individual as a US account
+          holder. Write-only — never returned in customer responses.
+        example: 123-45-6789


### PR DESCRIPTION
## Summary
Adds the individual account-holder's tax identification (**SSN/ITIN**) to `IndividualCustomerCreateRequest` so Grid can capture it at customer creation and bridge it downstream to `EntUserInfo.tax_identifier` for Lead (banking-partner) onboarding of a US individual.

Part of ENG-10686 (Individual account-holder CIP). Consumed by the webdev PR (lightsparkdev/webdev#29658), which reads `idType`/`identifier` off the regenerated client model.

## Details
- New fields on the **create request only** (added to the `allOf` in `IndividualCustomerCreateRequest.yaml`, not the shared `IndividualCustomerFields`), so the identifier is **write-only** and never echoed in customer GET responses.
- Reuses the existing `IdentificationType` enum (SSN/ITIN/EIN/NON_US_TAX_ID) and mirrors the flat `idType`/`identifier`/`countryOfIssuance` shape beneficial owners already expose (`BeneficialOwnerPersonalInfo`).
- Regenerated bundle (`openapi.yaml`, `mintlify/openapi.yaml`) via `make build`; `redocly lint` clean.

## Test plan
- `npm run build:openapi` + `npx @redocly/cli lint openapi.yaml` → valid.
- webdev client regeneration (`grid-api/update_schema.sh`) picks up `id_type`/`identifier`/`country_of_issuance` on the individual create model.

---
🤖 [sovereign-nebula-2](https://zeus.dev.dev.sparkinfra.net/#/arc?id=sovereign-nebula)[(#2)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=sovereign-nebula-2) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/636