### PR TITLE
feat(openapi): add counterparty payout failure reasons

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -17066,8 +17066,33 @@ components:
         - QUOTE_EXECUTION_FAILED
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
+        - COUNTERPARTY_COMPLIANCE_REJECTED
+        - COUNTERPARTY_ACCOUNT_INVALID
+        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+        - COUNTERPARTY_LIMIT_EXCEEDED
+        - COUNTERPARTY_PAYOUT_RETURNED
+        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+        - COUNTERPARTY_PAYOUT_EXPIRED
         - COUNTERPARTY_POST_TX_FAILED
-      description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+      description: |
+        Reason for failure of an outgoing transaction. This is used to provide more
+        context on why a transaction failed. If the transaction is not in a failed
+        state, this field is omitted.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
     OutgoingTransaction:
       title: Outgoing Transaction
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17066,8 +17066,33 @@ components:
         - QUOTE_EXECUTION_FAILED
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
+        - COUNTERPARTY_COMPLIANCE_REJECTED
+        - COUNTERPARTY_ACCOUNT_INVALID
+        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+        - COUNTERPARTY_LIMIT_EXCEEDED
+        - COUNTERPARTY_PAYOUT_RETURNED
+        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+        - COUNTERPARTY_PAYOUT_EXPIRED
         - COUNTERPARTY_POST_TX_FAILED
-      description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+      description: |
+        Reason for failure of an outgoing transaction. This is used to provide more
+        context on why a transaction failed. If the transaction is not in a failed
+        state, this field is omitted.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
     OutgoingTransaction:
       title: Outgoing Transaction
       allOf:

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -4,8 +4,30 @@ enum:
   - QUOTE_EXECUTION_FAILED
   - LIGHTNING_PAYMENT_FAILED
   - FUNDING_AMOUNT_MISMATCH
+  - COUNTERPARTY_COMPLIANCE_REJECTED
+  - COUNTERPARTY_ACCOUNT_INVALID
+  - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+  - COUNTERPARTY_LIMIT_EXCEEDED
+  - COUNTERPARTY_PAYOUT_RETURNED
+  - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+  - COUNTERPARTY_PAYOUT_EXPIRED
   - COUNTERPARTY_POST_TX_FAILED
-description: >-
+description: |
   Reason for failure of an outgoing transaction. This is used to provide more
   context on why a transaction failed. If the transaction is not in a failed
   state, this field is omitted.
+
+  | Reason | Description |
+  |--------|-------------|
+  | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+  | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+  | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+  | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+  | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+  | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+  | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+  | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+  | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+  | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+  | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |


### PR DESCRIPTION
## Summary

Adds 7 counterparty (payout-side) failure reasons to `OutgoingTransactionFailureReason`, based on the payout failure taxonomy. Today every partner-side failure that can't be pinned to a specific cause collapses into the generic `COUNTERPARTY_POST_TX_FAILED`; these new values let integrators distinguish recipient/customer-actionable failures from partner-side ones.

New values:
- `COUNTERPARTY_COMPLIANCE_REJECTED` — partner rejected the recipient on compliance grounds (sanctions, watchlist, KYC/AML)
- `COUNTERPARTY_ACCOUNT_INVALID` — recipient account not found / details wrong
- `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` — account exists but can't accept the payment (dormant, frozen, unsupported currency)
- `COUNTERPARTY_LIMIT_EXCEEDED` — payout exceeds a recipient/account/corridor limit at the partner
- `COUNTERPARTY_PAYOUT_RETURNED` — receiving bank accepted then returned/reversed the payout
- `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` — partner couldn't complete the required FX conversion
- `COUNTERPARTY_PAYOUT_EXPIRED` — partner didn't complete the payout within its processing window

The existing generic `COUNTERPARTY_POST_TX_FAILED` is retained as the fallback bucket.

Also upgrades the schema `description` to a markdown table documenting each value's customer-facing meaning, matching the `OutgoingTransactionStatus` convention.

## Changes
- `openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml` — source edit
- `openapi.yaml`, `mintlify/openapi.yaml` — regenerated via `make build`

## Verification
- `make build` rebundles cleanly
- Redocly validation passes (`Your API description is valid 🎉`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)