### PR TITLE
Add INR bank (NEFT/RTGS) fields to the INR account schema

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -10633,7 +10633,11 @@ components:
       type: object
       required:
         - accountType
-        - vpa
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - NEFT: accountNumber, ifsc, rail
+        - RTGS: accountNumber, ifsc, rail
+        - UPI: vpa
       properties:
         accountType:
           type: string
@@ -10646,9 +10650,38 @@ components:
           minLength: 3
           maxLength: 255
           pattern: ^[a-zA-Z0-9.\-_]+@[a-zA-Z0-9]+$
+        accountNumber:
+          type: string
+          description: Indian bank account number (9–18 digits)
+          minLength: 9
+          maxLength: 18
+          example: '000111222333'
+          pattern: ^[0-9]{9,18}$
+        ifsc:
+          type: string
+          description: The Indian Financial System Code (IFSC) of the beneficiary's bank branch (NEFT/RTGS)
+          example: HDFC0001234
+          minLength: 11
+          maxLength: 11
+          pattern: ^[A-Z]{4}0[A-Z0-9]{6}$
+        rail:
+          type: string
+          description: The payment rail to route the payout over, for currencies that support more than one (e.g. NEFT or RTGS for INR).
+          example: NEFT
+          minLength: 1
+          maxLength: 32
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
       example:
         accountType: INR_ACCOUNT
         vpa: user@upi
+        accountNumber: '000111222333'
+        ifsc: HDFC0001234
+        rail: NEFT
+        bankName: Example Bank
     InrAccountInfo:
       allOf:
         - $ref: '#/components/schemas/InrAccountInfoBase'
@@ -10662,6 +10695,8 @@ components:
                 type: string
                 enum:
                   - UPI
+                  - NEFT
+                  - RTGS
     PaymentInrAccountInfo:
       title: INR Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10633,7 +10633,11 @@ components:
       type: object
       required:
         - accountType
-        - vpa
+      description: |-
+        Required fields depend on the selected paymentRails:
+        - NEFT: accountNumber, ifsc, rail
+        - RTGS: accountNumber, ifsc, rail
+        - UPI: vpa
       properties:
         accountType:
           type: string
@@ -10646,9 +10650,38 @@ components:
           minLength: 3
           maxLength: 255
           pattern: ^[a-zA-Z0-9.\-_]+@[a-zA-Z0-9]+$
+        accountNumber:
+          type: string
+          description: Indian bank account number (9–18 digits)
+          minLength: 9
+          maxLength: 18
+          example: '000111222333'
+          pattern: ^[0-9]{9,18}$
+        ifsc:
+          type: string
+          description: The Indian Financial System Code (IFSC) of the beneficiary's bank branch (NEFT/RTGS)
+          example: HDFC0001234
+          minLength: 11
+          maxLength: 11
+          pattern: ^[A-Z]{4}0[A-Z0-9]{6}$
+        rail:
+          type: string
+          description: The payment rail to route the payout over, for currencies that support more than one (e.g. NEFT or RTGS for INR).
+          example: NEFT
+          minLength: 1
+          maxLength: 32
+        bankName:
+          type: string
+          description: The name of the bank
+          minLength: 1
+          maxLength: 255
       example:
         accountType: INR_ACCOUNT
         vpa: user@upi
+        accountNumber: '000111222333'
+        ifsc: HDFC0001234
+        rail: NEFT
+        bankName: Example Bank
     InrAccountInfo:
       allOf:
         - $ref: '#/components/schemas/InrAccountInfoBase'
@@ -10662,6 +10695,8 @@ components:
                 type: string
                 enum:
                   - UPI
+                  - NEFT
+                  - RTGS
     PaymentInrAccountInfo:
       title: INR Account
       allOf:

--- a/openapi/components/schemas/common/InrAccountInfo.yaml
+++ b/openapi/components/schemas/common/InrAccountInfo.yaml
@@ -10,3 +10,5 @@ allOf:
         type: string
         enum:
         - UPI
+        - NEFT
+        - RTGS

--- a/openapi/components/schemas/common/InrAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/InrAccountInfoBase.yaml
@@ -1,7 +1,13 @@
 type: object
 required:
 - accountType
-- vpa
+description: 'Required fields depend on the selected paymentRails:
+
+  - NEFT: accountNumber, ifsc, rail
+
+  - RTGS: accountNumber, ifsc, rail
+
+  - UPI: vpa'
 properties:
   accountType:
     type: string
@@ -14,6 +20,37 @@ properties:
     minLength: 3
     maxLength: 255
     pattern: ^[a-zA-Z0-9.\-_]+@[a-zA-Z0-9]+$
+  accountNumber:
+    type: string
+    description: Indian bank account number (9–18 digits)
+    minLength: 9
+    maxLength: 18
+    example: '000111222333'
+    pattern: ^[0-9]{9,18}$
+  ifsc:
+    type: string
+    description: The Indian Financial System Code (IFSC) of the beneficiary's bank
+      branch (NEFT/RTGS)
+    example: HDFC0001234
+    minLength: 11
+    maxLength: 11
+    pattern: ^[A-Z]{4}0[A-Z0-9]{6}$
+  rail:
+    type: string
+    description: The payment rail to route the payout over, for currencies that support
+      more than one (e.g. NEFT or RTGS for INR).
+    example: NEFT
+    minLength: 1
+    maxLength: 32
+  bankName:
+    type: string
+    description: The name of the bank
+    minLength: 1
+    maxLength: 255
 example:
   accountType: INR_ACCOUNT
   vpa: user@upi
+  accountNumber: '000111222333'
+  ifsc: HDFC0001234
+  rail: NEFT
+  bankName: Example Bank


### PR DESCRIPTION
INR external accounts were UPI-only (`vpa`). This adds the bank-rail fields so a NEFT/RTGS beneficiary can be represented: `InrAccountInfoBase` gains `accountNumber`, `ifsc`, `rail`, `bankName` (`accountType` is the only unconditional required field; required set is rail-dependent — NEFT/RTGS need accountNumber + ifsc + rail, UPI needs vpa), and `InrAccountInfo` allows `NEFT`/`RTGS` in `paymentRails`. Mirrors the shape sparkcore already generates in `scripts/grid/generated_common/InrAccountInfoBase.yaml` for the M2 non-instant INR corridor.

**Follow-ups (not in this PR):** regenerate the sparkcore grid-api client from this spec (`grid-api/update_schema.sh`), then wire the sparkcore server side to persist/serialize the bank fields in `destination_details`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJZdGCz7aSRNSHcBEdweyD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJZdGCz7aSRNSHcBEdweyD)_