### PR TITLE
Make PaymentSparkWalletInfo.assetType a free-form currency code

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11565,10 +11565,7 @@ components:
           properties:
             assetType:
               type: string
-              description: Type of asset
-              enum:
-                - BTC
-                - USDB
+              description: Type of asset or configured Spark token currency code
             invoice:
               type: string
               description: Invoice for the payment

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11565,10 +11565,7 @@ components:
           properties:
             assetType:
               type: string
-              description: Type of asset
-              enum:
-                - BTC
-                - USDB
+              description: Type of asset or configured Spark token currency code
             invoice:
               type: string
               description: Invoice for the payment

--- a/openapi/components/schemas/common/PaymentSparkWalletInfo.yaml
+++ b/openapi/components/schemas/common/PaymentSparkWalletInfo.yaml
@@ -8,10 +8,7 @@ allOf:
     properties:
       assetType:
         type: string
-        description: Type of asset
-        enum:
-          - BTC
-          - USDB
+        description: Type of asset or configured Spark token currency code
       invoice:
         type: string
         description: Invoice for the payment


### PR DESCRIPTION
## Why

`PaymentSparkWalletInfo.assetType` was a closed enum (`BTC` / `USDB`). Grid now supports arbitrary Spark tokens, so the valid set is per-environment runtime config (the Spark token registry) and can't be expressed as a static schema enum. The generated client already stamps/reads any configured token's currency code here.

This is the missing **source-repo** half of a change whose generated output already merged in webdev: [lightsparkdev/webdev#28745](https://github.com/lightsparkdev/webdev/pull/28745) removed the same `assetType` enum validator + description from the vendored `grid-api/` copy, but the corresponding grid-api source change was never made. This brings the source back in sync so the next webdev `update_schema.sh` sync is a no-op instead of re-adding the enum.

## What Changed

- `openapi/components/schemas/common/PaymentSparkWalletInfo.yaml`: drop `enum: [BTC, USDB]` on `assetType`; description "Type of asset" -> "Type of asset or configured Spark token currency code".
- Rebuilt `openapi.yaml` and `mintlify/openapi.yaml` via `npm run build:openapi` (Redocly bundle). Diff is exactly the three-line change in each file, no reformat churn.

## Validation

- `npm run lint:openapi` — valid, 0 errors (pre-existing warnings/infos only; none touch `PaymentSparkWalletInfo`).
- `mintlify/openapi.yaml` is byte-identical to `openapi.yaml` (as the build enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)