### PR TITLE
docs: add changelog page with sandbox card issuance and new country coverage

### DIFF
--- a/mintlify/changelog.mdx
+++ b/mintlify/changelog.mdx
@@ -1,0 +1,31 @@
+---
+title: "Changelog"
+description: "New features, improvements, and updates to the Grid API."
+icon: "/images/icons/IconNewspaper2.svg"
+mode: "wide"
+---
+
+Follow along with the latest additions and improvements to the Grid API. For upcoming
+changes and roadmap, [book a live demo](https://www.lightspark.com/contact) or
+[contact support](mailto:support@lightspark.com).
+
+<Update label="July 2026">
+
+## Card issuance in sandbox
+
+You can now issue cards directly in the sandbox environment. Test the full card
+lifecycle—[cardholder setup](/cards/onboarding/cardholder-setup),
+[issuing cards](/cards/card-management/issuing-cards),
+[funding sources](/cards/card-management/funding-sources), and
+[freezing and closing](/cards/card-management/freezing-and-closing)—end to end
+before going live, without touching production.
+
+See [Cards sandbox testing](/cards/platform-tools/sandbox-testing) to get started.
+
+## Expanded country coverage
+
+Grid now supports additional countries, including **China**, broadening the corridors
+available for global payments. Review the currencies and rails available in each region
+in [Currencies and rails](/platform-overview/core-concepts/currencies-and-rails).
+
+</Update>

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -374,6 +374,17 @@
         ]
       },
       {
+        "tab": "Changelog",
+        "groups": [
+          {
+            "group": "Changelog",
+            "pages": [
+              "changelog"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "API reference",
         "groups": [
           {


### PR DESCRIPTION
## Summary

Adds a Changelog page to the Grid API docs, surfaced as a new top-level **Changelog** tab.

The initial entry (July 2026) covers:
- **Card issuance in sandbox** — you can now test the full card lifecycle in sandbox before going live.
- **Expanded country coverage** — additional countries including China, broadening global payment corridors.

## Changes

- `mintlify/changelog.mdx` — new page using Mintlify's `<Update>` component, with links to the relevant cards and currencies/rails docs.
- `mintlify/docs.json` — added the Changelog tab to navigation.

## Notes

Preview locally with `cd mintlify && mint dev`. The repo's `make lint-markdown` target references a missing npm script (pre-existing, unrelated); `docs.json` was validated as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)