### PR TITLE
docs(mintlify): correct exchangeRate example basis (PROD-50)

### DIFF
--- a/mintlify/platform-overview/core-concepts/currencies-and-rails.mdx
+++ b/mintlify/platform-overview/core-concepts/currencies-and-rails.mdx
@@ -71,12 +71,12 @@ POST /quotes
     "decimals": 2
   },
   "totalSendingAmount": 100000,
-  "totalReceivingAmount": 1725000,
-  "exchangeRate": 17.25,
+  "totalReceivingAmount": 1716375,
+  "exchangeRate": 0.05797101,
   "feesIncluded": 500,
   "transactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000025"
 }
 ```
 </Accordion>
 
-This shows: Send $1,000 → Receive $17,250 (at rate 17.25), $5 fee.
+This shows: Send $1,000 → Receive $17,163.75 (1 USD ≈ 17.25 MXN, or exchangeRate: 0.05797101), $5 fee.

--- a/mintlify/platform-overview/core-concepts/quote-system.mdx
+++ b/mintlify/platform-overview/core-concepts/quote-system.mdx
@@ -95,14 +95,14 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/quotes \
     "decimals": 8
   },
   "totalSendingAmount": 100000,
-  "totalReceivingAmount": 829167,
-  "exchangeRate": 0.00000833,
+  "totalReceivingAmount": 828835,
+  "exchangeRate": 120048.01920768,
   "feesIncluded": 500,
   "transactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000025"
 }
 ```
 
-This quote says: Send \$1,000 USD, recipient receives 0.00829167 BTC, fees are \$5.00, expires in 5 minutes.
+This quote says: Send \$1,000 USD, recipient receives 0.00828835 BTC, fees are \$5.00, expires in 5 minutes.
 
 ### Locked Currency Side
 
@@ -289,7 +289,7 @@ curl -X POST https://api.lightspark.com/grid/2025-10-13/quotes \
   },
   "totalSendingAmount": 100000,
   "totalReceivingAmount": 91540,
-  "exchangeRate": 0.92,
+  "exchangeRate": 1.08695652,
   "feesIncluded": 500,
   "transactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000025"
 }
@@ -322,7 +322,7 @@ All fees are transparently displayed in the quote response:
     "gridApiMultiplier": 0.925,
     "gridApiFixedFee": 10,
     "gridApiVariableFeeRate": 0.003,
-    "gridApiVariableFeeAmount": 30
+    "gridApiVariableFeeAmount": 300
   }
 }
 ```
@@ -333,13 +333,13 @@ All fees are transparently displayed in the quote response:
 - **`gridApiMultiplier`**: Exchange rate from sending currency to mSATs including variable fees (0.925 = $1 USD = 0.925 mSATs)
 - **`gridApiFixedFee`**: Fixed fee charged by Grid API (10 cents USD)
 - **`gridApiVariableFeeRate`**: Variable fee rate as percentage (0.003 = 0.3%)
-- **`gridApiVariableFeeAmount`**: Variable fee amount (30 cents USD for $1,000 transaction)
+- **`gridApiVariableFeeAmount`**: Variable fee amount (300 cents USD for $1,000 transaction)
 
 Fees are deducted from the sending amount, so:
 - **Customer sends**: $1,000
 - **Fees**: $5.00
 - **Amount converted**: $995.00
-- **Recipient receives**: €915.40 (at 0.92 rate)
+- **Recipient receives**: €915.40 (1 USD ≈ 0.92 EUR, or exchangeRate: 1.08695652)
 
 <Note>
   Quoted fees may fluctuate between quotes. Some fee components (e.g.


### PR DESCRIPTION
## Summary

#631 (PROD-54) fixed the exchangeRate example on the standalone
`ExchangeRate` schema, and noted the narrative Mintlify examples
(`0.92`, `17.25`, etc.) share the same directional inconsistency but
were intentionally out of scope, tracked separately under PROD-50.
This PR covers that remaining scope.

All three examples had `exchangeRate` in the inverse (destination-per-
source) direction, contradicting the field description ("Number of
sending currency units per receiving currency unit") and the live API
— verified against a live sandbox `/quotes` and `/exchange-rates` call,
both consistent with `(totalSendingAmount − feesIncluded) / exchangeRate
= totalReceivingAmount`.

Also includes an unrelated fix: `gridApiVariableFeeAmount` example (30)
didn't match `gridApiVariableFeeRate` (0.3%) applied to the stated
$1,000 transaction — should be 300.

## Changes

| Corridor | File | Before | After | Basis check |
|---|---|---|---|---|
| USD→BTC | quote-system.mdx | rate `0.00000833`, receiving `829167` | rate `120048.01920768`, receiving `828835` | `(1000−5) / 120048.01920768 = 0.00828835 BTC` |
| USD→EUR | quote-system.mdx | rate `0.92` | rate `1.08695652` | `995 / 1.08695652 = 915.40` (receiving amount unchanged) |
| USD→MXN | currencies-and-rails.mdx | rate `17.25`, receiving `1725000` | rate `0.05797101`, receiving `1716375` | `(1000−5) / 0.05797101 = 17163.75` |
| gridApiVariableFeeAmount | quote-system.mdx | `30` | `300` | `$1,000 × 0.3% = $3.00 = 300 cents` |

Prose captions updated to match in all three currency examples.

## Known limitations (not addressed in this PR)

- `rateDetails` components (`counterpartyFixedFee` + `gridApiFixedFee`
  + `gridApiVariableFeeAmount`) sum to 320, not the `feesIncluded: 500`
  shown at the top of the same example. Left as-is — insufficient
  information to determine the correct total without knowing whether
  additional fee components exist.
- `counterpartyMultiplier` breakdown text ("1.08 = 1 mSAT = 1.08 cents
  EUR") implies an implausible BTC/EUR price either with or without
  "cents" — left unchanged since neither reading is verifiable.
- `payouts-and-b2b/quickstart.mdx` has the same directional issue in
  three more places (plus an explicit "17.25 MXN per USD" label), but
  its example amounts don't cleanly round-trip under either direction
  (possibly a different underlying rate was used for that example) —
  left for a follow-up.

## Test plan
- Verified each corrected value by recomputing from the unchanged
  `totalSendingAmount`/`feesIncluded` using `(sendingAmount − fees) /
  exchangeRate = receivingAmount`, matching #631's basis-check method
- Cross-checked against live sandbox `/quotes` and `/exchange-rates`
  responses (2026-07-02), both consistent with this direction
- `npx mint broken-links` — clean

Fixes PROD-50 (remaining scope from #631)