### PR TITLE
docs(openapi): add title to CardTransaction so docs render a named chip

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -17370,6 +17370,7 @@ components:
           description: Sum of all settled amounts in the smallest unit of the funding source's currency.
           example: 1500
     CardTransaction:
+      title: Card Transaction
       type: object
       required:
         - type

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17370,6 +17370,7 @@ components:
           description: Sum of all settled amounts in the smallest unit of the funding source's currency.
           example: 1500
     CardTransaction:
+      title: Card Transaction
       type: object
       required:
         - type

--- a/openapi/components/schemas/cards/CardTransaction.yaml
+++ b/openapi/components/schemas/cards/CardTransaction.yaml
@@ -1,3 +1,4 @@
+title: Card Transaction
 type: object
 required:
   - type


### PR DESCRIPTION
## Summary
The Grid API docs schema viewer (e.g. [get-transaction-by-id](https://docs.lightspark.com/api-reference/transactions/get-transaction-by-id)) rendered the third `TransactionOneOf` variant as a generic **Option 3** chip. `IncomingTransaction` and `OutgoingTransaction` both declare a `title`, which Mintlify uses for the chip label; `CardTransaction` (added in #622) did not, so the renderer fell back to "Option 3".

This adds `title: Card Transaction` to the `CardTransaction` schema and regenerates the bundled specs (`openapi.yaml`, `mintlify/openapi.yaml`) via `npm run build:openapi`.

## Test plan
- `npm run lint:openapi` passes (Redocly bundle + lint, Spectral lint — exit 0, only pre-existing warnings)
- Diff is exactly the one source line plus the same line in the two generated bundles

Requested by Ben in Slack (thread linked below).

Slack thread: https://lightsparkgroup.slack.com/archives/C0A28TVUZ4Z/p1783024275813329

---
🤖 [blazing-photon](https://zeus.dev.dev.sparkinfra.net/#/arc?id=blazing-photon)[(#1)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=blazing-photon) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/638