### PR TITLE
Playground: fix sign-in reveal regressions and stagger marketplace home on skin switch

### DIFF
--- a/components/grid-wallet-demo/src/apps/SignInFlow.module.scss
+++ b/components/grid-wallet-demo/src/apps/SignInFlow.module.scss
@@ -14,6 +14,12 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Own stacking context: without it the wallet's inner z-indexed content
+     (headers, tab bars, sheets) escapes and paints ABOVE the exiting auth
+     screen, inverting the reveal — the home pops in on top while the auth
+     backdrop fades behind it. (An animating opacity used to create this
+     context implicitly; the solid mount doesn't.) */
+  isolation: isolate;
 }
 
 /* The exiting auth screen blur-fades OVER the freshly mounted wallet. */

--- a/components/grid-wallet-demo/src/apps/SignInFlow.tsx
+++ b/components/grid-wallet-demo/src/apps/SignInFlow.tsx
@@ -132,6 +132,13 @@ function WalletHost({
   // The money-sheet brain rides the wallet brain's sheet state. The wiring here
   // (quote guard, save-confirmation toasts) was identical across every skin —
   // it lives with the brains now.
+  // The skin this host MOUNTED with — any other id means the user switched
+  // platforms mid-session, so the incoming view is a fresh face over live
+  // state (not the sign-in reveal). Skins that skip the sign-in stagger on
+  // their live home (marketplace) still cascade in on a switch.
+  const mountSkin = useRef(skinId);
+  const switchedIn = skinId !== mountSkin.current;
+
   const money = useMoneySheet({
     open: home.sheetOpen,
     mode: home.sheetMode,
@@ -168,7 +175,13 @@ function WalletHost({
         animate={{ ...SKIN_ENTER, transition: SKIN_FADE }}
         exit={{ ...SKIN_EXIT, transition: SKIN_FADE }}
       >
-        <WalletScreen entrance={entrance} home={home} money={money} onCardIssued={onCardIssued} />
+        <WalletScreen
+          entrance={entrance}
+          switchedIn={switchedIn}
+          home={home}
+          money={money}
+          onCardIssued={onCardIssued}
+        />
       </motion.div>
     </AnimatePresence>
   );
@@ -293,7 +306,11 @@ export function SignInFlow({
             // fades. Cross-fading both (wallet 0→1 while auth 1→0) lets the
             // page background bleed through mid-fade (~25% at the midpoint),
             // a visible flash even when the two layers are pixel-identical.
-            initial={false}
+            // An EXPLICIT solid pose, not initial={false}: false propagates
+            // down the motion tree and suppresses every descendant's entrance
+            // (the wallet home's stagger reveal hard-cut in instead of
+            // cascading under the dissolving auth layer).
+            initial={{ opacity: 1 }}
             animate={{ opacity: 1 }}
             // Stay solid underneath while the auth screen blur-fades in over it,
             // then unmount hidden — no peek at the background mid-transition.

--- a/components/grid-wallet-demo/src/apps/marketplace/wallet/MarketplaceWalletScreen.tsx
+++ b/components/grid-wallet-demo/src/apps/marketplace/wallet/MarketplaceWalletScreen.tsx
@@ -31,14 +31,16 @@ const PUSH_TRANSITION = motionTransition(easeOutSnappy, MARKETPLACE_PUSH_DURATIO
  *  AddMoneyPage in from the right, iOS-nav style, while the home parallax-
  *  shifts left beneath it. Withdraw/Send stay decorative this pass.
  *
- *  No entrance stagger on the LIVE home: the sign-in stagger plays on the
+ *  No entrance stagger on the SIGN-IN mount: the sign-in stagger plays on the
  *  auth screen's pixel-identical backdrop (items cascade in as the sheet
  *  dismisses — MarketplaceAuthScreen's `entranceHeld`), so by the time the
  *  auth → wallet swap fires, both layers show the fully-revealed layout and
  *  the crossfade is invisible. Staggering again here would re-reveal visible
- *  content — a flash of it crossfading on itself. */
+ *  content — a flash of it crossfading on itself. A SKIN SWITCH is different:
+ *  the incoming face is new content, so it cascades in like every other skin
+ *  (`switchedIn` from the wallet host). */
 export function MarketplaceWalletScreen(props: SkinWalletScreenProps) {
-  const { home, money } = props;
+  const { home, money, entrance, switchedIn } = props;
   const reduceMotion = useReducedMotion();
   const pageOpen = home.sheetOpen;
   // A close from the confirm step = a completed transfer: the page settles
@@ -96,6 +98,7 @@ export function MarketplaceWalletScreen(props: SkinWalletScreenProps) {
               balanceCents={home.availableCents}
               apyPercent={home.apyPercent}
               rewardsMonthCents={home.earningsMonthCents}
+              entrance={entrance && switchedIn}
               showActivity
               activity={home.homeActivity}
               animatedBalance

--- a/components/grid-wallet-demo/src/apps/social/wallet/CardIssuanceSheet.tsx
+++ b/components/grid-wallet-demo/src/apps/social/wallet/CardIssuanceSheet.tsx
@@ -404,6 +404,14 @@ export function CardIssuanceSheet({
             status while a tap runs. pointer-events pass through to the canvas
             everywhere except the interactive area, so the hero card keeps its
             hover tilt. */}
+        {/* Own AnimatePresence so the home content mounts as a FRESH presence
+            child: the skin-switch AnimatePresence up in SignInFlow carries
+            initial={false}, and this keepMounted sheet lives inside its
+            first-generation subtree — without this wrapper, that presence
+            context suppresses the `initial` of everything mounting later
+            here, popping the home content in with no entrance (the Aurora
+            WalletListCard lesson). */}
+        <AnimatePresence initial={false}>
         {showHome && (
           <motion.div
             key="home"
@@ -475,6 +483,7 @@ export function CardIssuanceSheet({
             </motion.div>
           </motion.div>
         )}
+        </AnimatePresence>
 
         <div
           className={clsx(styles.content, flow === 'fan' && styles.contentSolid)}

--- a/components/grid-wallet-demo/src/apps/types.ts
+++ b/components/grid-wallet-demo/src/apps/types.ts
@@ -46,6 +46,10 @@ export interface SkinWalletScreenProps {
   money: MoneySheet;
   /** One-shot sign-in entrance stagger. */
   entrance?: boolean;
+  /** This wallet view mounted because of a SKIN SWITCH, not sign-in. Skins
+   *  whose sign-in reveal pre-plays the home stagger elsewhere (marketplace's
+   *  auth backdrop) use this to still cascade in on a platform change. */
+  switchedIn?: boolean;
   /** A virtual card finished issuing on the phone — log the issue call. */
   onCardIssued?: () => void;
 }

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.tsx
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.tsx
@@ -47,14 +47,6 @@ export function ConfigurePanel({
           </section>
 
           <section className={styles.section}>
-            <SectionDivider label="Configure auth" />
-            {/* Never disabled: the auth screens render live from `methods`, and
-                an in-flight sign-in has already committed its method — toggling
-                mid-flow just updates the CTA list behind the overlay. */}
-            <AuthMethodPicker methods={methods} onToggle={onToggleMethod} />
-          </section>
-
-          <section className={styles.section}>
             <SectionDivider
               label="Explore flows"
               action={
@@ -72,6 +64,14 @@ export function ConfigurePanel({
               }
             />
             <FlowPicker wallet={wallet} running={running} onAction={onAction} />
+          </section>
+
+          <section className={styles.section}>
+            <SectionDivider label="Configure auth" />
+            {/* Never disabled: the auth screens render live from `methods`, and
+                an in-flight sign-in has already committed its method — toggling
+                mid-flow just updates the CTA list behind the overlay. */}
+            <AuthMethodPicker methods={methods} onToggle={onToggleMethod} />
           </section>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes three motion regressions introduced by the marketplace sign-in polish (in #647), plus two small follow-ups:

- **Sign-in entrance stagger was dead on every skin** — the auth → wallet swap mounted the wallet layer with `initial={false}`, which propagates down the motion tree and suppressed each home's entrance cascade (Aurora/Glitch read as a hard cut). The layer now mounts with an explicit solid pose (`initial={{ opacity: 1 }}`), keeping the no-bleed solid mount while letting descendants animate.
- **Home content painted over the dissolving auth screen** — the solid mount also dropped the stacking context the old cross-fade created implicitly, so the wallet's inner z-indexed chrome escaped above the exiting auth layer (home popped in on top while the aurora faded *behind* it). `isolation: isolate` on the screen layers makes each one an atomic paint layer.
- **Z card home appeared instantly and clipped after issuance** — the card home content now mounts inside its own `AnimatePresence` so its entrance choreography plays.
- **Waterbnb now staggers its home in on a skin switch** — new `switchedIn` prop from the wallet host distinguishes a platform change from the sign-in mount, so marketplace cascades in like every other skin while its sign-in swap stays a pixel-identical no-op.
- **Sidebar order** — Explore flows sits above Configure auth.

## Test plan

- [ ] Sign in on Aurora / Glitch: auth screen blur-dissolves OVER the home while its content staggers in beneath
- [ ] Sign in on Waterbnb: swap stays seamless (no re-reveal flash)
- [ ] Switch skins to Waterbnb mid-session: home content cascades in
- [ ] Z: issue card → card home, tap-to-pay + activity animate in un-clipped
- [ ] Sidebar reads Select platform → Explore flows → Configure auth

Made with [Cursor](https://cursor.com)