### PR TITLE
Docs: send the homepage hero banner CTA to the playground

### DIFF
--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -143,7 +143,7 @@ export const gridCategories = [
 </div>
 
 {/* Hero Banner with Sand Dunes Image */}
-<a href="/global-accounts" className="hero-banner">
+<a href="/global-accounts/demo" className="hero-banner">
   <div className="hero-banner-bg"></div>
   <div className="hero-banner-overlay">
     <span className="hero-banner-text">Introducing Grid Global Accounts <span className="hero-banner-text-link">Create global dollar accounts with one integration</span></span>


### PR DESCRIPTION
## Summary

- The "Start building" CTA on the homepage's Global Accounts hero banner landed on the introduction page (`/global-accounts`); it now goes to the playground (`/global-accounts/demo`) — the showcase the banner is pitching. (Feedback from Leo.)
- The whole banner is a single anchor, so the banner text goes there too.

## Test plan

- [ ] Homepage → click "Start building" on the hero banner → lands on `/global-accounts/demo` with the playground loaded

Made with [Cursor](https://cursor.com)