### PR TITLE
Add KYB business-entity fields for Lead — NAICS, structured source of funds, counterparty countries (ENG-10687)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9556,6 +9556,18 @@ components:
         - OTHER
       description: The intended purpose for using the Grid account
       example: CONTRACTOR_PAYOUTS
+    SourceOfFunds:
+      type: string
+      enum:
+        - OPERATING_REVENUE
+        - INVESTMENT_INCOME
+        - LOANS
+        - VENTURE_CAPITAL
+        - PERSONAL_SAVINGS
+        - DONATIONS
+        - OTHER
+      description: The primary source of funds for the business
+      example: OPERATING_REVENUE
     BusinessInfoUpdate:
       type: object
       description: Additional information for business entities
@@ -9627,6 +9639,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BusinessCustomerFields:
@@ -9720,6 +9761,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BeneficialOwnerRole:
@@ -10038,6 +10108,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BusinessCustomerCreateRequest:
@@ -16566,6 +16665,8 @@ components:
         - APPLICANT_CRIMINAL_RECORD
         - APPLICANT_REJECTED
         - MISSING_BENEFICIAL_OWNER
+        - MISSING_CONTROL_PERSON
+        - MISSING_GOOD_STANDING_DOCUMENT
       description: Type of verification error. The category-specific MISSING_*_DOCUMENT types indicate which document category is needed. Document quality types (POOR_QUALITY_DOCUMENT, SUSPECTED_FRAUD_DOCUMENT, etc.) indicate specific issues with uploaded documents. APPLICANT_* types indicate issues with the applicant themselves (sanctions, fraud, criminal records).
       example: MISSING_FIELD
     VerificationError:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9655,11 +9655,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases
@@ -9777,11 +9779,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases
@@ -10124,11 +10128,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9556,7 +9556,7 @@ components:
         - OTHER
       description: The intended purpose for using the Grid account
       example: CONTRACTOR_PAYOUTS
-    SourceOfFunds:
+    SourceOfFundsCategory:
       type: string
       enum:
         - OPERATING_REVENUE
@@ -9566,7 +9566,7 @@ components:
         - PERSONAL_SAVINGS
         - DONATIONS
         - OTHER
-      description: The primary source of funds for the business
+      description: A structured source-of-funds category for the business
       example: OPERATING_REVENUE
     BusinessInfoUpdate:
       type: object
@@ -9649,7 +9649,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE
@@ -9771,7 +9771,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE
@@ -10118,7 +10118,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9652,7 +9652,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500
@@ -9774,7 +9774,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500
@@ -10121,7 +10121,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9556,6 +9556,18 @@ components:
         - OTHER
       description: The intended purpose for using the Grid account
       example: CONTRACTOR_PAYOUTS
+    SourceOfFunds:
+      type: string
+      enum:
+        - OPERATING_REVENUE
+        - INVESTMENT_INCOME
+        - LOANS
+        - VENTURE_CAPITAL
+        - PERSONAL_SAVINGS
+        - DONATIONS
+        - OTHER
+      description: The primary source of funds for the business
+      example: OPERATING_REVENUE
     BusinessInfoUpdate:
       type: object
       description: Additional information for business entities
@@ -9627,6 +9639,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BusinessCustomerFields:
@@ -9720,6 +9761,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BeneficialOwnerRole:
@@ -10038,6 +10108,35 @@ components:
           items:
             type: string
           description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
+          example:
+            - US
+        naicsCode:
+          type: string
+          pattern: ^\d{2,6}$
+          description: NAICS code describing the nature of the business (2-6 digits)
+          example: '541511'
+        sourceOfFundsCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceOfFunds'
+          description: Structured source-of-funds categories for the business
+          example:
+            - BUSINESS_REVENUE
+        sourceOfFundsOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the source of funds when OTHER is selected
+          example: Proceeds from a legal settlement
+        purposeOfAccountOtherDescription:
+          type: string
+          maxLength: 500
+          description: Description of the account purpose when OTHER is selected
+          example: Escrow for equipment leases
+        expectedCounterpartyCountries:
+          type: array
+          items:
+            type: string
+          description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
     BusinessCustomerCreateRequest:
@@ -16566,6 +16665,8 @@ components:
         - APPLICANT_CRIMINAL_RECORD
         - APPLICANT_REJECTED
         - MISSING_BENEFICIAL_OWNER
+        - MISSING_CONTROL_PERSON
+        - MISSING_GOOD_STANDING_DOCUMENT
       description: Type of verification error. The category-specific MISSING_*_DOCUMENT types indicate which document category is needed. Document quality types (POOR_QUALITY_DOCUMENT, SUSPECTED_FRAUD_DOCUMENT, etc.) indicate specific issues with uploaded documents. APPLICANT_* types indicate issues with the applicant themselves (sanctions, fraud, criminal records).
       example: MISSING_FIELD
     VerificationError:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9655,11 +9655,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases
