### PR TITLE
Remove the broken Stainless csharp target so spec PRs stop failing CI

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -57,12 +57,8 @@ targets:
     edition: go.2026-04-15
     package_name: grid
     production_repo: null
-  csharp:
-    edition: csharp.2025-10-08
-    package_name: grid
-    production_repo: null
-    publish:
-      nuget: false
+  # csharp (unpublished) is omitted: its Stainless build CI fails on any
+  # freshly generated code, failing the preview check on spec-changing PRs.
   php:
     edition: php.2025-10-08
     package_name: grid


### PR DESCRIPTION
## Summary

Removes the csharp target from `.stainless/stainless.yml` so the `Build SDKs for pull request / preview` check stops failing on every spec-changing PR.

**Why every spec PR is red**: Stainless's csharp build CI is broken upstream for ANY freshly generated code (content-independent, proven by bisect on #650, breakage window ~Jul 3). The preview check gates on a per-language head-vs-base regression, and with csharp in main's config the base build resolves to a cached pre-breakage csharp *success* — so every fresh head failure counts as a regression → red.

**Why this fixes it**: with csharp out of the config on main, base builds have no cached csharp success to regress from — matching outcomes on base and head → "not a regression" → green. Proven end-to-end by probe #659: the exact previously-failing change class (doc-comment-only codegen delta) ran against a csharp-free base and `preview` **passed**. Full mechanics: [investigation writeup](https://github.com/lightsparkdev/grid-api/pull/657#issuecomment-4899325043).

**No shipping impact**: the csharp target is unpublished (`production_repo: null`, `publish.nuget: false`). Re-add the block when Stainless fixes their csharp build CI upstream.

## Sequencing (for #657 and other open spec PRs)

1. Merge this PR — **its own `preview` will be red** (its base is current main); merge through it (precedent: #633, #637).
2. Merge/rebase main into open spec PRs (e.g. #657) — their next `preview` run goes green.

## Verification

- `make lint` passes; the file matches the exact removal previously validated on the #657 branch (commit 069ad9a3) and by probe #659.

---
🤖 [thundering-graviton-3](https://zeus.dev.dev.sparkinfra.net/#/arc?id=thundering-graviton)[(#3)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=thundering-graviton-3) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/663