### PR TITLE
Add remittanceInformation field to the quotes API

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -18039,6 +18039,11 @@ components:
           type: string
           description: The ID of the transaction created from this quote.
           example: Transaction:019542f5-b3e7-1d02-0000-000000000005
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient, as provided on the quote request. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
         counterpartyInformation:
           $ref: '#/components/schemas/CounterpartyInformation'
           description: Additional information about the counterparty, if available and required by the platform in their configuration.
@@ -18107,6 +18112,11 @@ components:
           type: string
           description: Optional description/memo for the transfer
           example: 'Invoice #1234 payment'
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
         purposeOfPayment:
           $ref: '#/components/schemas/PurposeOfPayment'
         senderCustomerInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18039,6 +18039,11 @@ components:
           type: string
           description: The ID of the transaction created from this quote.
           example: Transaction:019542f5-b3e7-1d02-0000-000000000005
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient, as provided on the quote request. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
         counterpartyInformation:
           $ref: '#/components/schemas/CounterpartyInformation'
           description: Additional information about the counterparty, if available and required by the platform in their configuration.
@@ -18107,6 +18112,11 @@ components:
           type: string
           description: Optional description/memo for the transfer
           example: 'Invoice #1234 payment'
+        remittanceInformation:
+          type: string
+          maxLength: 80
+          description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
+          example: '12345'
         purposeOfPayment:
           $ref: '#/components/schemas/PurposeOfPayment'
         senderCustomerInfo:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -112,6 +112,17 @@ properties:
     type: string
     description: The ID of the transaction created from this quote.
     example: Transaction:019542f5-b3e7-1d02-0000-000000000005
+  remittanceInformation:
+    type: string
+    maxLength: 80
+    description: >-
+      Free-form information about the payment that travels with it to the
+      recipient, as provided on the quote request. The field this populates
+      depends on the payment rail: for ACH it populates the Addenda record, for
+      FedNow and RTP it populates the remittanceInformation field, and for wires
+      it populates the OBI (Originator to Beneficiary Information) / beneficiary
+      information.
+    example: '12345'
   counterpartyInformation:
     $ref: ../transactions/CounterpartyInformation.yaml
     description: >-

--- a/openapi/components/schemas/quotes/QuoteRequest.yaml
+++ b/openapi/components/schemas/quotes/QuoteRequest.yaml
@@ -55,6 +55,16 @@ properties:
     type: string
     description: Optional description/memo for the transfer
     example: 'Invoice #1234 payment'
+  remittanceInformation:
+    type: string
+    maxLength: 80
+    description: >-
+      Free-form information about the payment that travels with it to the
+      recipient. The field this populates depends on the payment rail: for ACH
+      it populates the Addenda record, for FedNow and RTP it populates the
+      remittanceInformation field, and for wires it populates the OBI
+      (Originator to Beneficiary Information) / beneficiary information.
+    example: '12345'
   purposeOfPayment:
     $ref: ./PurposeOfPayment.yaml
   senderCustomerInfo:


### PR DESCRIPTION
## Summary

Adds `remittanceInformation` as a field on the Grid **quotes API** so free-form remittance information can be captured when a quote is created and passed through the quotes flow.

- **`QuoteRequest`** (input) — new optional `remittanceInformation` string. Captures the free-form info that travels with the payment to the recipient.
- **`Quote`** (response) — echoes `remittanceInformation` back so the value provided on the request is visible throughout the quote lifecycle.

The definition mirrors the existing `remittanceInformation` field on the transfer-out API (`TransferOutRequest`): free-form string, `maxLength: 80`, with a rail-specific description — for ACH it populates the Addenda record, for FedNow and RTP the `remittanceInformation` field, and for wires the OBI (Originator to Beneficiary Information) / beneficiary information.

## Changes
- `openapi/components/schemas/quotes/QuoteRequest.yaml` — add `remittanceInformation` property
- `openapi/components/schemas/quotes/Quote.yaml` — add `remittanceInformation` property
- `openapi.yaml` + `mintlify/openapi.yaml` — regenerated bundles (`make build`)

## Test plan
- `make build` — rebundled cleanly
- `make lint-openapi` — passes (`Woohoo! Your API description is valid. 🎉`, exit 0); remaining output is pre-existing info/warning noise on unrelated schemas
- Codex pre-PR review — no findings

## Public
The quotes API now accepts and returns `remittanceInformation`, letting payment reference text be attached at quote time and carried through the flow.

Requested by @shreyav

Slack thread: https://lightsparkgroup.slack.com/archives/D0AH5T8FMGE/p1783639688002849

---
🤖 [humming-aether](https://zeus.dev.dev.sparkinfra.net/#/arc?id=humming-aether)[(#1)](https://zeus.dev.dev.sparkinfra.net/#/instance?id=humming-aether) | [Feedback](https://zeus.dev.dev.sparkinfra.net/feedback)

Original PR: https://github.com/lightsparkdev/grid-api/pull/675