@@ -9777,11 +9779,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases
@@ -10124,11 +10128,13 @@ components:
             - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the source of funds when OTHER is selected
           example: Proceeds from a legal settlement
         purposeOfAccountOtherDescription:
           type: string
+          minLength: 1
           maxLength: 500
           description: Description of the account purpose when OTHER is selected
           example: Escrow for equipment leases

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9556,7 +9556,7 @@ components:
         - OTHER
       description: The intended purpose for using the Grid account
       example: CONTRACTOR_PAYOUTS
-    SourceOfFunds:
+    SourceOfFundsCategory:
       type: string
       enum:
         - OPERATING_REVENUE
@@ -9566,7 +9566,7 @@ components:
         - PERSONAL_SAVINGS
         - DONATIONS
         - OTHER
-      description: The primary source of funds for the business
+      description: A structured source-of-funds category for the business
       example: OPERATING_REVENUE
     BusinessInfoUpdate:
       type: object
@@ -9649,7 +9649,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE
@@ -9771,7 +9771,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE
@@ -10118,7 +10118,7 @@ components:
         sourceOfFundsCategories:
           type: array
           items:
-            $ref: '#/components/schemas/SourceOfFunds'
+            $ref: '#/components/schemas/SourceOfFundsCategory'
           description: Structured source-of-funds categories for the business
           example:
             - OPERATING_REVENUE

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9652,7 +9652,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500
@@ -9774,7 +9774,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500
@@ -10121,7 +10121,7 @@ components:
             $ref: '#/components/schemas/SourceOfFunds'
           description: Structured source-of-funds categories for the business
           example:
-            - BUSINESS_REVENUE
+            - OPERATING_REVENUE
         sourceOfFundsOtherDescription:
           type: string
           maxLength: 500

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -85,7 +85,7 @@ properties:
       $ref: ./SourceOfFunds.yaml
     description: Structured source-of-funds categories for the business
     example:
-      - BUSINESS_REVENUE
+      - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
     maxLength: 500

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -74,3 +74,32 @@ properties:
     description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
     example:
       - US
+  naicsCode:
+    type: string
+    pattern: '^\d{2,6}$'
+    description: NAICS code describing the nature of the business (2-6 digits)
+    example: '541511'
+  sourceOfFundsCategories:
+    type: array
+    items:
+      $ref: ./SourceOfFunds.yaml
+    description: Structured source-of-funds categories for the business
+    example:
+      - BUSINESS_REVENUE
+  sourceOfFundsOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the source of funds when OTHER is selected
+    example: Proceeds from a legal settlement
+  purposeOfAccountOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the account purpose when OTHER is selected
+    example: Escrow for equipment leases
+  expectedCounterpartyCountries:
+    type: array
+    items:
+      type: string
+    description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
+    example:
+      - US

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -82,7 +82,7 @@ properties:
   sourceOfFundsCategories:
     type: array
     items:
-      $ref: ./SourceOfFunds.yaml
+      $ref: ./SourceOfFundsCategory.yaml
     description: Structured source-of-funds categories for the business
     example:
       - OPERATING_REVENUE

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -88,11 +88,13 @@ properties:
       - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the source of funds when OTHER is selected
     example: Proceeds from a legal settlement
   purposeOfAccountOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the account purpose when OTHER is selected
     example: Escrow for equipment leases

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -89,11 +89,13 @@ properties:
       - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the source of funds when OTHER is selected
     example: Proceeds from a legal settlement
   purposeOfAccountOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the account purpose when OTHER is selected
     example: Escrow for equipment leases

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -75,3 +75,32 @@ properties:
     description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
     example:
       - US
+  naicsCode:
+    type: string
+    pattern: '^\d{2,6}$'
+    description: NAICS code describing the nature of the business (2-6 digits)
+    example: '541511'
+  sourceOfFundsCategories:
+    type: array
+    items:
+      $ref: ./SourceOfFunds.yaml
+    description: Structured source-of-funds categories for the business
+    example:
+      - BUSINESS_REVENUE
+  sourceOfFundsOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the source of funds when OTHER is selected
+    example: Proceeds from a legal settlement
+  purposeOfAccountOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the account purpose when OTHER is selected
+    example: Escrow for equipment leases
+  expectedCounterpartyCountries:
+    type: array
+    items:
+      type: string
+    description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
+    example:
+      - US

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -83,7 +83,7 @@ properties:
   sourceOfFundsCategories:
     type: array
     items:
-      $ref: ./SourceOfFunds.yaml
+      $ref: ./SourceOfFundsCategory.yaml
     description: Structured source-of-funds categories for the business
     example:
       - OPERATING_REVENUE

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -86,7 +86,7 @@ properties:
       $ref: ./SourceOfFunds.yaml
     description: Structured source-of-funds categories for the business
     example:
