### PR TITLE
Flow builder: match the docs' new three-option theme switcher

### DIFF
--- a/components/grid-visualizer/src/app/layout.tsx
+++ b/components/grid-visualizer/src/app/layout.tsx
@@ -50,14 +50,19 @@ export default function RootLayout({
                   if (params.get('embed') === 'true') {
                     document.documentElement.setAttribute('data-embed', 'true');
                   }
-                  var paramTheme = params.get('theme');
-                  var theme = paramTheme || localStorage.getItem('grid-theme');
-                  if (!theme) {
-                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  // Preference (system/light/dark, mirroring the docs' Mintlify
+                  // switcher) and the resolved mode, both set before paint:
+                  // data-theme drives styling, data-theme-pref the footer
+                  // toggle's active option.
+                  var pref = params.get('theme') || localStorage.getItem('grid-theme');
+                  if (pref !== 'dark' && pref !== 'light' && pref !== 'system') {
+                    pref = 'system';
                   }
-                  if (theme === 'dark' || theme === 'light') {
-                    document.documentElement.setAttribute('data-theme', theme);
-                  }
+                  var theme = pref === 'system'
+                    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : pref;
+                  document.documentElement.setAttribute('data-theme', theme);
+                  document.documentElement.setAttribute('data-theme-pref', pref);
                 } catch (e) {}
               })();
             `,

--- a/components/grid-visualizer/src/app/page.tsx
+++ b/components/grid-visualizer/src/app/page.tsx
@@ -233,7 +233,7 @@ export default function Home() {
         </div>
 
         <div className={styles.sidebarFooter}>
-          <Footer pref={pref} setPref={handleThemeChange} />
+          <Footer pref={pref} setPref={handleThemeChange} embed={isEmbed} />
         </div>
       </div>
 

--- a/components/grid-visualizer/src/app/page.tsx
+++ b/components/grid-visualizer/src/app/page.tsx
@@ -85,26 +85,40 @@ export default function Home() {
     return () => window.removeEventListener('popstate', handlePop);
   }, [mobileView]);
 
-  const { theme, setTheme } = useTheme();
+  const { theme, pref, setPref } = useTheme();
 
-  const handleThemeChange = useCallback((t: 'light' | 'dark') => {
-    setTheme(t);
+  const handleThemeChange = useCallback((p: 'system' | 'light' | 'dark') => {
+    setPref(p);
     if (isEmbed) {
-      window.parent.postMessage({ type: 'theme-sync', theme: t }, '*');
+      // `theme` is the RESOLVED mode (what old docs handlers expect and
+      // toggle the .dark class from); `pref` lets the new docs handler route
+      // the change through Mintlify's own switcher so its state stays true.
+      const resolved =
+        p === 'system'
+          ? window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light'
+          : p;
+      window.parent.postMessage({ type: 'theme-sync', theme: resolved, pref: p }, '*');
     }
-  }, [setTheme, isEmbed]);
+  }, [setPref, isEmbed]);
 
   useEffect(() => {
     if (!isEmbed) return;
     const handler = (e: MessageEvent) => {
-      if (e.data?.type === 'theme-sync' && (e.data.theme === 'light' || e.data.theme === 'dark')) {
-        setTheme(e.data.theme);
+      if (e.data?.type !== 'theme-sync') return;
+      // New docs handler reports the Mintlify switcher's PREFERENCE so this
+      // footer mirrors it exactly; old handlers only send the resolved mode.
+      if (e.data.pref === 'system' || e.data.pref === 'light' || e.data.pref === 'dark') {
+        setPref(e.data.pref);
+      } else if (e.data.theme === 'light' || e.data.theme === 'dark') {
+        setPref(e.data.theme);
       }
     };
     window.addEventListener('message', handler);
     window.parent.postMessage({ type: 'theme-request' }, '*');
     return () => window.removeEventListener('message', handler);
-  }, [isEmbed, setTheme]);
+  }, [isEmbed, setPref]);
 
   // Sync iOS status bar color with the top element's background
   useEffect(() => {
@@ -219,7 +233,7 @@ export default function Home() {
         </div>
 
         <div className={styles.sidebarFooter}>
-          <Footer theme={theme} setTheme={handleThemeChange} />
+          <Footer pref={pref} setPref={handleThemeChange} />
         </div>
       </div>
 

--- a/components/grid-visualizer/src/components/Footer/DocsThemeIcons.tsx
+++ b/components/grid-visualizer/src/components/Footer/DocsThemeIcons.tsx
@@ -1,0 +1,77 @@
+/** The docs' theme-switcher glyphs, verbatim (16-grid, 1.5 stroke): system
+ *  and sun are extracted from Mintlify's own component, the crescent moon is
+ *  the classic one the docs restore over Mintlify's stock Lucide moon. Used
+ *  in EMBED mode only, so the footer toggle is pixel-identical to the docs'
+ *  sidebar switcher; the standalone flow builder keeps its central-icons set.
+ */
+
+interface IconProps {
+  size?: number;
+}
+
+export function DocsSystemIcon({ size = 12 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M5.11133 14.4444C5.78511 14.232 6.78066 14 8.00022 14C8.70688 14 9.72555 14.0782 10.8891 14.4444" />
+      <path d="M8 11.7778V14.0001" />
+      <path d="M12.6668 2.44434H3.33344C2.3516 2.44434 1.55566 3.24027 1.55566 4.22211V9.99989C1.55566 10.9817 2.3516 11.7777 3.33344 11.7777H12.6668C13.6486 11.7777 14.4446 10.9817 14.4446 9.99989V4.22211C14.4446 3.24027 13.6486 2.44434 12.6668 2.44434Z" />
+    </svg>
+  );
+}
+
+export function DocsSunIcon({ size = 12 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M8 1.11133V2.00022" />
+      <path d="M12.8711 3.12891L12.2427 3.75735" />
+      <path d="M14.8889 8H14" />
+      <path d="M12.8711 12.8711L12.2427 12.2427" />
+      <path d="M8 14.8889V14" />
+      <path d="M3.12891 12.8711L3.75735 12.2427" />
+      <path d="M1.11133 8H2.00022" />
+      <path d="M3.12891 3.12891L3.75735 3.75735" />
+      <path d="M8.00043 11.7782C10.0868 11.7782 11.7782 10.0868 11.7782 8.00043C11.7782 5.91402 10.0868 4.22266 8.00043 4.22266C5.91402 4.22266 4.22266 5.91402 4.22266 8.00043C4.22266 10.0868 5.91402 11.7782 8.00043 11.7782Z" />
+    </svg>
+  );
+}
+
+export function DocsMoonIcon({ size = 12 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M11.5556 10.4445C8.48717 10.4445 6.00005 7.95743 6.00005 4.88899C6.00005 3.68721 6.38494 2.57877 7.03294 1.66943C4.04272 2.22766 1.77783 4.84721 1.77783 8.0001C1.77783 11.5592 4.66317 14.4445 8.22228 14.4445C11.2196 14.4445 13.7316 12.3948 14.4525 9.62321C13.6081 10.1414 12.6187 10.4445 11.5556 10.4445Z" />
+    </svg>
+  );
+}

--- a/components/grid-visualizer/src/components/Footer/Footer.module.scss
+++ b/components/grid-visualizer/src/components/Footer/Footer.module.scss
@@ -90,13 +90,15 @@
     svg {
       width: 12px !important;
       height: 12px !important;
-    }
 
-    // The docs pin ALL svg strokes at their authored 1.5px (a global
-    // non-scaling-stroke rule in mintlify/style.css) — the flow builder's
-    // own non-scaling rule above does the same here, so the docs glyphs
-    // render at the docs' exact absolute weight. Don't "fix" this back to
-    // scaling: 1.125px reads thin next to the docs switcher.
+      path {
+        // Scale the strokes with the glyph: 16-grid 1.5 at 12px = 1.125px,
+        // the docs switcher's weight (the docs override their site-wide
+        // non-scaling rule for these glyphs the same way). Without this the
+        // non-scaling rule above pins them at a chunkier 1.5px absolute.
+        vector-effect: none;
+      }
+    }
   }
 
   :global([data-embed='true'][data-theme='dark']) & {

--- a/components/grid-visualizer/src/components/Footer/Footer.module.scss
+++ b/components/grid-visualizer/src/components/Footer/Footer.module.scss
@@ -90,6 +90,13 @@
     svg {
       width: 12px !important;
       height: 12px !important;
+
+      path {
+        // The docs glyphs must SCALE their strokes (16-grid 1.5 → 1.125px at
+        // 12px, the docs' exact weight); the global non-scaling rule above
+        // would pin them at 1.5px — the chunkiness this mode exists to avoid.
+        vector-effect: none;
+      }
     }
   }
 

--- a/components/grid-visualizer/src/components/Footer/Footer.module.scss
+++ b/components/grid-visualizer/src/components/Footer/Footer.module.scss
@@ -74,12 +74,17 @@
     vector-effect: non-scaling-stroke;
   }
 
-  // Embed mode: smaller items, CSS-only icon size and active state
+  // Embed mode: smaller items, CSS-only icon size and active state. Colors
+  // are measured from Mintlify's live component (their custom gray scale —
+  // no matching Origin tokens); base = INACTIVE on the light chrome.
   :global([data-embed='true']) & {
     width: 20px;
     height: 20px;
     border-radius: 9999px;
-    color: #505050 !important; // Mintlify text-gray-600 (no matching Origin token)
+    // The docs apply corner-shape globally, so their active pill reads as a
+    // soft superellipse square, not a circle — match it.
+    corner-shape: squircle;
+    color: #9f9f9f !important; // inactive, light (their text-gray-400)
     background: none !important;
 
     svg {
@@ -88,31 +93,29 @@
     }
   }
 
-  // CSS-only active state in embed mode (no React flash) — keyed to the
-  // PREFERENCE attribute (set pre-paint by the layout script), not the
-  // resolved theme, so `system` can be the selected option while the page
-  // renders light or dark.
-  // !important ensures these beat the React-applied .toggleItemActive class
-  :global([data-embed='true'][data-theme-pref='system']) &[data-mode='system'],
-  :global([data-embed='true'][data-theme-pref='light']) &[data-mode='light'],
-  :global([data-embed='true'][data-theme-pref='dark']) &[data-mode='dark'] {
-    color: #9f9f9f !important; // Mintlify text-gray-400 (no matching Origin token)
+  :global([data-embed='true'][data-theme='dark']) & {
+    color: #707070 !important; // inactive, dark (their dark:text-gray-500)
   }
 
-  // Active pill fill, on the light and dark chrome respectively. The active
-  // option is the preference; the fill color follows the resolved theme.
+  // ACTIVE — keyed to the PREFERENCE attribute (set pre-paint by the layout
+  // script), not the resolved theme, so `system` can be the selected option
+  // while the page renders light or dark. The selected option gets the
+  // prominent color + pill fill, per chrome.
+  // !important ensures these beat the React-applied .toggleItemActive class
   :global([data-embed='true'][data-theme='light'][data-theme-pref='system'])
     &[data-mode='system'],
   :global([data-embed='true'][data-theme='light'][data-theme-pref='light'])
     &[data-mode='light'] {
-    background: rgba(229, 231, 235, 0.5) !important;
+    color: #505050 !important; // active, light (their text-gray-600)
+    background: rgba(223, 223, 223, 0.5) !important; // bg-gray-200/50
   }
 
   :global([data-embed='true'][data-theme='dark'][data-theme-pref='system'])
     &[data-mode='system'],
   :global([data-embed='true'][data-theme='dark'][data-theme-pref='dark'])
     &[data-mode='dark'] {
-    background: #171717 !important;
+    color: #dfdfdf !important; // active, dark (their dark:text-gray-200)
+    background: #171717 !important; // dark:bg-gray-900
   }
 }
 

--- a/components/grid-visualizer/src/components/Footer/Footer.module.scss
+++ b/components/grid-visualizer/src/components/Footer/Footer.module.scss
@@ -90,14 +90,13 @@
     svg {
       width: 12px !important;
       height: 12px !important;
-
-      path {
-        // The docs glyphs must SCALE their strokes (16-grid 1.5 → 1.125px at
-        // 12px, the docs' exact weight); the global non-scaling rule above
-        // would pin them at 1.5px — the chunkiness this mode exists to avoid.
-        vector-effect: none;
-      }
     }
+
+    // The docs pin ALL svg strokes at their authored 1.5px (a global
+    // non-scaling-stroke rule in mintlify/style.css) — the flow builder's
+    // own non-scaling rule above does the same here, so the docs glyphs
+    // render at the docs' exact absolute weight. Don't "fix" this back to
+    // scaling: 1.125px reads thin next to the docs switcher.
   }
 
   :global([data-embed='true'][data-theme='dark']) & {

--- a/components/grid-visualizer/src/components/Footer/Footer.module.scss
+++ b/components/grid-visualizer/src/components/Footer/Footer.module.scss
@@ -29,7 +29,6 @@
   background: var(--surface-secondary);
   border: var(--stroke-xs) solid var(--border-tertiary);
   border-radius: var(--corner-radius-md);
-  cursor: pointer;
   transition: border-color 150ms ease;
 
   :global([data-theme='dark']) & {
@@ -40,16 +39,17 @@
     border-color: var(--border-secondary);
   }
 
-  // Match Mintlify sidebar toggle: 52x28 pill
+  // Match Mintlify's NEW sidebar switcher: 76x28 three-option pill
+  // (system / light / dark), justify-between like theirs.
   :global([data-embed='true']) & {
-    width: 52px;
+    width: 76px;
     height: 28px;
     padding: 4px;
-    gap: 2px;
+    gap: 0;
     border-radius: 9999px;
     background: transparent;
     border-color: rgba(0, 0, 0, 0.07);
-    justify-content: center;
+    justify-content: space-between;
   }
 
   :global([data-embed='true'][data-theme='dark']) & {
@@ -58,6 +58,7 @@
 }
 
 .toggleItem {
+  all: unset;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -66,6 +67,7 @@
   height: 24px;
   border-radius: var(--corner-radius-sm);
   color: var(--icon-secondary);
+  cursor: pointer;
   transition: background 150ms ease, color 150ms ease;
 
   svg path {
@@ -86,18 +88,30 @@
     }
   }
 
-  // CSS-only active state in embed mode (no React flash)
+  // CSS-only active state in embed mode (no React flash) — keyed to the
+  // PREFERENCE attribute (set pre-paint by the layout script), not the
+  // resolved theme, so `system` can be the selected option while the page
+  // renders light or dark.
   // !important ensures these beat the React-applied .toggleItemActive class
-  :global([data-embed='true'][data-theme='light']) &[data-mode='light'],
-  :global([data-embed='true'][data-theme='dark']) &[data-mode='dark'] {
-    color: #9F9F9F !important; // Mintlify text-gray-400 (no matching Origin token)
+  :global([data-embed='true'][data-theme-pref='system']) &[data-mode='system'],
+  :global([data-embed='true'][data-theme-pref='light']) &[data-mode='light'],
+  :global([data-embed='true'][data-theme-pref='dark']) &[data-mode='dark'] {
+    color: #9f9f9f !important; // Mintlify text-gray-400 (no matching Origin token)
   }
 
-  :global([data-embed='true'][data-theme='light']) &[data-mode='light'] {
+  // Active pill fill, on the light and dark chrome respectively. The active
+  // option is the preference; the fill color follows the resolved theme.
+  :global([data-embed='true'][data-theme='light'][data-theme-pref='system'])
+    &[data-mode='system'],
+  :global([data-embed='true'][data-theme='light'][data-theme-pref='light'])
+    &[data-mode='light'] {
     background: rgba(229, 231, 235, 0.5) !important;
   }
 
-  :global([data-embed='true'][data-theme='dark']) &[data-mode='dark'] {
+  :global([data-embed='true'][data-theme='dark'][data-theme-pref='system'])
+    &[data-mode='system'],
+  :global([data-embed='true'][data-theme='dark'][data-theme-pref='dark'])
+    &[data-mode='dark'] {
     background: #171717 !important;
   }
 }

--- a/components/grid-visualizer/src/components/Footer/Footer.tsx
+++ b/components/grid-visualizer/src/components/Footer/Footer.tsx
@@ -1,46 +1,49 @@
 'use client';
 
-import type { Theme } from '@/hooks/useTheme';
+import type { ThemePref } from '@/hooks/useTheme';
 import { IconSun } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconSun';
 import { IconMoon } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconMoon';
+import { IconStudioDisplay } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconStudioDisplay';
 import { IconGithub } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconGithub';
 import styles from './Footer.module.scss';
 import clsx from 'clsx';
 
 interface FooterProps {
-  theme: Theme;
-  setTheme: (t: Theme) => void;
+  pref: ThemePref;
+  setPref: (p: ThemePref) => void;
 }
 
-export function Footer({ theme, setTheme }: FooterProps) {
+// Mirrors the docs' Mintlify switcher: system / light / dark, in that order,
+// with matching aria-labels — so the embedded footer and the docs sidebar
+// read as the same control.
+const OPTIONS: { mode: ThemePref; label: string; Icon: typeof IconSun }[] = [
+  { mode: 'system', label: 'Switch to system theme', Icon: IconStudioDisplay },
+  { mode: 'light', label: 'Switch to light theme', Icon: IconSun },
+  { mode: 'dark', label: 'Switch to dark theme', Icon: IconMoon },
+];
+
+export function Footer({ pref, setPref }: FooterProps) {
   return (
     <>
       <span className={styles.coordsLabel}>(0, 0, 0)</span>
-      <button
-        className={styles.toggle}
-        type="button"
-        aria-label="Toggle theme"
-        onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-      >
-        <span
-          data-mode="light"
-          className={clsx(
-            styles.toggleItem,
-            theme === 'light' && styles.toggleItemActive,
-          )}
-        >
-          <IconSun size={14} />
-        </span>
-        <span
-          data-mode="dark"
-          className={clsx(
-            styles.toggleItem,
-            theme === 'dark' && styles.toggleItemActive,
-          )}
-        >
-          <IconMoon size={14} />
-        </span>
-      </button>
+      <div className={styles.toggle} role="group" aria-label="Theme preference">
+        {OPTIONS.map(({ mode, label, Icon }) => (
+          <button
+            key={mode}
+            type="button"
+            aria-label={label}
+            aria-pressed={pref === mode}
+            data-mode={mode}
+            className={clsx(
+              styles.toggleItem,
+              pref === mode && styles.toggleItemActive,
+            )}
+            onClick={() => setPref(mode)}
+          >
+            <Icon size={14} />
+          </button>
+        ))}
+      </div>
 
       <div className={styles.trailing}>
           <a href="https://docs.lightspark.com" className={styles.link} target="_blank" rel="noopener noreferrer">

--- a/components/grid-visualizer/src/components/Footer/Footer.tsx
+++ b/components/grid-visualizer/src/components/Footer/Footer.tsx
@@ -5,29 +5,39 @@ import { IconSun } from '@central-icons-react/round-outlined-radius-3-stroke-1.5
 import { IconMoon } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconMoon';
 import { IconStudioDisplay } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconStudioDisplay';
 import { IconGithub } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconGithub';
+import { DocsSystemIcon, DocsSunIcon, DocsMoonIcon } from './DocsThemeIcons';
 import styles from './Footer.module.scss';
 import clsx from 'clsx';
 
 interface FooterProps {
   pref: ThemePref;
   setPref: (p: ThemePref) => void;
+  /** Embedded in the docs — the toggle mirrors the docs' sidebar switcher
+   *  pixel-for-pixel, including its exact glyphs. Standalone keeps the flow
+   *  builder's own central-icons set (24-grid, non-scaling 1.5 stroke). */
+  embed?: boolean;
 }
 
 // Mirrors the docs' Mintlify switcher: system / light / dark, in that order,
 // with matching aria-labels — so the embedded footer and the docs sidebar
 // read as the same control.
-const OPTIONS: { mode: ThemePref; label: string; Icon: typeof IconSun }[] = [
-  { mode: 'system', label: 'Switch to system theme', Icon: IconStudioDisplay },
-  { mode: 'light', label: 'Switch to light theme', Icon: IconSun },
-  { mode: 'dark', label: 'Switch to dark theme', Icon: IconMoon },
-];
+const OPTIONS = [
+  {
+    mode: 'system',
+    label: 'Switch to system theme',
+    Icon: IconStudioDisplay,
+    DocsIcon: DocsSystemIcon,
+  },
+  { mode: 'light', label: 'Switch to light theme', Icon: IconSun, DocsIcon: DocsSunIcon },
+  { mode: 'dark', label: 'Switch to dark theme', Icon: IconMoon, DocsIcon: DocsMoonIcon },
+] as const;
 
-export function Footer({ pref, setPref }: FooterProps) {
+export function Footer({ pref, setPref, embed = false }: FooterProps) {
   return (
     <>
       <span className={styles.coordsLabel}>(0, 0, 0)</span>
       <div className={styles.toggle} role="group" aria-label="Theme preference">
-        {OPTIONS.map(({ mode, label, Icon }) => (
+        {OPTIONS.map(({ mode, label, Icon, DocsIcon }) => (
           <button
             key={mode}
             type="button"
@@ -40,7 +50,7 @@ export function Footer({ pref, setPref }: FooterProps) {
             )}
             onClick={() => setPref(mode)}
           >
-            <Icon size={14} />
+            {embed ? <DocsIcon size={12} /> : <Icon size={14} />}
           </button>
         ))}
       </div>

--- a/components/grid-visualizer/src/hooks/useTheme.ts
+++ b/components/grid-visualizer/src/hooks/useTheme.ts
@@ -1,37 +1,60 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 export type Theme = 'light' | 'dark';
+/** What the user picked — mirrors the docs' Mintlify switcher (system/light/
+ *  dark). `system` resolves live against the OS preference. */
+export type ThemePref = 'system' | Theme;
+
+const resolve = (pref: ThemePref): Theme =>
+  pref === 'system'
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+    : pref;
+
+const isPref = (v: unknown): v is ThemePref =>
+  v === 'system' || v === 'light' || v === 'dark';
 
 export function useTheme() {
+  const [pref, setPrefState] = useState<ThemePref>('system');
   const [theme, setThemeState] = useState<Theme>('light');
+  const prefRef = useRef(pref);
+
+  const apply = useCallback((p: ThemePref) => {
+    const t = resolve(p);
+    prefRef.current = p;
+    setPrefState(p);
+    setThemeState(t);
+    // data-theme drives ALL styling (resolved); data-theme-pref drives the
+    // footer toggle's active state (what's selected, incl. system).
+    document.documentElement.setAttribute('data-theme', t);
+    document.documentElement.setAttribute('data-theme-pref', p);
+  }, []);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const paramTheme = params.get('theme') as Theme | null;
-    const stored = localStorage.getItem('grid-theme') as Theme | null;
-    const resolved =
-      paramTheme === 'dark' || paramTheme === 'light'
-        ? paramTheme
-        : stored === 'dark' || stored === 'light'
-          ? stored
-          : window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light';
-    setThemeState(resolved);
-    document.documentElement.setAttribute('data-theme', resolved);
-  }, []);
+    const paramPref = params.get('theme');
+    const stored = localStorage.getItem('grid-theme');
+    apply(isPref(paramPref) ? paramPref : isPref(stored) ? stored : 'system');
 
-  const setTheme = useCallback((t: Theme) => {
-    setThemeState(t);
-    document.documentElement.setAttribute('data-theme', t);
-    localStorage.setItem('grid-theme', t);
-  }, []);
+    // While on `system`, follow the OS live — same as the docs switcher.
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      if (prefRef.current === 'system') apply('system');
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [apply]);
 
-  const toggleTheme = useCallback(() => {
-    setTheme(theme === 'light' ? 'dark' : 'light');
-  }, [theme, setTheme]);
+  const setPref = useCallback(
+    (p: ThemePref) => {
+      apply(p);
+      localStorage.setItem('grid-theme', p);
+    },
+    [apply],
+  );
 
-  return { theme, setTheme, toggleTheme };
+  return { theme, pref, setPref };
 }

--- a/mintlify/flow-builder.mdx
+++ b/mintlify/flow-builder.mdx
@@ -9,8 +9,30 @@ export const FlowBuilderEmbed = () => {
   const [src, setSrc] = React.useState(null);
 
   React.useEffect(() => {
+    const prefButtons = () => {
+      const g = document.querySelector('#sidebar-content [role="group"][aria-label="Theme preference"]');
+      if (!g) return null;
+      return {
+        group: g,
+        system: g.querySelector('button[aria-label="Switch to system theme"]'),
+        light: g.querySelector('button[aria-label="Switch to light theme"]'),
+        dark: g.querySelector('button[aria-label="Switch to dark theme"]'),
+      };
+    };
+
+    const currentPref = () => {
+      const b = prefButtons();
+      const pressed = b && b.group.querySelector('button[aria-pressed="true"]');
+      const label = pressed ? pressed.getAttribute('aria-label') || '' : '';
+      if (label.indexOf('system') !== -1) return 'system';
+      if (label.indexOf('light') !== -1) return 'light';
+      if (label.indexOf('dark') !== -1) return 'dark';
+      return null;
+    };
+
     const isDark = document.documentElement.classList.contains('dark');
-    setSrc('https://grid-flow-builder.vercel.app/?embed=true&theme=' + (isDark ? 'dark' : 'light'));
+    const initialPref = currentPref();
+    setSrc('https://grid-flow-builder.vercel.app/?embed=true&theme=' + (initialPref || (isDark ? 'dark' : 'light')));
 
     let ignoreNextMutation = false;
 
@@ -18,7 +40,7 @@ export const FlowBuilderEmbed = () => {
       const t = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
       const iframe = document.getElementById('flow-builder-iframe');
       if (iframe && iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: 'theme-sync', theme: t }, '*');
+        iframe.contentWindow.postMessage({ type: 'theme-sync', theme: t, pref: currentPref() || undefined }, '*');
       }
     };
 
@@ -28,9 +50,18 @@ export const FlowBuilderEmbed = () => {
         return;
       }
       if (e.data && e.data.type === 'theme-sync') {
-        const isDark = document.documentElement.classList.contains('dark');
+        const isDarkNow = document.documentElement.classList.contains('dark');
         const wantsDark = e.data.theme === 'dark';
-        if (isDark !== wantsDark) {
+        const want = e.data.pref;
+        const btns = want ? prefButtons() : null;
+        if (btns && btns[want]) {
+          if (currentPref() !== want) {
+            if (isDarkNow !== wantsDark) ignoreNextMutation = true;
+            btns[want].click();
+          }
+          return;
+        }
+        if (isDarkNow !== wantsDark) {
           ignoreNextMutation = true;
           document.documentElement.classList.toggle('dark');
         }


### PR DESCRIPTION
## Summary

Mintlify's hosted renderer replaced the docs' two-icon theme toggle with a three-option system/light/dark switcher, leaving the flow builder's duplicated footer toggle mismatched. This PR:

- **Footer toggle** (grid-visualizer): now the same three-option control as the docs — monitor/sun/moon in the same order with the same aria-labels, active state tracks the *preference* (`data-theme-pref`, set pre-paint), and `system` resolves live against the OS via a matchMedia listener. Embed mode matches the docs switcher's geometry (76×28 pill, 20px buttons, 12px glyphs).
- **Theme bridge** (`flow-builder.mdx` + visualizer): messages now carry the preference alongside the resolved theme. The docs side routes iframe-initiated changes through Mintlify's own (hidden) switcher buttons so its stored preference and `aria-pressed` stay true — no more class-vs-preference desync — and reports its preference into the iframe so the footer mirrors the docs exactly.
- **Deploy-order safe**: both sides fall back to the old resolved-theme messages, so docs and the visualizer can ship in either order.

## Test plan

- [ ] Flow builder standalone: three-option toggle works, system follows OS
- [ ] Docs flow-builder page: flipping the footer toggle updates the docs theme AND Mintlify's switcher state (check another page's sidebar switcher afterwards)
- [ ] Docs → iframe: changing theme on another docs page carries into the flow builder on navigation
- [ ] Old-format compatibility: prod visualizer + new docs (and vice versa) still sync resolved themes

Made with [Cursor](https://cursor.com)