### PR TITLE
fix: code block style nits

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1717,11 +1717,13 @@ div.callout,
   padding: 0 !important;
   overflow: hidden !important;
   border: 0.5px solid var(--ls-black-10) !important;
+  background-color: var(--ls-white) !important;
 }
 
 html.dark .code-group,
 html.dark [data-testid="code-group-select"] {
   border-color: var(--ls-white-06) !important;
+  background-color: var(--ls-gray-975) !important;
 }
 
 /* Code group inner container - no border radius (exclude interactive tabs/buttons) */
@@ -1785,6 +1787,11 @@ html.dark .code-group [data-component-part="code-block-root"],
 html.dark .code-block-background,
 html.dark .code-group [class*="dark:bg-codeblock"] {
   background-color: var(--ls-gray-975) !important;
+}
+
+/* Match the scroll fade overlay to the dark code block background */
+[data-fade-overlay] {
+  --fade-color-dark: var(--ls-gray-975) !important;
 }
 
 /* API Reference - Try It input fields */

--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1717,13 +1717,11 @@ div.callout,
   padding: 0 !important;
   overflow: hidden !important;
   border: 0.5px solid var(--ls-black-10) !important;
-  background-color: var(--ls-white) !important;
 }
 
 html.dark .code-group,
 html.dark [data-testid="code-group-select"] {
   border-color: var(--ls-white-06) !important;
-  background-color: var(--ls-gray-975) !important;
 }
 
 /* Code group inner container - no border radius (exclude interactive tabs/buttons) */
@@ -1736,6 +1734,19 @@ html.dark [data-testid="code-group-select"] {
 .code-group [data-component-part="code-block-root"],
 [data-testid="code-group-select"] [data-component-part="code-block-root"] {
   border-radius: 0 !important;
+}
+
+/* Mintlify rounds the content area via a `rounded-xt!` utility that lives in
+   @layer utilities; layered !important beats our unlayered !important no
+   matter the specificity, so this override must join the same layer. Inside
+   the layer the extra `div` type wins the specificity tie against the
+   utility's (0,2,0) selector */
+@layer utilities {
+  .code-group div[data-component-part="code-block-root"],
+  [data-testid="code-group-select"] div[data-component-part="code-block-root"],
+  div:has(> [data-component-part="code-block-header"]) div[data-component-part="code-block-root"] {
+    border-radius: 0 !important;
+  }
 }
 
 /* Restore radius on interactive tabs and pills inside code groups */


### PR DESCRIPTION
<table>
<thead>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="440" height="236" alt="CleanShot 2026-07-08 at 1  21 13@2x" src="https://github.com/user-attachments/assets/f130a29c-690a-4a5d-a1af-60b44c1caf1e" />

</td>
<td>
<img width="440" height="236" alt="CleanShot 2026-07-08 at 1  21 46@2x" src="https://github.com/user-attachments/assets/749614d4-608b-429a-8e8e-f21b761a787a" />

</td>
</tr>
<tr>
<td>

<img width="1098" height="450" alt="CleanShot 2026-07-08 at 2  07 28@2x" src="https://github.com/user-attachments/assets/4eb302ab-29c2-4895-8744-fadb0bd16596" />

</td>
<td>

<img width="1098" height="450" alt="CleanShot 2026-07-08 at 2  07 19@2x" src="https://github.com/user-attachments/assets/a5b233b8-f006-44b2-8b5e-131a3fcc54e2" />

</td>
</tr>
</tbody>
</table>