### PR TITLE
Add spendingLimits to delegated key API (per-transaction, per-currency)

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -19215,6 +19215,24 @@ components:
         - `ACTIVE`: The policy is granted and the key may stamp quote executions.
         - `REVOKED`: The delegated user has been deleted and the key can no longer sign.
       example: ACTIVE
+    DelegatedKeySpendingLimit:
+      title: Delegated Key Spending Limit
+      type: object
+      required:
+        - currencyCode
+        - maxPerTransaction
+      properties:
+        currencyCode:
+          type: string
+          pattern: ^[A-Z0-9]{3,16}$
+          description: Uppercase alphanumeric currency code the limit applies to — ISO 4217 for fiat (e.g. USD), or a Grid token code for stablecoins (e.g. USDB). Must match the card's currency; requests with any other currency are rejected.
+          example: USD
+        maxPerTransaction:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Largest amount a single card transaction may authorize, in the smallest unit of the currency (e.g., cents for USD).
+          example: 5000
     DelegatedKey:
       title: Delegated Key
       type: object
@@ -19256,6 +19274,12 @@ components:
           example: Settlement service key
         status:
           $ref: '#/components/schemas/DelegatedKeyStatus'
+        spendingLimits:
+          type: array
+          uniqueItems: true
+          description: Per-transaction spending limits the key was created with, at most one entry per currency. Absent when the key has no limits.
+          items:
+            $ref: '#/components/schemas/DelegatedKeySpendingLimit'
         createdAt:
           type: string
           format: date-time
@@ -19299,6 +19323,12 @@ components:
           maxLength: 256
           description: Human-readable label for the delegated key.
           example: Card payments key
+        spendingLimits:
+          type: array
+          uniqueItems: true
+          description: Optional per-transaction spending limits for the key, at most one entry per currency — a request with duplicate currency entries is rejected. Grid enforces the limits when authorizing card transactions funded by the key's Embedded Wallet account; a currency with no entry is unlimited. Immutable — revoke the key and create a new one to change limits.
+          items:
+            $ref: '#/components/schemas/DelegatedKeySpendingLimit'
     DelegatedKeySignedRequestChallenge:
       title: Delegated Key Signed Request Challenge
       description: 202 response returned from the delegated-key endpoints. Stamp `payloadToSign` with the session API keypair of a verified credential on the delegated key's Embedded Wallet funding account, then retry the same request with the full stamp in `Grid-Wallet-Signature` and the `requestId` echoed in `Request-Id`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19215,6 +19215,24 @@ components:
         - `ACTIVE`: The policy is granted and the key may stamp quote executions.
         - `REVOKED`: The delegated user has been deleted and the key can no longer sign.
       example: ACTIVE
+    DelegatedKeySpendingLimit:
+      title: Delegated Key Spending Limit
+      type: object
+      required:
+        - currencyCode
+        - maxPerTransaction
+      properties:
+        currencyCode:
+          type: string
+          pattern: ^[A-Z0-9]{3,16}$
+          description: Uppercase alphanumeric currency code the limit applies to — ISO 4217 for fiat (e.g. USD), or a Grid token code for stablecoins (e.g. USDB). Must match the card's currency; requests with any other currency are rejected.
+          example: USD
+        maxPerTransaction:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Largest amount a single card transaction may authorize, in the smallest unit of the currency (e.g., cents for USD).
+          example: 5000
     DelegatedKey:
       title: Delegated Key
       type: object
@@ -19256,6 +19274,12 @@ components:
           example: Settlement service key
         status:
           $ref: '#/components/schemas/DelegatedKeyStatus'
+        spendingLimits:
+          type: array
+          uniqueItems: true
+          description: Per-transaction spending limits the key was created with, at most one entry per currency. Absent when the key has no limits.
+          items:
+            $ref: '#/components/schemas/DelegatedKeySpendingLimit'
         createdAt:
           type: string
           format: date-time
@@ -19299,6 +19323,12 @@ components:
           maxLength: 256
           description: Human-readable label for the delegated key.
           example: Card payments key
