### PR TITLE
Playground: give the code panel more room + graceful docs-sidebar toggles

### DIFF
--- a/components/grid-wallet-demo/src/app/globals.scss
+++ b/components/grid-wallet-demo/src/app/globals.scss
@@ -155,14 +155,14 @@ body {
   --dot-grid-dot-peak: #b8b8b3;
 }
 
-/* 3-col layout (>= $breakpoint-layout-wide): the light stage steps down a hair
-   so it separates from the raised cards flanking it. Declared BEFORE the dark
-   block below so dark mode (same specificity, later in source) still wins.
-   The JS canvas re-reads the token on resize (StageGL's ResizeObserver). */
-@media (min-width: 1440px) {
-  :root {
-    --dot-grid-bg: #f4f4f3;
-  }
+/* 3-col layout: the light stage steps down a hair so it separates from the
+   raised cards flanking it. Keyed to html's data-layout attribute (set
+   pre-paint by layout.tsx, kept live by page.tsx) so the color rides the
+   same clock as the arrangement flip. Light-only — the dark stage is
+   gray-950 in both arrangements. The JS canvas re-reads the token on resize
+   (StageGL's ResizeObserver), which every arrangement flip triggers. */
+html:not([data-theme='dark']):not([data-layout='stacked']) {
+  --dot-grid-bg: #f4f4f3;
 }
 
 :root {

--- a/components/grid-wallet-demo/src/app/globals.scss
+++ b/components/grid-wallet-demo/src/app/globals.scss
@@ -147,14 +147,22 @@ body {
    [data-theme] flips, so the whole backdrop changes in lockstep (no stagger).
    `--dot-grid-dot` is the resting dot; `--dot-grid-dot-peak` is the ripple crest. */
 :root {
-  /* Light: halfway between surface-secondary's sunken stage gray (#F0F0EE —
-     too close to the Mintlify chrome) and the panel surface (#F8F8F7), so the
-     stage reads as its own layer without matching either. Dark overrides to
-     gray-925 below — the WebGL dots' original backdrop; surface-secondary's
-     #111111 reads too dark. */
-  --dot-grid-bg: #f5f5f3;
+  /* Light: surface-primary (#F8F8F7) — the stage sits a step ABOVE the
+     chrome-gray side panels (surface-secondary), matching the raised cards.
+     Dark overrides below mirror it: gray-950 stage over #111111 chrome. */
+  --dot-grid-bg: var(--surface-primary);
   --dot-grid-dot: #deded9;
   --dot-grid-dot-peak: #b8b8b3;
+}
+
+/* 3-col layout (>= $breakpoint-layout-wide): the light stage steps down a hair
+   so it separates from the raised cards flanking it. Declared BEFORE the dark
+   block below so dark mode (same specificity, later in source) still wins.
+   The JS canvas re-reads the token on resize (StageGL's ResizeObserver). */
+@media (min-width: 1440px) {
+  :root {
+    --dot-grid-bg: #f4f4f3;
+  }
 }
 
 :root {
@@ -178,9 +186,11 @@ body {
 }
 
 [data-theme='dark'] {
-  --dot-grid-bg: var(--color-gray-925);
-  --dot-grid-dot: #333330;
-  --dot-grid-dot-peak: #4d4d47;
+  /* gray-950 (#1A1A1A) — a step darker than the chrome-gray side panels'
+     raised cards, mirroring the light stage sitting under the panel surface. */
+  --dot-grid-bg: var(--color-gray-950);
+  --dot-grid-dot: #2d2d2a;
+  --dot-grid-dot-peak: #474741;
   --p-bg: #000000;
   --p-screen: #000000;
   --p-surface: #141414;

--- a/components/grid-wallet-demo/src/app/globals.scss
+++ b/components/grid-wallet-demo/src/app/globals.scss
@@ -147,10 +147,12 @@ body {
    [data-theme] flips, so the whole backdrop changes in lockstep (no stagger).
    `--dot-grid-dot` is the resting dot; `--dot-grid-dot-peak` is the ripple crest. */
 :root {
-  /* Light: surface-secondary is the sunken stage gray (#F0F0EE), like
-     grid-visualizer's dot panels. Dark overrides to gray-925 below — the WebGL
-     dots' original backdrop; surface-secondary's #111111 reads too dark. */
-  --dot-grid-bg: var(--surface-secondary);
+  /* Light: halfway between surface-secondary's sunken stage gray (#F0F0EE —
+     too close to the Mintlify chrome) and the panel surface (#F8F8F7), so the
+     stage reads as its own layer without matching either. Dark overrides to
+     gray-925 below — the WebGL dots' original backdrop; surface-secondary's
+     #111111 reads too dark. */
+  --dot-grid-bg: #f5f5f3;
   --dot-grid-dot: #deded9;
   --dot-grid-dot-peak: #b8b8b3;
 }

--- a/components/grid-wallet-demo/src/app/layout.tsx
+++ b/components/grid-wallet-demo/src/app/layout.tsx
@@ -44,7 +44,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preload" href="/fonts/SuisseIntl-Book.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/SuisseIntl-Medium.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/SuisseIntlMono-Regular-WebXL.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
-        {/* Set data-embed and an initial data-theme before paint to avoid a flash. */}
+        {/* Set data-embed, an initial data-theme, and the stacked ⇄ 3-col
+            data-layout before paint to avoid a flash. The layout attribute
+            must land pre-paint (not in a React effect): the SSR HTML paints
+            long before hydration, and the wide default would flash 3-col on
+            stacked viewports while the JS loads. 1600 matches
+            $breakpoint-layout-wide. */}
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{
@@ -58,6 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';
               }
               document.documentElement.setAttribute('data-theme',t);
+              document.documentElement.setAttribute('data-layout',window.innerWidth<1600?'stacked':'wide');
             }catch(e){}})();`,
           }}
         />

--- a/components/grid-wallet-demo/src/app/layout.tsx
+++ b/components/grid-wallet-demo/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { easingVarsStylesheet } from '@/lib/easing';
+import { CONFIGURE_COL_PX, LAYOUT_WIDE_PX } from '@/lib/layout';
 import './globals.scss';
 
 const TITLE = 'Grid Global Accounts — Live demo';
@@ -44,12 +45,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preload" href="/fonts/SuisseIntl-Book.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/SuisseIntl-Medium.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
         <link rel="preload" href="/fonts/SuisseIntlMono-Regular-WebXL.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />
-        {/* Set data-embed, an initial data-theme, and the stacked ⇄ 3-col
-            data-layout before paint to avoid a flash. The layout attribute
-            must land pre-paint (not in a React effect): the SSR HTML paints
-            long before hydration, and the wide default would flash 3-col on
-            stacked viewports while the JS loads. 1600 matches
-            $breakpoint-layout-wide. */}
+        {/* Boot attributes, set before first paint to avoid flashes — an
+            effect is too late (the SSR HTML paints long before hydration):
+            - data-embed / data-theme from the URL (embed) or stored pref
+            - data-layout (stacked ⇄ 3-col) from the viewport width
+            - --api-col-default from the embed's ?nav param (the live docs
+              sidebar width), so the wide layout's code column paints at its
+              real default — sidebar + configure column — instead of the
+              expanded-sidebar assumption and re-fitting after hydration. */}
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{
@@ -63,7 +66,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';
               }
               document.documentElement.setAttribute('data-theme',t);
-              document.documentElement.setAttribute('data-layout',window.innerWidth<1600?'stacked':'wide');
+              document.documentElement.setAttribute('data-layout',window.innerWidth<${LAYOUT_WIDE_PX}?'stacked':'wide');
+              var nav=parseFloat(p.get('nav'));
+              if(isFinite(nav)&&nav>=0){document.documentElement.style.setProperty('--api-col-default',(Math.round(nav)+${CONFIGURE_COL_PX})+'px');}
             }catch(e){}})();`,
           }}
         />

--- a/components/grid-wallet-demo/src/app/page.module.scss
+++ b/components/grid-wallet-demo/src/app/page.module.scss
@@ -47,6 +47,21 @@
   overflow: hidden;
 }
 
+/* Side-by-side: ease programmatic width changes (the default following a docs
+   sidebar collapse/expand) — but never a live drag, which must track 1:1.
+   Scoped to the wide layout so the stacked breakpoints (width: 100%) flip
+   instantly with the media query. */
+@media (min-width: $breakpoint-layout-wide) {
+  .apiCol {
+    transition: width 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
+  }
+
+  .apiCol[data-resizing],
+  .apiCol[data-snap] {
+    transition: none;
+  }
+}
+
 /* Laptop: configure left, app over API on the right. Floored at the mobile
    breakpoint so these rules never leak into the mobile single-column layout. */
 @media (min-width: ($breakpoint-layout-mobile + 1px)) and (max-width: ($breakpoint-layout-wide - 1px)) {

--- a/components/grid-wallet-demo/src/app/page.module.scss
+++ b/components/grid-wallet-demo/src/app/page.module.scss
@@ -60,7 +60,9 @@
   .appCol {
     flex: none;
     width: 100% !important;
-    min-height: calc(100% - var(--panel-header-height, 52px));
+    /* Peek the API panel's header PLUS a strip of its body under the phone —
+       enough to read as content waiting below, not just a bar. */
+    min-height: calc(100% - var(--panel-header-height, 52px) - 64px);
     overflow: visible;
   }
 

--- a/components/grid-wallet-demo/src/app/page.module.scss
+++ b/components/grid-wallet-demo/src/app/page.module.scss
@@ -47,45 +47,48 @@
   overflow: hidden;
 }
 