-      - BUSINESS_REVENUE
+      - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
     maxLength: 500

--- a/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
@@ -78,7 +78,7 @@ properties:
   sourceOfFundsCategories:
     type: array
     items:
-      $ref: ./SourceOfFunds.yaml
+      $ref: ./SourceOfFundsCategory.yaml
     description: Structured source-of-funds categories for the business
     example:
       - OPERATING_REVENUE

--- a/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
@@ -84,11 +84,13 @@ properties:
       - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the source of funds when OTHER is selected
     example: Proceeds from a legal settlement
   purposeOfAccountOtherDescription:
     type: string
+    minLength: 1
     maxLength: 500
     description: Description of the account purpose when OTHER is selected
     example: Escrow for equipment leases

--- a/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
@@ -70,3 +70,32 @@ properties:
     description: List of countries where the business expects to send payments (ISO 3166-1 alpha-2)
     example:
       - US
+  naicsCode:
+    type: string
+    pattern: '^\d{2,6}$'
+    description: NAICS code describing the nature of the business (2-6 digits)
+    example: '541511'
+  sourceOfFundsCategories:
+    type: array
+    items:
+      $ref: ./SourceOfFunds.yaml
+    description: Structured source-of-funds categories for the business
+    example:
+      - BUSINESS_REVENUE
+  sourceOfFundsOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the source of funds when OTHER is selected
+    example: Proceeds from a legal settlement
+  purposeOfAccountOtherDescription:
+    type: string
+    maxLength: 500
+    description: Description of the account purpose when OTHER is selected
+    example: Escrow for equipment leases
+  expectedCounterpartyCountries:
+    type: array
+    items:
+      type: string
+    description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
+    example:
+      - US

--- a/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
@@ -81,7 +81,7 @@ properties:
       $ref: ./SourceOfFunds.yaml
     description: Structured source-of-funds categories for the business
     example:
-      - BUSINESS_REVENUE
+      - OPERATING_REVENUE
   sourceOfFundsOtherDescription:
     type: string
     maxLength: 500

--- a/openapi/components/schemas/customers/SourceOfFundsCategory.yaml
+++ b/openapi/components/schemas/customers/SourceOfFundsCategory.yaml
@@ -7,5 +7,5 @@ enum:
   - PERSONAL_SAVINGS
   - DONATIONS
   - OTHER
-description: The primary source of funds for the business
+description: A structured source-of-funds category for the business
 example: OPERATING_REVENUE

--- a/openapi/components/schemas/verifications/VerificationErrorType.yaml
+++ b/openapi/components/schemas/verifications/VerificationErrorType.yaml
@@ -20,6 +20,8 @@ enum:
   - APPLICANT_CRIMINAL_RECORD
   - APPLICANT_REJECTED
   - MISSING_BENEFICIAL_OWNER
+  - MISSING_CONTROL_PERSON
+  - MISSING_GOOD_STANDING_DOCUMENT
 description: >-
   Type of verification error. The category-specific MISSING_*_DOCUMENT types
   indicate which document category is needed. Document quality types


### PR DESCRIPTION
## Summary

Spec side of webdev ENG-10687 (KYB field gaps for Lead business entities). Companion to the webdev stack rooted at lightsparkdev/webdev#29776.

Adds to `BusinessInfo` / `BusinessInfoUpdate` / `BusinessInfoResponse`:
- `naicsCode` — 2–6 digit NAICS code (Lead takes NAICS via `business_details.industry`)
- `sourceOfFundsCategories` — array referencing the existing (previously unreferenced) `SourceOfFunds` enum, plus `sourceOfFundsOtherDescription`
- `purposeOfAccountOtherDescription` — CDD 'other' description for `purposeOfAccount: OTHER`
- `expectedCounterpartyCountries` — geographic-risk CDD field (distinct from send-side `expectedRecipientJurisdictions`)

Adds `MISSING_CONTROL_PERSON` and `MISSING_GOOD_STANDING_DOCUMENT` to `VerificationErrorType` (control person and Certificate of Good Standing are Lead KYB requirements; the webdev validator will emit these for Lead-partnered platforms).

`make build` re-bundled `openapi.yaml` + `mintlify/openapi.yaml`. `make lint-openapi` is baseline-equivalent (same single pre-existing error as main).

## Test plan

- Redocly bundle + lint (no new findings vs main)
- webdev regen from this spec compiles and is exercised by the webdev stack's handler tests

---
🤖 [fierce-nexus-2](https://zeus.dev.dev.sparkinfra.net/#/arc?id=fierce-nexus)[(#2)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=fierce-nexus-2) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/641