+        spendingLimits:
+          type: array
+          uniqueItems: true
+          description: Optional per-transaction spending limits for the key, at most one entry per currency — a request with duplicate currency entries is rejected. Grid enforces the limits when authorizing card transactions funded by the key's Embedded Wallet account; a currency with no entry is unlimited. Immutable — revoke the key and create a new one to change limits.
+          items:
+            $ref: '#/components/schemas/DelegatedKeySpendingLimit'
     DelegatedKeySignedRequestChallenge:
       title: Delegated Key Signed Request Challenge
       description: 202 response returned from the delegated-key endpoints. Stamp `payloadToSign` with the session API keypair of a verified credential on the delegated key's Embedded Wallet funding account, then retry the same request with the full stamp in `Grid-Wallet-Signature` and the `requestId` echoed in `Request-Id`.

--- a/openapi/components/schemas/auth/DelegatedKey.yaml
+++ b/openapi/components/schemas/auth/DelegatedKey.yaml
@@ -48,6 +48,14 @@ properties:
     example: Settlement service key
   status:
     $ref: ./DelegatedKeyStatus.yaml
+  spendingLimits:
+    type: array
+    uniqueItems: true
+    description: >-
+      Per-transaction spending limits the key was created with, at most one
+      entry per currency. Absent when the key has no limits.
+    items:
+      $ref: ./DelegatedKeySpendingLimit.yaml
   createdAt:
     type: string
     format: date-time

--- a/openapi/components/schemas/auth/DelegatedKeyCreateRequest.yaml
+++ b/openapi/components/schemas/auth/DelegatedKeyCreateRequest.yaml
@@ -24,3 +24,15 @@ properties:
     maxLength: 256
     description: Human-readable label for the delegated key.
     example: Card payments key
+  spendingLimits:
+    type: array
+    uniqueItems: true
+    description: >-
+      Optional per-transaction spending limits for the key, at most one entry
+      per currency — a request with duplicate currency entries is rejected.
+      Grid enforces the limits when authorizing card transactions funded by
+      the key's Embedded Wallet account; a currency with no entry is
+      unlimited. Immutable — revoke the key and create a new one to change
+      limits.
+    items:
+      $ref: ./DelegatedKeySpendingLimit.yaml

--- a/openapi/components/schemas/auth/DelegatedKeySpendingLimit.yaml
+++ b/openapi/components/schemas/auth/DelegatedKeySpendingLimit.yaml
@@ -1,0 +1,22 @@
+title: Delegated Key Spending Limit
+type: object
+required:
+  - currencyCode
+  - maxPerTransaction
+properties:
+  currencyCode:
+    type: string
+    pattern: '^[A-Z0-9]{3,16}$'
+    description: >-
+      Uppercase alphanumeric currency code the limit applies to — ISO 4217 for
+      fiat (e.g. USD), or a Grid token code for stablecoins (e.g. USDB). Must
+      match the card's currency; requests with any other currency are rejected.
+    example: USD
+  maxPerTransaction:
+    type: integer
+    format: int64
+    minimum: 1
+    description: >-
+      Largest amount a single card transaction may authorize, in the smallest
+      unit of the currency (e.g., cents for USD).
+    example: 5000


### PR DESCRIPTION
## Reason

Grid custodies delegated signing keys for spark-wallet-funded cards. We eventually want a Turnkey policy enforcing per-transaction amount limits (computed from transaction outputs, token-scoped); until that exists, Grid accepts the limits at key creation and enforces them backend-side at card decision time (lightsparkdev/webdev#30157 stack).

## Overview

- New `DelegatedKeySpendingLimit` schema: `currencyCode` (ISO 4217, must match the card's currency) + `maxPerTransaction` (`int64 >= 1`, smallest unit of the currency).
- `DelegatedKeyCreateRequest` gains optional `spendingLimits` — at most one entry per currency, immutable (revoke + recreate to change).
- `DelegatedKey` response echoes `spendingLimits`; absent = unlimited.
- Rebundled `openapi.yaml` / `mintlify/openapi.yaml` via `make build`.

## Test Plan

- `make lint` passes (Redocly valid, no new warnings on these schemas).
- The regenerated Python client from this spec is exercised end-to-end by the webdev handler tests in lightsparkdev/webdev#30159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)