-/* Side-by-side: ease programmatic width changes (the default following a docs
-   sidebar collapse/expand) — but never a live drag, which must track 1:1.
-   Scoped to the wide layout so the stacked breakpoints (width: 100%) flip
-   instantly with the media query. */
+/* Side-by-side: nav-driven width changes (the default following a docs
+   sidebar collapse/expand) opt INTO the ease via data-easing — set in the
+   same commit as the width change, never by default. An always-on transition
+   would race the stacked ⇄ 3-col media flip and hold the column at its full
+   stacked width inside the fresh row layout for a frame or two, crushing the
+   app column to zero (the phone blinks out). Drags always track 1:1. */
 @media (min-width: $breakpoint-layout-wide) {
-  .apiCol {
+  .apiCol[data-easing]:not([data-resizing]) {
     transition: width 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
-  }
-
-  .apiCol[data-resizing],
-  .apiCol[data-snap] {
-    transition: none;
   }
 }
 
-/* Laptop: configure left, app over API on the right. Floored at the mobile
-   breakpoint so these rules never leak into the mobile single-column layout. */
-@media (min-width: ($breakpoint-layout-mobile + 1px)) and (max-width: ($breakpoint-layout-wide - 1px)) {
-  .stackCol {
-    flex-direction: column;
-    min-height: 0;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-  }
+/* Laptop: configure left, app over API on the right. Keyed to html's
+   data-layout attribute (set pre-paint by the layout.tsx inline script, kept
+   live by page.tsx) instead of a media query, so the arrangement and the
+   attribute-keyed chrome colors flip on one clock. Floored at the mobile
+   breakpoint so these rules never leak into the mobile single-column layout
+   (whose media rules set the same properties at lower specificity). */
+@media (min-width: ($breakpoint-layout-mobile + 1px)) {
+  :global(html[data-layout='stacked']) {
+    .stackCol {
+      flex-direction: column;
+      min-height: 0;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
 
-  .appCol {
-    flex: none;
-    width: 100% !important;
-    /* Peek the API panel's header PLUS a strip of its body under the phone —
-       enough to read as content waiting below, not just a bar. */
-    min-height: calc(100% - var(--panel-header-height, 52px) - 64px);
-    overflow: visible;
-  }
+    .appCol {
+      flex: none;
+      width: 100% !important;
+      /* Peek the API panel's header PLUS a strip of its body under the phone —
+         enough to read as content waiting below, not just a bar. */
+      min-height: calc(100% - var(--panel-header-height, 52px) - 64px);
+      overflow: visible;
+    }
 
-  .apiCol {
-    flex: none;
-    width: 100% !important;
-    min-height: 0;
-    overflow: visible;
+    .apiCol {
+      flex: none;
+      width: 100% !important;
+      min-height: 0;
+      overflow: visible;
+    }
   }
 }
 

--- a/components/grid-wallet-demo/src/app/page.module.scss
+++ b/components/grid-wallet-demo/src/app/page.module.scss
@@ -45,6 +45,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Pre-hydration width: --api-col-default is set before first paint (from
+     the embed's ?nav param, see layout.tsx) so the wide layout boots at the
+     REAL default instead of re-fitting once React measures. The 680px
+     fallback is the standalone default — keep in sync with API_DEFAULT_WIDTH
+     in useColumnResize. React's inline width takes over after hydration. */
+  width: var(--api-col-default, 680px);
 }
 
 /* Side-by-side: nav-driven width changes (the default following a docs

--- a/components/grid-wallet-demo/src/app/page.tsx
+++ b/components/grid-wallet-demo/src/app/page.tsx
@@ -33,7 +33,7 @@ function withViewTransition(update: () => void) {
 
 export default function Page() {
   const logic = useWalletDemoLogic();
-  const { layoutRef, apiColRef, apiWidth, onResizeStart } = useColumnResize();
+  const { layoutRef, apiColRef, apiWidth, resizing, onResizeStart } = useColumnResize();
 
   // Mobile only (<=767): the layout collapses to one view at a time. On desktop
   // this stays 'configure' forever (the switch is gated to the mobile viewport),
@@ -153,6 +153,7 @@ export default function Page() {
         <div
           ref={apiColRef}
           className={styles.apiCol}
+          data-resizing={resizing || undefined}
           style={{ width: apiWidth, flex: '0 0 auto' }}
         >
           <ApiPanel entries={logic.entries} />

--- a/components/grid-wallet-demo/src/app/page.tsx
+++ b/components/grid-wallet-demo/src/app/page.tsx
@@ -11,6 +11,7 @@ import { ColumnResizeHandle } from '@/components/ColumnResizeHandle/ColumnResize
 import { ThemeSync } from '@/components/ThemeSync';
 import { useColumnResize } from '@/hooks/useColumnResize';
 import { useWalletDemoLogic } from '@/hooks/useWalletDemoLogic';
+import { LAYOUT_WIDE_PX } from '@/lib/layout';
 import type { ActionId } from '@/data/actions';
 import styles from './page.module.scss';
 
@@ -41,8 +42,7 @@ export default function Page() {
   // would flash the SSR wide default on stacked viewports while JS loads);
   // this listener only keeps it live across resizes.
   useLayoutEffect(() => {
-    // Matches $breakpoint-layout-wide.
-    const mql = window.matchMedia('(max-width: 1599px)');
+    const mql = window.matchMedia(`(max-width: ${LAYOUT_WIDE_PX - 1}px)`);
     const apply = () =>
       document.documentElement.setAttribute('data-layout', mql.matches ? 'stacked' : 'wide');
     apply();
@@ -173,7 +173,10 @@ export default function Page() {
           ref={apiColRef}
           className={styles.apiCol}
           data-resizing={resizing || undefined}
-          style={{ width: apiWidth, flex: '0 0 auto' }}
+          // No inline width until the post-hydration measure — the stylesheet's
+          // var(--api-col-default) (seeded pre-paint from the embed's ?nav
+          // param) styles the column so the first paint is already correct.
+          style={{ width: apiWidth ?? undefined }}
         >
           <ApiPanel entries={logic.entries} />
         </div>

--- a/components/grid-wallet-demo/src/app/page.tsx
+++ b/components/grid-wallet-demo/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { IconArrowRight } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconArrowRight';
 import { IconArrowLeft } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconArrowLeft';
@@ -34,6 +34,21 @@ function withViewTransition(update: () => void) {
 export default function Page() {
   const logic = useWalletDemoLogic();
   const { layoutRef, apiColRef, apiWidth, resizing, onResizeStart } = useColumnResize();
+
+  // Stacked ⇄ 3-col as a data-layout attribute on <html> so the arrangement,
+  // the panel chrome colors, and the API header all flip on one clock. The
+  // inline script in layout.tsx sets it BEFORE first paint (an effect here
+  // would flash the SSR wide default on stacked viewports while JS loads);
+  // this listener only keeps it live across resizes.
+  useLayoutEffect(() => {
+    // Matches $breakpoint-layout-wide.
+    const mql = window.matchMedia('(max-width: 1599px)');
+    const apply = () =>
+      document.documentElement.setAttribute('data-layout', mql.matches ? 'stacked' : 'wide');
+    apply();
+    mql.addEventListener('change', apply);
+    return () => mql.removeEventListener('change', apply);
+  }, []);
 
   // Mobile only (<=767): the layout collapses to one view at a time. On desktop
   // this stays 'configure' forever (the switch is gated to the mobile viewport),
@@ -93,7 +108,11 @@ export default function Page() {
   }, [mobileView]);
 
   return (
-    <main ref={layoutRef} className={styles.layout} data-mobile-view={mobileView}>
+    <main
+      ref={layoutRef}
+      className={styles.layout}
+      data-mobile-view={mobileView}
+    >
       <ThemeSync />
       <div className={styles.configCol}>
         <ConfigurePanel

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiCallList.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiCallList.module.scss
@@ -102,16 +102,19 @@
   corner-shape: var(--corner-shape);
   --badge-height: 20px;
   --row-padding: calc((48px - var(--badge-height)) / 2);
+  /* Single source for the card surface — the endpoint fade + tab indicator
+     must match it exactly, and the wide layout re-tints all three at once. */
+  --call-card-bg: var(--surface-base);
   display: flex;
   flex-direction: column;
   width: 100%;
-  background: var(--surface-base);
+  background: var(--call-card-bg);
   border: 0.5px solid var(--border-tertiary);
   border-radius: var(--corner-radius-md);
   overflow: clip;
 
   :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
+    --call-card-bg: var(--color-gray-925);
   }
 
   &:hover,
@@ -190,11 +193,7 @@
   pointer-events: none;
   opacity: 0;
   transition: opacity 150ms ease;
-  background: linear-gradient(to right, transparent, var(--surface-base) 52%);
-
-  :global([data-theme='dark']) & {
-    background: linear-gradient(to right, transparent, var(--color-gray-925) 52%);
-  }
+  background: linear-gradient(to right, transparent, var(--call-card-bg) 52%);
 }
 
 .endpointCopyBtn {
@@ -254,12 +253,8 @@
   box-sizing: border-box;
   border-left: var(--stroke-xs) solid var(--border-tertiary);
   border-right: var(--stroke-xs) solid var(--border-tertiary);
-  background: var(--surface-base);
+  background: var(--call-card-bg);
   pointer-events: none;
-
-  :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
-  }
 }
 
 .tabGroupLeadingActive .tabIndicator {
@@ -369,6 +364,19 @@
 
   :global([data-theme='dark']) & {
     color: #85e89d;
+  }
+}
+
+/* Side-by-side the panel wears the docs-chrome gray, so the cards step down
+   with it: pure white (light) / gray-925 (dark) read too hot on the chrome —
+   one notch softer keeps the same card-to-panel delta as the stacked layout. */
+@media (min-width: $breakpoint-layout-wide) {
+  .callCard {
+    --call-card-bg: var(--surface-primary);
+
+    :global([data-theme='dark']) & {
+      --call-card-bg: var(--color-gray-950);
+    }
   }
 }
 

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiCallList.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiCallList.module.scss
@@ -13,7 +13,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 48px;
+  /* Sides match the Configure panel's content padding. */
+  padding: 48px $layout-laptop-content-padding;
   padding-top: calc(var(--spacing-md) + 12px);
 
   // Mobile: match the Configure panel's 24px side padding.

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
@@ -75,6 +75,13 @@
   .panel {
     overflow-y: auto;
     overscroll-behavior: contain;
+    /* Experiment: side-by-side, the calls column wears the docs-chrome gray
+       (both modes — surface-secondary flips with the theme). */
+    background: var(--surface-secondary);
+
+    :global([data-theme='dark']) & {
+      background: var(--surface-secondary);
+    }
   }
 
   .body {

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
@@ -81,12 +81,10 @@
     overflow: visible;
   }
 
+  /* Side-by-side: the calls ARE the column — no header bar needed (it only
+     earns its keep stacked, where it's the peek target + new-call signifier).
+     The resize handle draws the full-height column divider. */
   .headerStacked {
-    border-left: var(--stroke-xs) solid var(--border-primary);
-  }
-
-  /* Side-by-side: calls are always in view, so no "new" signifier. */
-  .newPill {
     display: none;
   }
 }

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
@@ -59,25 +59,23 @@
   }
 }
 
