### PR TITLE
Add HOLD KYB/KYC status and FAILED internal account status

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9429,7 +9429,8 @@ components:
         - PENDING
         - APPROVED
         - REJECTED
-      description: The current KYC status of a customer
+        - HOLD
+      description: The current KYC status of a customer. `HOLD` means the customer is placed on hold and may be required to update or provide more information.
       example: APPROVED
     Address:
       type: object
@@ -9500,7 +9501,8 @@ components:
         - PENDING
         - APPROVED
         - REJECTED
-      description: The current KYB status of a business customer
+        - HOLD
+      description: The current KYB status of a business customer. `HOLD` means the customer is placed on hold and may be required to update or provide more information.
       example: APPROVED
     EntityType:
       type: string
@@ -10342,6 +10344,7 @@ components:
         - ACTIVE
         - CLOSED
         - FROZEN
+        - FAILED
       description: |-
         Status of a Grid internal account. The status determines whether the account can send or receive payments.
 
@@ -10349,6 +10352,7 @@ components:
         - `ACTIVE`: The account is ready to send and receive payments.
         - `CLOSED`: The account cannot send or receive payments. A customer can initiate the closing of an internal account, after which the account transitions to this status.
         - `FROZEN`: The account cannot send or receive payments. Grid may freeze an account in response to compliance or fraud signals; payments are blocked while the account remains frozen.
+        - `FAILED`: The account could not be provisioned. Grid was unable to create the underlying account, so it cannot send or receive payments and requires remediation.
       example: ACTIVE
     CurrencyAmount:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9429,7 +9429,8 @@ components:
         - PENDING
         - APPROVED
         - REJECTED
-      description: The current KYC status of a customer
+        - HOLD
+      description: The current KYC status of a customer. `HOLD` means the customer is placed on hold and may be required to update or provide more information.
       example: APPROVED
     Address:
       type: object
@@ -9500,7 +9501,8 @@ components:
         - PENDING
         - APPROVED
         - REJECTED
-      description: The current KYB status of a business customer
+        - HOLD
+      description: The current KYB status of a business customer. `HOLD` means the customer is placed on hold and may be required to update or provide more information.
       example: APPROVED
     EntityType:
       type: string
@@ -10342,6 +10344,7 @@ components:
         - ACTIVE
         - CLOSED
         - FROZEN
+        - FAILED
       description: |-
         Status of a Grid internal account. The status determines whether the account can send or receive payments.
 
@@ -10349,6 +10352,7 @@ components:
         - `ACTIVE`: The account is ready to send and receive payments.
         - `CLOSED`: The account cannot send or receive payments. A customer can initiate the closing of an internal account, after which the account transitions to this status.
         - `FROZEN`: The account cannot send or receive payments. Grid may freeze an account in response to compliance or fraud signals; payments are blocked while the account remains frozen.
+        - `FAILED`: The account could not be provisioned. Grid was unable to create the underlying account, so it cannot send or receive payments and requires remediation.
       example: ACTIVE
     CurrencyAmount:
       type: object

--- a/openapi/components/schemas/customers/InternalAccountStatus.yaml
+++ b/openapi/components/schemas/customers/InternalAccountStatus.yaml
@@ -5,6 +5,7 @@ enum:
   - ACTIVE
   - CLOSED
   - FROZEN
+  - FAILED
 description: >-
   Status of a Grid internal account. The status determines whether the account
   can send or receive payments.
@@ -22,4 +23,8 @@ description: >-
   - `FROZEN`: The account cannot send or receive payments. Grid may freeze an
   account in response to compliance or fraud signals; payments are blocked
   while the account remains frozen.
+
+  - `FAILED`: The account could not be provisioned. Grid was unable to create
+  the underlying account, so it cannot send or receive payments and requires
+  remediation.
 example: ACTIVE

--- a/openapi/components/schemas/customers/KybStatus.yaml
+++ b/openapi/components/schemas/customers/KybStatus.yaml
@@ -4,5 +4,8 @@ enum:
   - PENDING
   - APPROVED
   - REJECTED
-description: The current KYB status of a business customer
+  - HOLD
+description: >-
+  The current KYB status of a business customer. `HOLD` means the customer is
+  placed on hold and may be required to update or provide more information.
 example: APPROVED

--- a/openapi/components/schemas/customers/KycStatus.yaml
+++ b/openapi/components/schemas/customers/KycStatus.yaml
@@ -4,5 +4,8 @@ enum:
   - PENDING
   - APPROVED
   - REJECTED
-description: The current KYC status of a customer
+  - HOLD
+description: >-
+  The current KYC status of a customer. `HOLD` means the customer is placed on
+  hold and may be required to update or provide more information.
 example: APPROVED


### PR DESCRIPTION
## Summary

- Adds `FAILED` to `InternalAccountStatus` for internal accounts whose provisioning failed and require remediation.
- Adds `HOLD` to `KybStatus` and `KycStatus`. `HOLD` means the customer is placed on hold and may be required to update or provide more information.

## Notes

Consumed by webdev via `grid-api/update_schema.sh` to regenerate the vendored Python client. Supports two stacked webdev PRs: internal-account failure handling (`FAILED`) and the KYC/KYB `HOLD` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)