-/* Keyed to the JS-managed layout attribute (page.tsx), not the media query,
-   so the panel's structure and chrome follow the arrangement flip exactly —
-   including when a docs-sidebar toggle flips it ahead of the media crossing.
-   (The attribute is 'stacked' on laptop AND mobile, matching the old
-   max-width media block.) */
-:global([data-layout='stacked']) .panel {
+/* Keyed to html's data-layout attribute (set pre-paint by layout.tsx, kept
+   live by page.tsx) rather than the media query, so the panel's structure
+   and chrome flip on the same clock as the arrangement. The attribute is
+   'stacked' on laptop AND mobile, matching the old max-width media block. */
+:global(html[data-layout='stacked']) .panel {
   overflow: visible;
 }
 
-:global([data-layout='stacked']) .body {
+:global(html[data-layout='stacked']) .body {
   overflow: visible;
 }
 
-:global([data-layout='stacked']) .headerStacked {
+:global(html[data-layout='stacked']) .headerStacked {
   border-top: var(--stroke-xs) solid var(--border-primary);
 }
 
-/* Side-by-side (attribute absent — also the SSR default; the pre-paint
-   layout effect corrects narrow viewports before first paint). */
+/* Side-by-side. */
 :global(html:not([data-layout='stacked'])) .panel {
   overflow-y: auto;
   overscroll-behavior: contain;

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanel.module.scss
@@ -8,6 +8,8 @@
   flex-direction: column;
   background: var(--surface-primary);
   overflow: hidden;
+  /* Chrome gray only side-by-side — glide the color across the crossing. */
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 
   :global([data-theme='dark']) & {
     background: var(--color-gray-950);
@@ -57,41 +59,40 @@
   }
 }
 
-@media (max-width: ($breakpoint-layout-wide - 1px)) {
-  .panel {
-    overflow: visible;
-  }
-
-  .body {
-    overflow: visible;
-  }
-
-  .headerStacked {
-    border-top: var(--stroke-xs) solid var(--border-primary);
-  }
+/* Keyed to the JS-managed layout attribute (page.tsx), not the media query,
+   so the panel's structure and chrome follow the arrangement flip exactly —
+   including when a docs-sidebar toggle flips it ahead of the media crossing.
+   (The attribute is 'stacked' on laptop AND mobile, matching the old
+   max-width media block.) */
+:global([data-layout='stacked']) .panel {
+  overflow: visible;
 }
 
-@media (min-width: $breakpoint-layout-wide) {
-  .panel {
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    /* Experiment: side-by-side, the calls column wears the docs-chrome gray
-       (both modes — surface-secondary flips with the theme). */
-    background: var(--surface-secondary);
+:global([data-layout='stacked']) .body {
+  overflow: visible;
+}
 
-    :global([data-theme='dark']) & {
-      background: var(--surface-secondary);
-    }
-  }
+:global([data-layout='stacked']) .headerStacked {
+  border-top: var(--stroke-xs) solid var(--border-primary);
+}
 
-  .body {
-    overflow: visible;
-  }
+/* Side-by-side (attribute absent — also the SSR default; the pre-paint
+   layout effect corrects narrow viewports before first paint). */
+:global(html:not([data-layout='stacked'])) .panel {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* The calls column wears the docs-chrome gray. surface-secondary flips
+     with the theme, and this selector outweighs the base dark override. */
+  background: var(--surface-secondary);
+}
 
-  /* Side-by-side: the calls ARE the column — no header bar needed (it only
-     earns its keep stacked, where it's the peek target + new-call signifier).
-     The resize handle draws the full-height column divider. */
-  .headerStacked {
-    display: none;
-  }
+:global(html:not([data-layout='stacked'])) .body {
+  overflow: visible;
+}
+
+/* Side-by-side: the calls ARE the column — no header bar needed (it only
+   earns its keep stacked, where it's the peek target + new-call signifier).
+   The resize handle draws the full-height column divider. */
+:global(html:not([data-layout='stacked'])) .headerStacked {
+  display: none;
 }

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelEmpty.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelEmpty.module.scss
@@ -22,6 +22,8 @@
 .skeletonCover {
   --cover-fade-height: 56px;
   --cover-top: 0px;
+  /* Must match the panel surface exactly or the melt reads as a tint band. */
+  --cover-bg: var(--surface-primary);
   position: absolute;
   inset: var(--cover-top) 0 0;
   pointer-events: none;
@@ -30,16 +32,21 @@
   transition: opacity var(--cover-duration, 550ms) cubic-bezier(0.19, 1, 0.22, 1);
   background: linear-gradient(
     to top,
-    var(--surface-primary) calc(100% - var(--cover-fade-height)),
+    var(--cover-bg) calc(100% - var(--cover-fade-height)),
     transparent 100%
   );
 
   :global([data-theme='dark']) & {
-    background: linear-gradient(
-      to top,
-      var(--color-gray-950) calc(100% - var(--cover-fade-height)),
-      transparent 100%
-    );
+    --cover-bg: var(--color-gray-950);
+  }
+
+  /* Side-by-side the panel wears the docs-chrome gray (both modes). */
+  @media (min-width: $breakpoint-layout-wide) {
+    --cover-bg: var(--surface-secondary);
+
+    :global([data-theme='dark']) & {
+      --cover-bg: var(--surface-secondary);
+    }
   }
 }
 

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelSkeleton.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelSkeleton.module.scss
@@ -16,7 +16,8 @@ $skeleton-bone-dark: var(--color-gray-850);
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 48px;
+  /* Sides match the Configure panel's content padding. */
+  padding: 48px $layout-laptop-content-padding;
   padding-top: calc(var(--spacing-md) + 12px);
   gap: var(--spacing-md);
   opacity: 0.5;

--- a/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelSkeleton.module.scss
+++ b/components/grid-wallet-demo/src/components/ApiPanel/ApiPanelSkeleton.module.scss
@@ -1,6 +1,8 @@
 @use '../../styles/breakpoints' as *;
 
-$skeleton-bone-light: var(--color-gray-075);
+/* gray-100 (was 075): at the feed's 0.5 opacity the pills washed out against
+   the chrome-gray panel — one notch darker keeps them faint but legible. */
+$skeleton-bone-light: var(--color-gray-100);
 $skeleton-bone-dark: var(--color-gray-850);
 
 .list {
@@ -56,6 +58,15 @@ $skeleton-bone-dark: var(--color-gray-850);
 
   :global([data-theme='dark']) & {
     background: var(--color-gray-925);
+  }
+
+  /* Match the live cards' softer surface on the chrome-gray panel (wide). */
+  @media (min-width: $breakpoint-layout-wide) {
+    background: var(--surface-primary);
+
+    :global([data-theme='dark']) & {
+      background: var(--color-gray-950);
+    }
   }
 }
 

--- a/components/grid-wallet-demo/src/components/AppPanel/AppPanel.module.scss
+++ b/components/grid-wallet-demo/src/components/AppPanel/AppPanel.module.scss
@@ -7,6 +7,9 @@
   flex-direction: column;
   overflow: hidden;
   background-color: var(--dot-grid-bg);
+  /* The stage color differs per layout (see globals.scss) — glide it across
+     the stacked ⇄ 3-col crossing instead of snapping. */
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 }
 
 @media (max-width: ($breakpoint-layout-wide - 1px)) {

--- a/components/grid-wallet-demo/src/components/AppPanel/AppPanel.tsx
+++ b/components/grid-wallet-demo/src/components/AppPanel/AppPanel.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { IconPhoneDynamicIsland } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconPhoneDynamicIsland';
-import { PanelHeader } from '@/components/PanelHeader/PanelHeader';
 import { DotGridCanvas } from '@/components/DotGridCanvas/DotGridCanvas';
 import type { PhoneProps } from '@/components/Phone';
 import { DemoPhone } from '@/components/DemoPhone/DemoPhone';
@@ -114,7 +112,6 @@ export function AppPanel(phone: DemoLogicPhoneSlice) {
 
   return (
     <section className={styles.panel}>
-      <PanelHeader icon={<IconPhoneDynamicIsland size={20} />} title="App" />
       <div className={styles.body}>
         <div className={styles.phoneStage}>
           <DotGridCanvas glassConfig={PHONE_SHELL_GLASS}>

--- a/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
@@ -13,6 +13,8 @@
   border: var(--stroke-xs) solid var(--border-primary);
   border-radius: var(--corner-radius-md);
   overflow: clip;
+  // The tile surface steps down side-by-side — glide it across the crossing.
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 
   :global([data-theme='dark']) & {
     --tile-bg: var(--color-gray-925);

--- a/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/AuthMethodPicker/AuthMethodPicker.module.scss
@@ -3,16 +3,27 @@
 
 .group {
   corner-shape: var(--corner-shape);
+  /* Single source for the tile surface — press states mix from it, and the
+     wide layout steps it down to sit on the chrome-gray panel. */
+  --tile-bg: var(--surface-base);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   width: 100%;
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border: var(--stroke-xs) solid var(--border-primary);
   border-radius: var(--corner-radius-md);
   overflow: clip;
 
   :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
+    --tile-bg: var(--color-gray-925);
+  }
+
+  @media (min-width: $breakpoint-layout-wide) {
+    --tile-bg: var(--surface-primary);
+
+    :global([data-theme='dark']) & {
+      --tile-bg: var(--color-gray-950);
+    }
   }
 }
 
@@ -24,15 +35,11 @@
   gap: var(--spacing-sm);
   min-width: 0;
   padding: var(--spacing-md);
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border-bottom: var(--stroke-xs) solid var(--border-primary);
   overflow: clip;
   cursor: pointer;
   transition: background 100ms ease;
-
-  :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
-  }
 
   &:nth-child(odd) {
     border-right: var(--stroke-xs) solid var(--border-primary);
@@ -54,7 +61,7 @@
   // Hover only with a real pointer — avoids the fill sticking after a tap on touch.
   @media (hover: hover) {
     &:not(:disabled):hover {
-      background: color-mix(in srgb, var(--surface-base) 98%, black);
+      background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
       :global([data-theme='dark']) & {
         background: var(--color-alpha-white-04);
@@ -64,7 +71,7 @@
 
   // Tap/press feedback — works on touch and resets on release (unlike :hover).
   &:not(:disabled):active {
-    background: color-mix(in srgb, var(--surface-base) 98%, black);
+    background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
     :global([data-theme='dark']) & {
       background: var(--color-alpha-white-04);

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
@@ -13,6 +13,16 @@
   :global([data-theme='dark']) & {
     background: var(--color-gray-950);
   }
+
+  /* Side-by-side, the configure column wears the docs-chrome gray, matching
+     the API panel (both modes — surface-secondary flips with the theme). */
+  @media (min-width: $breakpoint-layout-wide) {
+    background: var(--surface-secondary);
+
+    :global([data-theme='dark']) & {
+      background: var(--surface-secondary);
+    }
+  }
 }
 
 @media (max-width: $breakpoint-layout-mobile) {
@@ -47,10 +57,6 @@
   flex-direction: column;
   gap: var(--spacing-md);
   width: 100%;
-  /* Center in the panel when there's spare room; auto margins collapse to 0 when
-     the content overflows, so it top-aligns and scrolls without clipping (unlike
-     justify-content: center, which would clip the top). */
-  margin-block: auto;
 }
 
 .section {

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
@@ -1,7 +1,8 @@
 @use '../../styles/breakpoints' as *;
 
 .panel {
-  width: 475px;
+  /* The laptop layout's compact sizing is the default at every breakpoint. */
+  width: $layout-laptop-config-width;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -11,12 +12,6 @@
 
   :global([data-theme='dark']) & {
     background: var(--color-gray-950);
-  }
-}
-
-@include layout-laptop {
-  .panel {
-    width: $layout-laptop-config-width;
   }
 }
 
@@ -32,14 +27,10 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-4xl);
+  padding: $layout-laptop-content-padding;
   overflow-y: auto;
   overscroll-behavior: contain;
   min-height: 0;
-
-  @include layout-laptop {
-    padding: $layout-laptop-content-padding;
-  }
 
   // Mobile: tighter 24px padding (32px on top for breathing room under the navbar)
   // + room for the fixed "Explore playground" button. Declared after the base

--- a/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
+++ b/components/grid-wallet-demo/src/components/ConfigurePanel/ConfigurePanel.module.scss
@@ -9,19 +9,20 @@
   background: var(--surface-primary);
   border-right: var(--stroke-xs) solid var(--border-primary);
   overflow: hidden;
+  /* The panel wears the chrome gray only side-by-side — glide the color
+     across the stacked ⇄ 3-col crossing instead of snapping. */
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 
   :global([data-theme='dark']) & {
     background: var(--color-gray-950);
   }
 
-  /* Side-by-side, the configure column wears the docs-chrome gray, matching
-     the API panel (both modes — surface-secondary flips with the theme). */
-  @media (min-width: $breakpoint-layout-wide) {
+  /* Side-by-side (keyed to the JS layout attribute so the color rides the
+     same clock as the arrangement flip), the configure column wears the
+     docs-chrome gray, matching the API panel. surface-secondary flips with
+     the theme, and this selector outweighs the dark override above. */
+  :global(html:not([data-layout='stacked'])) & {
     background: var(--surface-secondary);
-
-    :global([data-theme='dark']) & {
-      background: var(--surface-secondary);
-    }
   }
 }
 

--- a/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
@@ -1,17 +1,29 @@
 @use '@lightsparkdev/origin/src/tokens/text-styles' as *;
+@use '../../styles/breakpoints' as *;
 
 .group {
   corner-shape: var(--corner-shape);
+  /* Single source for the tile surface — press states mix from it, and the
+     wide layout steps it down to sit on the chrome-gray panel. */
+  --tile-bg: var(--surface-base);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   width: 100%;
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border: var(--stroke-xs) solid var(--border-primary);
   border-radius: var(--corner-radius-md);
   overflow: clip;
 
   :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
+    --tile-bg: var(--color-gray-925);
+  }
+
+  @media (min-width: $breakpoint-layout-wide) {
+    --tile-bg: var(--surface-primary);
+
+    :global([data-theme='dark']) & {
+      --tile-bg: var(--color-gray-950);
+    }
   }
 }
 
@@ -23,14 +35,10 @@
   gap: var(--spacing-sm);
   min-width: 0;
   padding: var(--spacing-md);
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border-bottom: var(--stroke-xs) solid var(--border-primary);
   cursor: default;
   transition: background 100ms ease;
-
-  :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
-  }
 
   /* Left column of each pair. */
   &:nth-child(odd) {
@@ -49,9 +57,9 @@
   // Hover only with a real pointer — avoids the fill sticking after a tap on touch.
   @media (hover: hover) {
     &:hover {
-      // Opaque equivalent of alpha-black-02 on surface-base — transparent tokens
-      // composite differently depending on parent bg (see use case/auth vs flow).
-      background: color-mix(in srgb, var(--surface-base) 98%, black);
+      // Opaque equivalent of alpha-black-02 on the tile surface — transparent
+      // tokens composite differently depending on parent bg.
+      background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
       :global([data-theme='dark']) & {
         background: var(--color-alpha-white-04);
@@ -61,7 +69,7 @@
 
   // Tap/press feedback — works on touch and resets on release (unlike :hover).
   &:active {
-    background: color-mix(in srgb, var(--surface-base) 98%, black);
+    background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
     :global([data-theme='dark']) & {
       background: var(--color-alpha-white-04);

--- a/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
+++ b/components/grid-wallet-demo/src/components/FlowPicker/FlowPicker.module.scss
@@ -13,6 +13,8 @@
   border: var(--stroke-xs) solid var(--border-primary);
   border-radius: var(--corner-radius-md);
   overflow: clip;
+  // The tile surface steps down side-by-side — glide it across the crossing.
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 
   :global([data-theme='dark']) & {
     --tile-bg: var(--color-gray-925);

--- a/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
+++ b/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
@@ -25,6 +25,8 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
   border-radius: var(--corner-radius-md);
   // Ring extends past cell bounds (and morphs across cells during layout animation).
   overflow: visible;
+  // The tile surface steps down side-by-side — glide it across the crossing.
+  transition: background-color 240ms cubic-bezier(0.19, 1, 0.22, 1);
 
   :global([data-theme='dark']) & {
     --tile-bg: var(--color-gray-925);

--- a/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
+++ b/components/grid-wallet-demo/src/components/UseCasePicker/UseCasePicker.module.scss
@@ -13,18 +13,29 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
 
 .group {
   corner-shape: var(--corner-shape);
+  /* Single source for the tile surface — press states mix from it, and the
+     wide layout steps it down to sit on the chrome-gray panel. */
+  --tile-bg: var(--surface-base);
   position: relative;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   width: 100%;
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border: var(--stroke-xs) solid var(--border-primary);
   border-radius: var(--corner-radius-md);
   // Ring extends past cell bounds (and morphs across cells during layout animation).
   overflow: visible;
 
   :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
+    --tile-bg: var(--color-gray-925);
+  }
+
+  @media (min-width: $breakpoint-layout-wide) {
+    --tile-bg: var(--surface-primary);
+
+    :global([data-theme='dark']) & {
+      --tile-bg: var(--color-gray-950);
+    }
   }
 }
 
@@ -37,15 +48,11 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
   align-items: center;
   min-width: 0;
   padding: var(--spacing-md);
-  background: var(--surface-base);
+  background: var(--tile-bg);
   border-bottom: var(--stroke-xs) solid var(--border-primary);
   overflow: visible;
   cursor: pointer;
   transition: background 100ms ease;
-
-  :global([data-theme='dark']) & {
-    background: var(--color-gray-925);
-  }
 
   &:nth-child(odd) {
     border-right: var(--stroke-xs) solid var(--border-primary);
@@ -84,7 +91,7 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
   // tap on touch (mobile emulates :hover until you tap elsewhere).
   @media (hover: hover) {
     &:not(:disabled):not(.cardSelected):hover {
-      background: color-mix(in srgb, var(--surface-base) 98%, black);
+      background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
       :global([data-theme='dark']) & {
         background: var(--color-alpha-white-04);
@@ -95,7 +102,7 @@ $ease-out-swift: cubic-bezier(0.175, 0.885, 0.32, 1.1);
   // Tap/press feedback — applies on touch too and resets on release (unlike
   // :hover, which sticks after a tap). Same fill as the hover state.
   &:not(:disabled):not(.cardSelected):active {
-    background: color-mix(in srgb, var(--surface-base) 98%, black);
+    background: color-mix(in srgb, var(--tile-bg) 98%, black);
 
     :global([data-theme='dark']) & {
       background: var(--color-alpha-white-04);

--- a/components/grid-wallet-demo/src/components/glass-gl/StageGL.tsx
+++ b/components/grid-wallet-demo/src/components/glass-gl/StageGL.tsx
@@ -769,6 +769,9 @@ export const StageGL = forwardRef<StageGLHandle, StageGLProps>(function StageGL(
       // static dot field can show immediately.
       paintBootFrame();
       ro = new ResizeObserver(() => {
+        // The palette is media-query-dependent (the light stage color changes
+        // at the wide breakpoint), so a resize can change it too.
+        palette = readDotGridPalette(offCtx);
         markResize();
         lastRadius = NaN;
         invalidate(true);

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 // Matches $layout-laptop-config-width — the compact configure column is the
 // default at every breakpoint.
@@ -9,30 +9,48 @@ const MIN_APP = 320;
 // Never resize the API column below the configure column width; dragging only
 // widens it from there.
 const MIN_API = CONFIGURE_WIDTH;
+// The DEFAULT width + snap target: the docs sidebar plus the configure column —
+// the combined chrome flanking the embedded playground. Standalone (and until
+// the docs parent reports in) this assumes the expanded sidebar: 280px
+// (--ls-sidebar-width) + 400 = 680 = $layout-laptop-api-content-max-width.
+// Embedded, the docs page posts `nav-sync` with the live sidebar width (48px
+// rail when collapsed, drag-resized values too) and the default follows.
+// Dragging can still grow the panel freely up to (middle − MIN_APP).
+const DOCS_SIDEBAR_DEFAULT = 280;
 const SNAP_THRESHOLD = 28;
 
-/** SSR/first-paint fallback — replaced by the 50/50 split once the layout
- *  measures (pre-paint, in the layout effect below). */
-export const API_DEFAULT_WIDTH = CONFIGURE_WIDTH;
+/** SSR/first-paint fallback — replaced by the chrome-width default once the
+ *  layout measures (pre-paint, in the layout effect below). */
+export const API_DEFAULT_WIDTH = DOCS_SIDEBAR_DEFAULT + CONFIGURE_WIDTH;
 
 function clampApiWidth(width: number, totalMiddle: number): number {
   return Math.max(MIN_API, Math.min(totalMiddle - MIN_APP, width));
 }
 
-/** Default + snap target — the app and API panels split the space right of
- *  the configure column 50/50. */
-function defaultApiWidth(totalMiddle: number): number {
-  return clampApiWidth(Math.round(totalMiddle / 2), totalMiddle);
-}
-
 export function useColumnResize() {
   const layoutRef = useRef<HTMLElement>(null);
   const apiColRef = useRef<HTMLDivElement>(null);
+  const [defaultApi, setDefaultApi] = useState(API_DEFAULT_WIDTH);
   const [apiWidth, setApiWidth] = useState(API_DEFAULT_WIDTH);
-  // While the column sits at the default split, window resizes keep it AT the
-  // split (both panels breathe together). A custom drag pins it to a px width
-  // until the user snaps it back to the split.
+  // While the column sits at the default, window resizes (and nav-sync
+  // updates) keep it there. A custom drag pins it to a px width until the
+  // user snaps it back to the default.
   const userResized = useRef(false);
+
+  // Embed contract (same shape as theme-sync): the docs page reports its
+  // sidebar width on request and whenever it changes (collapse / drag-resize).
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.data && e.data.type === 'nav-sync' && typeof e.data.sidebarWidth === 'number') {
+        setDefaultApi(Math.round(e.data.sidebarWidth) + CONFIGURE_WIDTH);
+      }
+    };
+    window.addEventListener('message', onMessage);
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: 'nav-request' }, '*');
+    }
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
 
   useLayoutEffect(() => {
     const fitToLayout = () => {
@@ -40,49 +58,52 @@ export function useColumnResize() {
       if (!layout) return;
       const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
       setApiWidth((w) =>
-        userResized.current ? clampApiWidth(w, totalMiddle) : defaultApiWidth(totalMiddle),
+        clampApiWidth(userResized.current ? w : defaultApi, totalMiddle),
       );
     };
 
     fitToLayout();
     window.addEventListener('resize', fitToLayout);
     return () => window.removeEventListener('resize', fitToLayout);
-  }, []);
+  }, [defaultApi]);
 
-  const onResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startApiWidth = apiColRef.current?.getBoundingClientRect().width ?? API_DEFAULT_WIDTH;
+  const onResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startApiWidth = apiColRef.current?.getBoundingClientRect().width ?? defaultApi;
 
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
 
-    const applyWidth = (clientX: number) => {
-      const layout = layoutRef.current;
-      if (!layout) return;
-      const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
-      const delta = clientX - startX;
-      const raw = clampApiWidth(startApiWidth - delta, totalMiddle);
-      const target = defaultApiWidth(totalMiddle);
-      const snapped = Math.abs(raw - target) <= SNAP_THRESHOLD ? target : raw;
-      // Snapping back to the split resumes 50/50 tracking on window resize.
-      userResized.current = snapped !== target;
-      setApiWidth(snapped);
-    };
+      const applyWidth = (clientX: number) => {
+        const layout = layoutRef.current;
+        if (!layout) return;
+        const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
+        const delta = clientX - startX;
+        const raw = clampApiWidth(startApiWidth - delta, totalMiddle);
+        const target = clampApiWidth(defaultApi, totalMiddle);
+        const snapped = Math.abs(raw - target) <= SNAP_THRESHOLD ? target : raw;
+        // Snapping back to the default resumes default tracking on resize.
+        userResized.current = snapped !== target;
+        setApiWidth(snapped);
+      };
 
-    const onMove = (ev: MouseEvent) => applyWidth(ev.clientX);
+      const onMove = (ev: MouseEvent) => applyWidth(ev.clientX);
 
-    const onUp = (ev: MouseEvent) => {
-      applyWidth(ev.clientX);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
-    };
+      const onUp = (ev: MouseEvent) => {
+        applyWidth(ev.clientX);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
 
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
-  }, []);
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [defaultApi],
+  );
 
   return { layoutRef, apiColRef, apiWidth, onResizeStart };
 }

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -1,14 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { CONFIGURE_COL_PX } from '@/lib/layout';
 
-// Matches $layout-laptop-config-width — the compact configure column is the
-// default at every breakpoint.
-const CONFIGURE_WIDTH = 400;
 const MIN_APP = 320;
 // Never resize the API column below the configure column width; dragging only
 // widens it from there.
-const MIN_API = CONFIGURE_WIDTH;
+const MIN_API = CONFIGURE_COL_PX;
 // The DEFAULT width + snap target: the docs sidebar plus the configure column —
 // the combined chrome flanking the embedded playground. Standalone (and until
 // the docs parent reports in) this assumes the expanded sidebar: 280px
@@ -19,9 +17,21 @@ const MIN_API = CONFIGURE_WIDTH;
 const DOCS_SIDEBAR_DEFAULT = 280;
 const SNAP_THRESHOLD = 28;
 
-/** SSR/first-paint fallback — replaced by the chrome-width default once the
- *  layout measures (pre-paint, in the layout effect below). */
-export const API_DEFAULT_WIDTH = DOCS_SIDEBAR_DEFAULT + CONFIGURE_WIDTH;
+/** Standalone fallback — the embed overrides it via the ?nav URL param.
+ *  Kept in sync with the --api-col-default fallback in page.module.scss. */
+export const API_DEFAULT_WIDTH = DOCS_SIDEBAR_DEFAULT + CONFIGURE_COL_PX;
+
+/** The embed bakes the live sidebar width into the iframe URL so the very
+ *  first paint uses the real default: the pre-paint script in layout.tsx
+ *  turns it into the --api-col-default CSS var (which styles the column
+ *  until React takes over below), and this seeds the same value into state
+ *  so the JS width agrees with that paint instead of re-fitting to the
+ *  expanded-sidebar assumption a beat later. */
+function initialDefaultApi(): number {
+  if (typeof window === 'undefined') return API_DEFAULT_WIDTH;
+  const nav = parseFloat(new URLSearchParams(window.location.search).get('nav') ?? '');
+  return Number.isFinite(nav) && nav >= 0 ? Math.round(nav) + CONFIGURE_COL_PX : API_DEFAULT_WIDTH;
+}
 
 function clampApiWidth(width: number, totalMiddle: number): number {
   return Math.max(MIN_API, Math.min(totalMiddle - MIN_APP, width));
@@ -30,8 +40,12 @@ function clampApiWidth(width: number, totalMiddle: number): number {
 export function useColumnResize() {
   const layoutRef = useRef<HTMLElement>(null);
   const apiColRef = useRef<HTMLDivElement>(null);
-  const [defaultApi, setDefaultApi] = useState(API_DEFAULT_WIDTH);
-  const [apiWidth, setApiWidth] = useState(API_DEFAULT_WIDTH);
+  const [defaultApi, setDefaultApi] = useState(initialDefaultApi);
+  // null until the post-hydration measure: SSR and the hydration render emit
+  // NO inline width, leaving the stylesheet's var(--api-col-default) in
+  // charge — which the pre-paint script already set to the true default. An
+  // inline SSR width would paint the wrong column for the whole JS load.
+  const [apiWidth, setApiWidth] = useState<number | null>(null);
   // True while the user drags the divider — the column's width transition is
   // disabled so the drag tracks the pointer 1:1 (it only eases programmatic
   // changes, e.g. the default following a docs-sidebar collapse).
@@ -45,38 +59,27 @@ export function useColumnResize() {
   // sidebar width on request and whenever it changes (collapse / drag-resize).
   //
   // A nav-driven width change EASES (the glide that runs in parallel with the
-  // docs sidebar wipe); everything else — drags, window resizes, and above
-  // all the stacked ⇄ 3-col breakpoint flip — snaps. The ease is opted into
-  // right here, in the same commit as the width change, instead of being an
-  // always-on transition suppressed around crossings: an always-on transition
-  // races the media flip by a task, and for that 1–2 frame window the API
-  // column still holds its full stacked width inside a row layout — crushing
-  // the app column to zero and blinking the phone out (the ghost frame).
+  // docs sidebar wipe); everything else — drags, window resizes, breakpoint
+  // flips — snaps. The ease is opted into per-message via data-easing rather
+  // than an always-on transition, and only when the column is already painted
+  // at its tracked inline width (i.e. the row layout is settled). That guard
+  // is load-bearing: the embed re-sends nav-sync every frame of the sidebar
+  // wipe, and once the growing iframe crosses the breakpoint those messages
+  // race the stacked → wide flip. If the transition arms during the flip's
+  // style recalc, it starts from the STACKED computed width — 100% of the
+  // row — and the column spends 240ms nearly full-width, crushing the app
+  // column to zero (the phone blinks out).
   const easeTimer = useRef(0);
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
-      if (e.data && e.data.type === 'nav-sync' && typeof e.data.sidebarWidth === 'number') {
-        // Ease only when the column is ALREADY laid out at its tracked inline
-        // width — i.e. the row layout is settled. A viewport check
-        // (min-width: 1600px) is not enough: the embed re-sends nav-sync every
-        // frame of the sidebar wipe, and once the growing iframe crosses the
-        // breakpoint those messages race the stacked → wide attribute flip. If
-        // the easing attribute is live at the flip's style recalc, the width
-        // transition starts from the STACKED computed width (100% of the row)
-        // and the API column spends 240ms nearly full-width, crushing the app
-        // column to zero (the phone blinks out). Mid-flip the painted width is
-        // that full row — miles from the inline width — so this guard skips
-        // the ease; once settled they match and nav glides ease as intended.
-        const el = apiColRef.current;
-        const painted = el ? el.getBoundingClientRect().width : NaN;
-        const tracked = el ? parseFloat(el.style.width) : NaN;
-        if (el && Math.abs(painted - tracked) < 2) {
-          el.setAttribute('data-easing', '');
-          window.clearTimeout(easeTimer.current);
-          easeTimer.current = window.setTimeout(() => el.removeAttribute('data-easing'), 300);
-        }
-        setDefaultApi(Math.round(e.data.sidebarWidth) + CONFIGURE_WIDTH);
+      if (!e.data || e.data.type !== 'nav-sync' || typeof e.data.sidebarWidth !== 'number') return;
+      const el = apiColRef.current;
+      if (el && Math.abs(el.getBoundingClientRect().width - parseFloat(el.style.width)) < 2) {
+        el.setAttribute('data-easing', '');
+        window.clearTimeout(easeTimer.current);
+        easeTimer.current = window.setTimeout(() => el.removeAttribute('data-easing'), 300);
       }
+      setDefaultApi(Math.round(e.data.sidebarWidth) + CONFIGURE_COL_PX);
     };
     window.addEventListener('message', onMessage);
     if (window.parent && window.parent !== window) {
@@ -92,9 +95,9 @@ export function useColumnResize() {
     const fitToLayout = () => {
       const layout = layoutRef.current;
       if (!layout) return;
-      const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
+      const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_COL_PX;
       setApiWidth((w) =>
-        clampApiWidth(userResized.current ? w : defaultApi, totalMiddle),
+        clampApiWidth(userResized.current && w !== null ? w : defaultApi, totalMiddle),
       );
     };
 
@@ -116,7 +119,7 @@ export function useColumnResize() {
       const applyWidth = (clientX: number) => {
         const layout = layoutRef.current;
         if (!layout) return;
-        const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
+        const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_COL_PX;
         const delta = clientX - startX;
         const raw = clampApiWidth(startApiWidth - delta, totalMiddle);
         const target = clampApiWidth(defaultApi, totalMiddle);

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -32,10 +32,36 @@ export function useColumnResize() {
   const apiColRef = useRef<HTMLDivElement>(null);
   const [defaultApi, setDefaultApi] = useState(API_DEFAULT_WIDTH);
   const [apiWidth, setApiWidth] = useState(API_DEFAULT_WIDTH);
+  // True while the user drags the divider — the column's width transition is
+  // disabled so the drag tracks the pointer 1:1 (it only eases programmatic
+  // changes, e.g. the default following a docs-sidebar collapse).
+  const [resizing, setResizing] = useState(false);
   // While the column sits at the default, window resizes (and nav-sync
   // updates) keep it there. A custom drag pins it to a px width until the
   // user snaps it back to the default.
   const userResized = useRef(false);
+
+  // Crossing the stacked ⇄ side-by-side breakpoint must SNAP, not glide: the
+  // column arrives from a full-width stacked layout, and easing that change
+  // reads as a giant shrink sweep. Kill the transition for a beat around the
+  // crossing (direct DOM write — React state could land a frame late, after
+  // the transition has already started). Width changes WITHIN the wide layout
+  // (nav-sync defaults) keep the ease.
+  useEffect(() => {
+    // Matches $breakpoint-layout-wide.
+    const mql = window.matchMedia('(min-width: 1440px)');
+    let timer = 0;
+    const onChange = () => {
+      apiColRef.current?.setAttribute('data-snap', '');
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => apiColRef.current?.removeAttribute('data-snap'), 120);
+    };
+    mql.addEventListener('change', onChange);
+    return () => {
+      mql.removeEventListener('change', onChange);
+      window.clearTimeout(timer);
+    };
+  }, []);
 
   // Embed contract (same shape as theme-sync): the docs page reports its
   // sidebar width on request and whenever it changes (collapse / drag-resize).
@@ -75,6 +101,7 @@ export function useColumnResize() {
 
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
+      setResizing(true);
 
       const applyWidth = (clientX: number) => {
         const layout = layoutRef.current;
@@ -95,6 +122,7 @@ export function useColumnResize() {
         applyWidth(ev.clientX);
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
+        setResizing(false);
         document.removeEventListener('mousemove', onMove);
         document.removeEventListener('mouseup', onUp);
       };
@@ -105,5 +133,5 @@ export function useColumnResize() {
     [defaultApi],
   );
 
-  return { layoutRef, apiColRef, apiWidth, onResizeStart };
+  return { layoutRef, apiColRef, apiWidth, resizing, onResizeStart };
 }

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -2,7 +2,9 @@
 
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
-const CONFIGURE_WIDTH = 475;
+// Matches $layout-laptop-config-width — the compact configure column is the
+// default at every breakpoint.
+const CONFIGURE_WIDTH = 400;
 const MIN_APP = 320;
 // Never resize the API column below the configure column width; dragging only
 // widens it from there.

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -4,40 +4,47 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 const CONFIGURE_WIDTH = 475;
 const MIN_APP = 320;
-// Never resize the API column below its default/snap width (= the configure
-// column width); dragging only widens it from there.
+// Never resize the API column below the configure column width; dragging only
+// widens it from there.
 const MIN_API = CONFIGURE_WIDTH;
 const SNAP_THRESHOLD = 28;
 
-/** Default + snap target — matches configure column width. */
+/** SSR/first-paint fallback — replaced by the 50/50 split once the layout
+ *  measures (pre-paint, in the layout effect below). */
 export const API_DEFAULT_WIDTH = CONFIGURE_WIDTH;
 
 function clampApiWidth(width: number, totalMiddle: number): number {
   return Math.max(MIN_API, Math.min(totalMiddle - MIN_APP, width));
 }
 
-function snapApiWidth(width: number, totalMiddle: number): number {
-  const target = clampApiWidth(API_DEFAULT_WIDTH, totalMiddle);
-  if (Math.abs(width - target) <= SNAP_THRESHOLD) return target;
-  return width;
+/** Default + snap target — the app and API panels split the space right of
+ *  the configure column 50/50. */
+function defaultApiWidth(totalMiddle: number): number {
+  return clampApiWidth(Math.round(totalMiddle / 2), totalMiddle);
 }
 
 export function useColumnResize() {
   const layoutRef = useRef<HTMLElement>(null);
   const apiColRef = useRef<HTMLDivElement>(null);
   const [apiWidth, setApiWidth] = useState(API_DEFAULT_WIDTH);
+  // While the column sits at the default split, window resizes keep it AT the
+  // split (both panels breathe together). A custom drag pins it to a px width
+  // until the user snaps it back to the split.
+  const userResized = useRef(false);
 
   useLayoutEffect(() => {
-    const clampToLayout = () => {
+    const fitToLayout = () => {
       const layout = layoutRef.current;
       if (!layout) return;
       const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
-      setApiWidth((w) => clampApiWidth(w, totalMiddle));
+      setApiWidth((w) =>
+        userResized.current ? clampApiWidth(w, totalMiddle) : defaultApiWidth(totalMiddle),
+      );
     };
 
-    clampToLayout();
-    window.addEventListener('resize', clampToLayout);
-    return () => window.removeEventListener('resize', clampToLayout);
+    fitToLayout();
+    window.addEventListener('resize', fitToLayout);
+    return () => window.removeEventListener('resize', fitToLayout);
   }, []);
 
   const onResizeStart = useCallback((e: React.MouseEvent) => {
@@ -54,7 +61,11 @@ export function useColumnResize() {
       const totalMiddle = layout.getBoundingClientRect().width - CONFIGURE_WIDTH;
       const delta = clientX - startX;
       const raw = clampApiWidth(startApiWidth - delta, totalMiddle);
-      setApiWidth(snapApiWidth(raw, totalMiddle));
+      const target = defaultApiWidth(totalMiddle);
+      const snapped = Math.abs(raw - target) <= SNAP_THRESHOLD ? target : raw;
+      // Snapping back to the split resumes 50/50 tracking on window resize.
+      userResized.current = snapped !== target;
+      setApiWidth(snapped);
     };
 
     const onMove = (ev: MouseEvent) => applyWidth(ev.clientX);

--- a/components/grid-wallet-demo/src/hooks/useColumnResize.ts
+++ b/components/grid-wallet-demo/src/hooks/useColumnResize.ts
@@ -41,33 +41,40 @@ export function useColumnResize() {
   // user snaps it back to the default.
   const userResized = useRef(false);
 
-  // Crossing the stacked ⇄ side-by-side breakpoint must SNAP, not glide: the
-  // column arrives from a full-width stacked layout, and easing that change
-  // reads as a giant shrink sweep. Kill the transition for a beat around the
-  // crossing (direct DOM write — React state could land a frame late, after
-  // the transition has already started). Width changes WITHIN the wide layout
-  // (nav-sync defaults) keep the ease.
-  useEffect(() => {
-    // Matches $breakpoint-layout-wide.
-    const mql = window.matchMedia('(min-width: 1440px)');
-    let timer = 0;
-    const onChange = () => {
-      apiColRef.current?.setAttribute('data-snap', '');
-      window.clearTimeout(timer);
-      timer = window.setTimeout(() => apiColRef.current?.removeAttribute('data-snap'), 120);
-    };
-    mql.addEventListener('change', onChange);
-    return () => {
-      mql.removeEventListener('change', onChange);
-      window.clearTimeout(timer);
-    };
-  }, []);
-
   // Embed contract (same shape as theme-sync): the docs page reports its
   // sidebar width on request and whenever it changes (collapse / drag-resize).
+  //
+  // A nav-driven width change EASES (the glide that runs in parallel with the
+  // docs sidebar wipe); everything else — drags, window resizes, and above
+  // all the stacked ⇄ 3-col breakpoint flip — snaps. The ease is opted into
+  // right here, in the same commit as the width change, instead of being an
+  // always-on transition suppressed around crossings: an always-on transition
+  // races the media flip by a task, and for that 1–2 frame window the API
+  // column still holds its full stacked width inside a row layout — crushing
+  // the app column to zero and blinking the phone out (the ghost frame).
+  const easeTimer = useRef(0);
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
       if (e.data && e.data.type === 'nav-sync' && typeof e.data.sidebarWidth === 'number') {
+        // Ease only when the column is ALREADY laid out at its tracked inline
+        // width — i.e. the row layout is settled. A viewport check
+        // (min-width: 1600px) is not enough: the embed re-sends nav-sync every
+        // frame of the sidebar wipe, and once the growing iframe crosses the
+        // breakpoint those messages race the stacked → wide attribute flip. If
+        // the easing attribute is live at the flip's style recalc, the width
+        // transition starts from the STACKED computed width (100% of the row)
+        // and the API column spends 240ms nearly full-width, crushing the app
+        // column to zero (the phone blinks out). Mid-flip the painted width is
+        // that full row — miles from the inline width — so this guard skips
+        // the ease; once settled they match and nav glides ease as intended.
+        const el = apiColRef.current;
+        const painted = el ? el.getBoundingClientRect().width : NaN;
+        const tracked = el ? parseFloat(el.style.width) : NaN;
+        if (el && Math.abs(painted - tracked) < 2) {
+          el.setAttribute('data-easing', '');
+          window.clearTimeout(easeTimer.current);
+          easeTimer.current = window.setTimeout(() => el.removeAttribute('data-easing'), 300);
+        }
         setDefaultApi(Math.round(e.data.sidebarWidth) + CONFIGURE_WIDTH);
       }
     };
@@ -75,7 +82,10 @@ export function useColumnResize() {
     if (window.parent && window.parent !== window) {
       window.parent.postMessage({ type: 'nav-request' }, '*');
     }
-    return () => window.removeEventListener('message', onMessage);
+    return () => {
+      window.removeEventListener('message', onMessage);
+      window.clearTimeout(easeTimer.current);
+    };
   }, []);
 
   useLayoutEffect(() => {

--- a/components/grid-wallet-demo/src/lib/layout.ts
+++ b/components/grid-wallet-demo/src/lib/layout.ts
@@ -1,0 +1,10 @@
+/** Playground layout constants shared by the pre-paint boot script
+ *  (layout.tsx), the live listeners (page.tsx, useColumnResize), and —
+ *  by convention, since SCSS can't import TS — the stylesheet twins in
+ *  styles/breakpoints.scss. Change them together. */
+
+/** Stacked ⇄ 3-col threshold. Twin: $breakpoint-layout-wide. */
+export const LAYOUT_WIDE_PX = 1600;
+
+/** Configure column width. Twin: $layout-laptop-config-width. */
+export const CONFIGURE_COL_PX = 400;

--- a/components/grid-wallet-demo/src/styles/breakpoints.scss
+++ b/components/grid-wallet-demo/src/styles/breakpoints.scss
@@ -1,9 +1,11 @@
 /** App + API side-by-side inside the right column. Above this the layout is 3
-    columns: Configure (400) | App | API (App and API split the rest 50/50 by
-    default). The phone needs ~466px (434 shell + 16px inset each side) to
-    render full size; stack at 1440px so the phone never shrinks before App +
-    API stack vertically (each full-width). Tune to taste. */
-$breakpoint-layout-wide: 1440px;
+    columns: Configure (400) | App | API. The phone needs ~466px (434 shell +
+    16px inset each side) to render full size, and the API column defaults to
+    680 — below ~1600 the 3-col reads cramped (a MacBook Pro 16" at 1728 with
+    the docs sidebar expanded gives the embed 1448, which should stack; with
+    the sidebar collapsed it gets 1680, which fits 3-col comfortably). Keep in
+    sync with the JS listeners in page.tsx and useColumnResize. */
+$breakpoint-layout-wide: 1600px;
 
 /** Configure stacks above app + API (phone). */
 $breakpoint-layout-mobile: 767px;

--- a/components/grid-wallet-demo/src/styles/breakpoints.scss
+++ b/components/grid-wallet-demo/src/styles/breakpoints.scss
@@ -1,9 +1,8 @@
 /** App + API side-by-side inside the right column. Above this the layout is 3
-    columns: Configure (475) | App (phone) | API (475 default), so the App column
-    is roughly (viewport − 950). The phone needs ~466px (434 shell + 16px inset
-    each side) to render full size, i.e. ~1416px of viewport; below that the App
-    column squeezes the phone tiny. Stack at 1440px so the phone never shrinks
-    before App + API stack vertically (each full-width). Tune to taste. */
+    columns: Configure (400) | App | API (App and API split the rest 50/50 by
+    default). The phone needs ~466px (434 shell + 16px inset each side) to
+    render full size; stack at 1440px so the phone never shrinks before App +
+    API stack vertically (each full-width). Tune to taste. */
 $breakpoint-layout-wide: 1440px;
 
 /** Configure stacks above app + API (phone). */

--- a/components/grid-wallet-demo/src/styles/breakpoints.scss
+++ b/components/grid-wallet-demo/src/styles/breakpoints.scss
@@ -3,14 +3,15 @@
     16px inset each side) to render full size, and the API column defaults to
     680 — below ~1600 the 3-col reads cramped (a MacBook Pro 16" at 1728 with
     the docs sidebar expanded gives the embed 1448, which should stack; with
-    the sidebar collapsed it gets 1680, which fits 3-col comfortably). Keep in
-    sync with the JS listeners in page.tsx and useColumnResize. */
+    the sidebar collapsed it gets 1680, which fits 3-col comfortably).
+    TS twin: LAYOUT_WIDE_PX in lib/layout.ts — change them together. */
 $breakpoint-layout-wide: 1600px;
 
 /** Configure stacks above app + API (phone). */
 $breakpoint-layout-mobile: 767px;
 
-/** Configure left, app over API on the right (between mobile and wide). */
+/** Configure left, app over API on the right (between mobile and wide).
+    TS twin: CONFIGURE_COL_PX in lib/layout.ts — change them together. */
 $layout-laptop-config-width: 400px;
 $layout-laptop-content-padding: 40px;
 $layout-laptop-api-content-max-width: 680px;

--- a/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
+++ b/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
@@ -21,6 +21,20 @@ export const WalletDemoEmbed = () => {
     if (window.__wdHideTimer) { clearTimeout(window.__wdHideTimer); window.__wdHideTimer = null; }
     host.style.display = 'block';
 
+    const navWidth = () => {
+      const root = document.documentElement;
+      const collapsed = root.classList.contains('ls-nav-collapsed');
+      const cs = getComputedStyle(root);
+      const v = parseFloat(cs.getPropertyValue(collapsed ? '--ls-nav-rail-w' : '--ls-sidebar-width'));
+      return Number.isFinite(v) ? v : (collapsed ? 48 : 280);
+    };
+    const sendNav = () => {
+      const iframe = document.getElementById('wallet-demo-iframe');
+      if (iframe && iframe.contentWindow) {
+        iframe.contentWindow.postMessage({ type: 'nav-sync', sidebarWidth: navWidth() }, '*');
+      }
+    };
+
     let raf = 0;
     let last = { left: -1, top: -1, width: -1, height: -1 };
     const sync = () => {
@@ -33,6 +47,7 @@ export const WalletDemoEmbed = () => {
           host.style.width = r.width + 'px';
           host.style.height = r.height + 'px';
           last = { left: r.left, top: r.top, width: r.width, height: r.height };
+          sendNav();
         }
       }
       raf = requestAnimationFrame(sync);
@@ -53,6 +68,10 @@ export const WalletDemoEmbed = () => {
         sendTheme();
         return;
       }
+      if (e.data && e.data.type === 'nav-request') {
+        sendNav();
+        return;
+      }
       if (e.data && e.data.type === 'theme-sync') {
         const wantsDark = e.data.theme === 'dark';
         if (isDark() !== wantsDark) {
@@ -64,12 +83,14 @@ export const WalletDemoEmbed = () => {
     window.addEventListener('message', handleMessage);
 
     const obs = new MutationObserver(() => {
+      sendNav();
       if (ignoreNextMutation) { ignoreNextMutation = false; return; }
       sendTheme();
     });
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
     sendTheme();
+    sendNav();
     requestAnimationFrame(sendTheme);
 
     return () => {

--- a/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
+++ b/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
@@ -29,6 +29,10 @@ export const WalletDemoEmbed = () => {
       return Number.isFinite(v) ? v : (collapsed ? 48 : 280);
     };
     const sendNav = () => {
+      const html = document.documentElement;
+      const animating = html.classList.contains('ls-nav-animating');
+      const collapsed = html.classList.contains('ls-nav-collapsed');
+      if (animating && !collapsed) return;
       const iframe = document.getElementById('wallet-demo-iframe');
       if (iframe && iframe.contentWindow) {
         iframe.contentWindow.postMessage({ type: 'nav-sync', sidebarWidth: navWidth() }, '*');

--- a/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
+++ b/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
@@ -4,6 +4,14 @@ export const WalletDemoEmbed = () => {
     const base = isLocal ? 'http://localhost:4000' : 'https://grid-wallet-demo.vercel.app';
     const isDark = () => document.documentElement.classList.contains('dark');
 
+    const navWidth = () => {
+      const root = document.documentElement;
+      const collapsed = root.classList.contains('ls-nav-collapsed');
+      const cs = getComputedStyle(root);
+      const v = parseFloat(cs.getPropertyValue(collapsed ? '--ls-nav-rail-w' : '--ls-sidebar-width'));
+      return Number.isFinite(v) ? v : (collapsed ? 48 : 280);
+    };
+
     let host = document.getElementById('wallet-demo-host');
     if (!host) {
       host = document.createElement('div');
@@ -11,7 +19,7 @@ export const WalletDemoEmbed = () => {
       host.style.cssText = 'position:fixed;z-index:1;overflow:hidden;';
       const iframe = document.createElement('iframe');
       iframe.id = 'wallet-demo-iframe';
-      iframe.src = base + '/?embed=true&theme=' + (isDark() ? 'dark' : 'light');
+      iframe.src = base + '/?embed=true&theme=' + (isDark() ? 'dark' : 'light') + '&nav=' + navWidth();
       iframe.title = 'Grid Global Accounts — live demo';
       iframe.setAttribute('allow', 'publickey-credentials-create *; publickey-credentials-get *; clipboard-write');
       iframe.style.cssText = 'width:100%;height:100%;border:0;display:block;';
@@ -20,14 +28,6 @@ export const WalletDemoEmbed = () => {
     }
     if (window.__wdHideTimer) { clearTimeout(window.__wdHideTimer); window.__wdHideTimer = null; }
     host.style.display = 'block';
-
-    const navWidth = () => {
-      const root = document.documentElement;
-      const collapsed = root.classList.contains('ls-nav-collapsed');
-      const cs = getComputedStyle(root);
-      const v = parseFloat(cs.getPropertyValue(collapsed ? '--ls-nav-rail-w' : '--ls-sidebar-width'));
-      return Number.isFinite(v) ? v : (collapsed ? 48 : 280);
-    };
     const sendNav = () => {
       const html = document.documentElement;
       const animating = html.classList.contains('ls-nav-animating');

--- a/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
+++ b/mintlify/snippets/global-accounts/wallet-demo-embed.mdx
@@ -29,10 +29,6 @@ export const WalletDemoEmbed = () => {
     if (window.__wdHideTimer) { clearTimeout(window.__wdHideTimer); window.__wdHideTimer = null; }
     host.style.display = 'block';
     const sendNav = () => {
-      const html = document.documentElement;
-      const animating = html.classList.contains('ls-nav-animating');
-      const collapsed = html.classList.contains('ls-nav-collapsed');
-      if (animating && !collapsed) return;
       const iframe = document.getElementById('wallet-demo-iframe');
       if (iframe && iframe.contentWindow) {
         iframe.contentWindow.postMessage({ type: 'nav-sync', sidebarWidth: navWidth() }, '*');


### PR DESCRIPTION
## Summary

Layout pass to surface the API/code panel more prominently, plus a follow-up pass making docs-sidebar toggles and page loads land cleanly:

- **Chrome-width code column on the wide (3-col) layout** — the API column's default (and drag-snap target) is the docs sidebar + configure column width, so the phone stage sits centered between equal chrome. The embed reports the live sidebar width (`nav-sync` messages + a `?nav` boot param), and the default follows it: collapsing/expanding the docs sidebar glides the code column in sync with the wipe, in both directions. Dragging still sets a free custom width.
- **Stacked ⇄ 3-col breakpoint raised to 1600px** — at 1440 the 3-col read cramped (MacBook Pro 16" with expanded sidebar). The arrangement is a `data-layout` attribute on `<html>`, set before first paint by the boot script (no SSR layout flash on refresh) and kept live by a matchMedia listener. Breakpoint-crossing toggles snap the arrangement; the panel chrome colors glide across the flip. A guard keeps the width transition from arming mid-flip (which briefly crushed the app column to zero).
- **Chrome-gray side panels on the wide layout** — configure + API columns wear surface-secondary (docs-chrome gray) with card/tile/code-block contrast retuned to match; the dot-grid stage steps to #F4F4F3 (light) / gray-950 (dark) so it reads as its own layer.
- **Deeper API peek on the stacked laptop layout** — the API panel peeks its header + a strip of body (116px) instead of just the 52px header bar. Mobile is untouched.
- **Header cleanup** — the App panel header is gone at every breakpoint, and the API calls header is gone on the wide layout only (side-by-side, the calls are the column; the resize handle draws the full-height divider). It stays on stacked layouts as the peek target + new-call pill.
- **Compact configure panel everywhere** — the laptop layout's 400px width + 40px padding is the default at all breakpoints; layout constants (1600 / 400) live in `lib/layout.ts` with SCSS twins.

## Test plan

- [ ] Wide (≥1600px): configure 400px, code column = sidebar + 400, no app/API headers, drag-resize + snap-back works
- [ ] Docs sidebar collapse AND expand at ≥1600: code column glides in sync, one motion, no jumps
- [ ] Sidebar toggle across the breakpoint (e.g. MBP 16" at 1728): clean snap, app column never collapses, phone doesn't blink
- [ ] Refresh at stacked and 3-col viewports: no layout flash, code column paints at its real width from the first frame
- [ ] Laptop (768–1599px): API panel peeks header + body strip; header present with new-call pill
- [ ] Mobile (≤767px): unchanged — header-bar peek, Explore/Configure swap works
- [ ] Light + dark mode chrome/stage colors, standalone (non-embedded) demo unaffected

Made with [Cursor](https://cursor.com)