### PR TITLE
feat!: granular counterparty payout failure reasons

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21110,25 +21110,30 @@ components:
       enum:
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-        - LIGHTNING_PAYMENT_FAILED
-        - FUNDING_AMOUNT_MISMATCH
-        - COUNTERPARTY_COMPLIANCE_REJECTED
-        - COUNTERPARTY_ACCOUNT_INVALID
-        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
-        - COUNTERPARTY_LIMIT_EXCEEDED
-        - COUNTERPARTY_PAYOUT_RETURNED
-        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
-        - COUNTERPARTY_PAYOUT_EXPIRED
-        - COUNTERPARTY_POST_TX_FAILED
-        - SCA_NOT_COMPLETED
         - EXECUTION_FAILED_POST_DEBIT
         - SETTLEMENT_FAILED
+        - FUNDING_AMOUNT_MISMATCH
         - TIMEOUT
         - MANUAL_REFUND
+        - SCA_NOT_COMPLETED
+        - LSP_OPERATIONAL_FAILURE
+        - PAYOUT_RETURNED
+        - LIMIT_EXCEEDED
+        - ACCOUNT_CANNOT_RECEIVE
+        - ACCOUNT_INVALID
+        - COMPLIANCE_REJECTED
+        - LIGHTNING_PAYMENT_FAILED
+        - COUNTERPARTY_POST_TX_FAILED
       description: |
         Reason for failure of an outgoing transaction. This is used to provide more
         context on why a transaction failed. If the transaction is not in a failed
         state, this field is omitted.
+
+        When a payout partner rejects or fails a payment, one of the granular payout
+        reasons (`PAYOUT_RETURNED`, `LIMIT_EXCEEDED`, `ACCOUNT_CANNOT_RECEIVE`,
+        `ACCOUNT_INVALID`, `COMPLIANCE_REJECTED`) is returned when available.
+        `COUNTERPARTY_POST_TX_FAILED` is a coarse fallback used only when no granular
+        reason is available.
 
         `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
         Authentication challenge before it expired, so the transaction was never
@@ -21139,22 +21144,21 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
-        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
-        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
-        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
-        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
-        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
-        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
-        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
-        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
         | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
         | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
         | `TIMEOUT` | The transaction did not complete within its processing window |
         | `MANUAL_REFUND` | The transaction was refunded manually |
+        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
+        | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+        | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |
     RailSelectionMode:
       type: string
       enum:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21144,7 +21144,7 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
         | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
         | `SETTLEMENT_FAILED` | The settlement leg failed |
         | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21110,11 +21110,7 @@ components:
       enum:
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-        - EXECUTION_FAILED_POST_DEBIT
-        - SETTLEMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
-        - TIMEOUT
-        - MANUAL_REFUND
         - SCA_NOT_COMPLETED
         - PAYOUT_RETURNED
         - LIMIT_EXCEEDED
@@ -21143,19 +21139,15 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-        | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
-        | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. Covers any internal failure on the way to settlement, whether or not funds were debited — a debited amount is refunded automatically |
         | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-        | `TIMEOUT` | The transaction did not complete within its processing window |
-        | `MANUAL_REFUND` | The transaction was refunded manually |
         | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
         | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
         | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
         | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
         | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
         | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `QUOTE_EXECUTION_FAILED`. The Lightning settlement leg failed |
         | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |
     RailSelectionMode:
       type: string

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21112,16 +21112,49 @@ components:
         - QUOTE_EXECUTION_FAILED
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
+        - COUNTERPARTY_COMPLIANCE_REJECTED
+        - COUNTERPARTY_ACCOUNT_INVALID
+        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+        - COUNTERPARTY_LIMIT_EXCEEDED
+        - COUNTERPARTY_PAYOUT_RETURNED
+        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+        - COUNTERPARTY_PAYOUT_EXPIRED
         - COUNTERPARTY_POST_TX_FAILED
         - SCA_NOT_COMPLETED
         - EXECUTION_FAILED_POST_DEBIT
         - SETTLEMENT_FAILED
         - TIMEOUT
         - MANUAL_REFUND
-      description: |-
-        Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+      description: |
+        Reason for failure of an outgoing transaction. This is used to provide more
+        context on why a transaction failed. If the transaction is not in a failed
+        state, this field is omitted.
 
-        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer Authentication challenge before it expired, so the transaction was never authorized and no funds were moved. Only occurs for customers in a region where SCA is required (e.g. the EU). Create a new quote to try again, and have the customer authorize it while the challenge is live.
+        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
+        Authentication challenge before it expired, so the transaction was never
+        authorized and no funds were moved. Only occurs for customers in a region
+        where SCA is required (e.g. the EU). Create a new quote to try again, and have
+        the customer authorize it while the challenge is live.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
+        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
+        | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `TIMEOUT` | The transaction did not complete within its processing window |
+        | `MANUAL_REFUND` | The transaction was refunded manually |
     RailSelectionMode:
       type: string
       enum:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21116,7 +21116,6 @@ components:
         - TIMEOUT
         - MANUAL_REFUND
         - SCA_NOT_COMPLETED
-        - LSP_OPERATIONAL_FAILURE
         - PAYOUT_RETURNED
         - LIMIT_EXCEEDED
         - ACCOUNT_CANNOT_RECEIVE
@@ -21151,7 +21150,6 @@ components:
         | `TIMEOUT` | The transaction did not complete within its processing window |
         | `MANUAL_REFUND` | The transaction was refunded manually |
         | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
-        | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
         | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
         | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
         | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -442,7 +442,6 @@ Use for reconciliation and reporting.
 | `FUNDING_AMOUNT_MISMATCH` | Funding amount doesn't match expected amount | Verify amounts and retry |
 | `TIMEOUT` | Transaction didn't complete within its processing window | Retry with a new quote |
 | `MANUAL_REFUND` | Transaction was refunded manually | Contact support |
-| `LSP_OPERATIONAL_FAILURE` | Lightspark-internal operational issue | Contact Lightspark |
 | `PAYOUT_RETURNED` | Receiving bank returned or reversed the payout | Verify details and retry |
 | `LIMIT_EXCEEDED` | Payout exceeds a partner limit | Reduce amount or contact support |
 | `ACCOUNT_CANNOT_RECEIVE` | Recipient account can't accept the payment | Use a different account |

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -436,12 +436,8 @@ Use for reconciliation and reporting.
 | Failure Reason | Description | Recovery |
 |----------------|-------------|----------|
 | `QUOTE_EXPIRED` | Quote expired before execution | Create new quote |
-| `QUOTE_EXECUTION_FAILED` | Error executing the quote | Create new quote |
-| `EXECUTION_FAILED_POST_DEBIT` | Execution failed after debit; funds are refunded automatically | Retry with a new quote |
-| `SETTLEMENT_FAILED` | The settlement leg failed | Retry or use alternative rail |
+| `QUOTE_EXECUTION_FAILED` | Error executing the quote; a debited amount is refunded automatically | Create new quote |
 | `FUNDING_AMOUNT_MISMATCH` | Funding amount doesn't match expected amount | Verify amounts and retry |
-| `TIMEOUT` | Transaction didn't complete within its processing window | Retry with a new quote |
-| `MANUAL_REFUND` | Transaction was refunded manually | Contact support |
 | `PAYOUT_RETURNED` | Receiving bank returned or reversed the payout | Verify details and retry |
 | `LIMIT_EXCEEDED` | Payout exceeds a partner limit | Reduce amount or contact support |
 | `ACCOUNT_CANNOT_RECEIVE` | Recipient account can't accept the payment | Use a different account |

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -436,11 +436,19 @@ Use for reconciliation and reporting.
 | Failure Reason | Description | Recovery |
 |----------------|-------------|----------|
 | `QUOTE_EXPIRED` | Quote expired before execution | Create new quote |
-| `QUOTE_EXECUTION_FAILED` | Error executing the quote | Create new quote |
+| `QUOTE_EXECUTION_FAILED` | Error executing the quote; no funds were debited | Create new quote |
+| `EXECUTION_FAILED_POST_DEBIT` | Execution failed after debit; funds are refunded automatically | Retry with a new quote |
 | `INSUFFICIENT_BALANCE` | Source account lacks funds | Fund account, retry |
-| `LIGHTNING_PAYMENT_FAILED` | Lightning network payment could not be routed | Retry or use alternative rail |
+| `SETTLEMENT_FAILED` | The settlement leg failed | Retry or use alternative rail |
 | `FUNDING_AMOUNT_MISMATCH` | Funding amount doesn't match expected amount | Verify amounts and retry |
-| `COUNTERPARTY_POST_TX_FAILED` | Post-transaction processing at counterparty failed | Contact support |
+| `ACCOUNT_INVALID` | Recipient account details are wrong or not found | Correct recipient details |
+| `ACCOUNT_CANNOT_RECEIVE` | Recipient account can't accept the payment | Use a different account |
+| `LIMIT_EXCEEDED` | Payout exceeds a partner limit | Reduce amount or contact support |
+| `COMPLIANCE_REJECTED` | Payout partner rejected on compliance grounds | Contact support |
+| `PAYOUT_RETURNED` | Receiving bank returned or reversed the payout | Verify details and retry |
+| `LSP_OPERATIONAL_FAILURE` | Lightspark-internal operational issue | Contact Lightspark |
+
+The `failureReason` field on a transaction may return additional values, including deprecated reasons (`LIGHTNING_PAYMENT_FAILED`, `COUNTERPARTY_POST_TX_FAILED`) retained for historical transactions.
 
 When a transaction fails, a refund is initiated automatically. Track the refund via the `refund` object on the transaction and `OUTGOING_PAYMENT.REFUND_*` webhook events. See [Refund Object](#refund-object) above.
 

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -436,7 +436,7 @@ Use for reconciliation and reporting.
 | Failure Reason | Description | Recovery |
 |----------------|-------------|----------|
 | `QUOTE_EXPIRED` | Quote expired before execution | Create new quote |
-| `QUOTE_EXECUTION_FAILED` | Error executing the quote; no funds were debited | Create new quote |
+| `QUOTE_EXECUTION_FAILED` | Error executing the quote | Create new quote |
 | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after debit; funds are refunded automatically | Retry with a new quote |
 | `SETTLEMENT_FAILED` | The settlement leg failed | Retry or use alternative rail |
 | `FUNDING_AMOUNT_MISMATCH` | Funding amount doesn't match expected amount | Verify amounts and retry |

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -252,7 +252,7 @@ Outgoing payment webhooks use the format `OUTGOING_PAYMENT.<STATUS>`. The webhoo
   "data": {
     "id": "Transaction:...",
     "status": "FAILED",
-    "failureReason": "INVALID_BANK_ACCOUNT"
+    "failureReason": "ACCOUNT_INVALID"
   }
 }
 ```
@@ -438,15 +438,16 @@ Use for reconciliation and reporting.
 | `QUOTE_EXPIRED` | Quote expired before execution | Create new quote |
 | `QUOTE_EXECUTION_FAILED` | Error executing the quote; no funds were debited | Create new quote |
 | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after debit; funds are refunded automatically | Retry with a new quote |
-| `INSUFFICIENT_BALANCE` | Source account lacks funds | Fund account, retry |
 | `SETTLEMENT_FAILED` | The settlement leg failed | Retry or use alternative rail |
 | `FUNDING_AMOUNT_MISMATCH` | Funding amount doesn't match expected amount | Verify amounts and retry |
-| `ACCOUNT_INVALID` | Recipient account details are wrong or not found | Correct recipient details |
-| `ACCOUNT_CANNOT_RECEIVE` | Recipient account can't accept the payment | Use a different account |
-| `LIMIT_EXCEEDED` | Payout exceeds a partner limit | Reduce amount or contact support |
-| `COMPLIANCE_REJECTED` | Payout partner rejected on compliance grounds | Contact support |
-| `PAYOUT_RETURNED` | Receiving bank returned or reversed the payout | Verify details and retry |
+| `TIMEOUT` | Transaction didn't complete within its processing window | Retry with a new quote |
+| `MANUAL_REFUND` | Transaction was refunded manually | Contact support |
 | `LSP_OPERATIONAL_FAILURE` | Lightspark-internal operational issue | Contact Lightspark |
+| `PAYOUT_RETURNED` | Receiving bank returned or reversed the payout | Verify details and retry |
+| `LIMIT_EXCEEDED` | Payout exceeds a partner limit | Reduce amount or contact support |
+| `ACCOUNT_CANNOT_RECEIVE` | Recipient account can't accept the payment | Use a different account |
+| `ACCOUNT_INVALID` | Recipient account details are wrong or not found | Correct recipient details |
+| `COMPLIANCE_REJECTED` | Payout partner rejected on compliance grounds | Contact support |
 
 The `failureReason` field on a transaction may return additional values, including deprecated reasons (`LIGHTNING_PAYMENT_FAILED`, `COUNTERPARTY_POST_TX_FAILED`) retained for historical transactions.
 

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -146,13 +146,16 @@ When a transaction fails, the `failureReason` field provides specific details:
 - `QUOTE_EXPIRED` - Quote expired before execution
 - `QUOTE_EXECUTION_FAILED` - Error executing the quote; no funds were debited
 - `EXECUTION_FAILED_POST_DEBIT` - Execution failed after debit; funds are refunded automatically
+- `SETTLEMENT_FAILED` - The settlement leg failed
 - `FUNDING_AMOUNT_MISMATCH` - Funding amount doesn't match expected amount
-- `ACCOUNT_INVALID` - Recipient account details are wrong or not found
-- `ACCOUNT_CANNOT_RECEIVE` - Recipient account can't accept the payment
-- `LIMIT_EXCEEDED` - Payout exceeds a partner limit
-- `COMPLIANCE_REJECTED` - Payout partner rejected on compliance grounds
-- `PAYOUT_RETURNED` - Receiving bank returned or reversed the payout
+- `TIMEOUT` - Transaction didn't complete within its processing window
+- `MANUAL_REFUND` - Transaction was refunded manually
 - `LSP_OPERATIONAL_FAILURE` - Lightspark-internal operational issue; contact Lightspark
+- `PAYOUT_RETURNED` - Receiving bank returned or reversed the payout
+- `LIMIT_EXCEEDED` - Payout exceeds a partner limit
+- `ACCOUNT_CANNOT_RECEIVE` - Recipient account can't accept the payment
+- `ACCOUNT_INVALID` - Recipient account details are wrong or not found
+- `COMPLIANCE_REJECTED` - Payout partner rejected on compliance grounds
 
 ### Incoming payment failures
 

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -144,7 +144,7 @@ When a transaction fails, the `failureReason` field provides specific details:
 **Common outgoing failure reasons:**
 
 - `QUOTE_EXPIRED` - Quote expired before execution
-- `QUOTE_EXECUTION_FAILED` - Error executing the quote; no funds were debited
+- `QUOTE_EXECUTION_FAILED` - Error executing the quote
 - `EXECUTION_FAILED_POST_DEBIT` - Execution failed after debit; funds are refunded automatically
 - `SETTLEMENT_FAILED` - The settlement leg failed
 - `FUNDING_AMOUNT_MISMATCH` - Funding amount doesn't match expected amount

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -144,12 +144,8 @@ When a transaction fails, the `failureReason` field provides specific details:
 **Common outgoing failure reasons:**
 
 - `QUOTE_EXPIRED` - Quote expired before execution
-- `QUOTE_EXECUTION_FAILED` - Error executing the quote
-- `EXECUTION_FAILED_POST_DEBIT` - Execution failed after debit; funds are refunded automatically
-- `SETTLEMENT_FAILED` - The settlement leg failed
+- `QUOTE_EXECUTION_FAILED` - Error executing the quote; a debited amount is refunded automatically
 - `FUNDING_AMOUNT_MISMATCH` - Funding amount doesn't match expected amount
-- `TIMEOUT` - Transaction didn't complete within its processing window
-- `MANUAL_REFUND` - Transaction was refunded manually
 - `PAYOUT_RETURNED` - Receiving bank returned or reversed the payout
 - `LIMIT_EXCEEDED` - Payout exceeds a partner limit
 - `ACCOUNT_CANNOT_RECEIVE` - Recipient account can't accept the payment

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -150,7 +150,6 @@ When a transaction fails, the `failureReason` field provides specific details:
 - `FUNDING_AMOUNT_MISMATCH` - Funding amount doesn't match expected amount
 - `TIMEOUT` - Transaction didn't complete within its processing window
 - `MANUAL_REFUND` - Transaction was refunded manually
-- `LSP_OPERATIONAL_FAILURE` - Lightspark-internal operational issue; contact Lightspark
 - `PAYOUT_RETURNED` - Receiving bank returned or reversed the payout
 - `LIMIT_EXCEEDED` - Payout exceeds a partner limit
 - `ACCOUNT_CANNOT_RECEIVE` - Recipient account can't accept the payment

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -144,8 +144,15 @@ When a transaction fails, the `failureReason` field provides specific details:
 **Common outgoing failure reasons:**
 
 - `QUOTE_EXPIRED` - Quote expired before execution
-- `QUOTE_EXECUTION_FAILED` - Error executing the quote
+- `QUOTE_EXECUTION_FAILED` - Error executing the quote; no funds were debited
+- `EXECUTION_FAILED_POST_DEBIT` - Execution failed after debit; funds are refunded automatically
 - `FUNDING_AMOUNT_MISMATCH` - Funding amount doesn't match expected amount
+- `ACCOUNT_INVALID` - Recipient account details are wrong or not found
+- `ACCOUNT_CANNOT_RECEIVE` - Recipient account can't accept the payment
+- `LIMIT_EXCEEDED` - Payout exceeds a partner limit
+- `COMPLIANCE_REJECTED` - Payout partner rejected on compliance grounds
+- `PAYOUT_RETURNED` - Receiving bank returned or reversed the payout
+- `LSP_OPERATIONAL_FAILURE` - Lightspark-internal operational issue; contact Lightspark
 
 ### Incoming payment failures
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21110,25 +21110,30 @@ components:
       enum:
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-        - LIGHTNING_PAYMENT_FAILED
-        - FUNDING_AMOUNT_MISMATCH
-        - COUNTERPARTY_COMPLIANCE_REJECTED
-        - COUNTERPARTY_ACCOUNT_INVALID
-        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
-        - COUNTERPARTY_LIMIT_EXCEEDED
-        - COUNTERPARTY_PAYOUT_RETURNED
-        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
-        - COUNTERPARTY_PAYOUT_EXPIRED
-        - COUNTERPARTY_POST_TX_FAILED
-        - SCA_NOT_COMPLETED
         - EXECUTION_FAILED_POST_DEBIT
         - SETTLEMENT_FAILED
+        - FUNDING_AMOUNT_MISMATCH
         - TIMEOUT
         - MANUAL_REFUND
+        - SCA_NOT_COMPLETED
+        - LSP_OPERATIONAL_FAILURE
+        - PAYOUT_RETURNED
+        - LIMIT_EXCEEDED
+        - ACCOUNT_CANNOT_RECEIVE
+        - ACCOUNT_INVALID
+        - COMPLIANCE_REJECTED
+        - LIGHTNING_PAYMENT_FAILED
+        - COUNTERPARTY_POST_TX_FAILED
       description: |
         Reason for failure of an outgoing transaction. This is used to provide more
         context on why a transaction failed. If the transaction is not in a failed
         state, this field is omitted.
+
+        When a payout partner rejects or fails a payment, one of the granular payout
+        reasons (`PAYOUT_RETURNED`, `LIMIT_EXCEEDED`, `ACCOUNT_CANNOT_RECEIVE`,
+        `ACCOUNT_INVALID`, `COMPLIANCE_REJECTED`) is returned when available.
+        `COUNTERPARTY_POST_TX_FAILED` is a coarse fallback used only when no granular
+        reason is available.
 
         `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
         Authentication challenge before it expired, so the transaction was never
@@ -21139,22 +21144,21 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
-        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
-        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
-        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
-        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
-        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
-        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
-        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
-        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
         | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
         | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
         | `TIMEOUT` | The transaction did not complete within its processing window |
         | `MANUAL_REFUND` | The transaction was refunded manually |
+        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
+        | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+        | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |
     RailSelectionMode:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21144,7 +21144,7 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
         | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
         | `SETTLEMENT_FAILED` | The settlement leg failed |
         | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21110,11 +21110,7 @@ components:
       enum:
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-        - EXECUTION_FAILED_POST_DEBIT
-        - SETTLEMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
-        - TIMEOUT
-        - MANUAL_REFUND
         - SCA_NOT_COMPLETED
         - PAYOUT_RETURNED
         - LIMIT_EXCEEDED
@@ -21143,19 +21139,15 @@ components:
         | Reason | Description |
         |--------|-------------|
         | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-        | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
-        | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. Covers any internal failure on the way to settlement, whether or not funds were debited — a debited amount is refunded automatically |
         | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-        | `TIMEOUT` | The transaction did not complete within its processing window |
-        | `MANUAL_REFUND` | The transaction was refunded manually |
         | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
         | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
         | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
         | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
         | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
         | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+        | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `QUOTE_EXECUTION_FAILED`. The Lightning settlement leg failed |
         | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |
     RailSelectionMode:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21112,16 +21112,49 @@ components:
         - QUOTE_EXECUTION_FAILED
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
+        - COUNTERPARTY_COMPLIANCE_REJECTED
+        - COUNTERPARTY_ACCOUNT_INVALID
+        - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+        - COUNTERPARTY_LIMIT_EXCEEDED
+        - COUNTERPARTY_PAYOUT_RETURNED
+        - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+        - COUNTERPARTY_PAYOUT_EXPIRED
         - COUNTERPARTY_POST_TX_FAILED
         - SCA_NOT_COMPLETED
         - EXECUTION_FAILED_POST_DEBIT
         - SETTLEMENT_FAILED
         - TIMEOUT
         - MANUAL_REFUND
-      description: |-
-        Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+      description: |
+        Reason for failure of an outgoing transaction. This is used to provide more
+        context on why a transaction failed. If the transaction is not in a failed
+        state, this field is omitted.
 
-        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer Authentication challenge before it expired, so the transaction was never authorized and no funds were moved. Only occurs for customers in a region where SCA is required (e.g. the EU). Create a new quote to try again, and have the customer authorize it while the challenge is live.
+        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
+        Authentication challenge before it expired, so the transaction was never
+        authorized and no funds were moved. Only occurs for customers in a region
+        where SCA is required (e.g. the EU). Create a new quote to try again, and have
+        the customer authorize it while the challenge is live.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+        | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+        | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+        | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+        | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+        | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+        | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+        | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+        | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+        | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+        | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+        | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
+        | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+        | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
+        | `SETTLEMENT_FAILED` | The settlement leg failed |
+        | `TIMEOUT` | The transaction did not complete within its processing window |
+        | `MANUAL_REFUND` | The transaction was refunded manually |
     RailSelectionMode:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21116,7 +21116,6 @@ components:
         - TIMEOUT
         - MANUAL_REFUND
         - SCA_NOT_COMPLETED
-        - LSP_OPERATIONAL_FAILURE
         - PAYOUT_RETURNED
         - LIMIT_EXCEEDED
         - ACCOUNT_CANNOT_RECEIVE
@@ -21151,7 +21150,6 @@ components:
         | `TIMEOUT` | The transaction did not complete within its processing window |
         | `MANUAL_REFUND` | The transaction was refunded manually |
         | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
-        | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
         | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
         | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
         | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -2,25 +2,30 @@ type: string
 enum:
   - QUOTE_EXPIRED
   - QUOTE_EXECUTION_FAILED
-  - LIGHTNING_PAYMENT_FAILED
-  - FUNDING_AMOUNT_MISMATCH
-  - COUNTERPARTY_COMPLIANCE_REJECTED
-  - COUNTERPARTY_ACCOUNT_INVALID
-  - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
-  - COUNTERPARTY_LIMIT_EXCEEDED
-  - COUNTERPARTY_PAYOUT_RETURNED
-  - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
-  - COUNTERPARTY_PAYOUT_EXPIRED
-  - COUNTERPARTY_POST_TX_FAILED
-  - SCA_NOT_COMPLETED
   - EXECUTION_FAILED_POST_DEBIT
   - SETTLEMENT_FAILED
+  - FUNDING_AMOUNT_MISMATCH
   - TIMEOUT
   - MANUAL_REFUND
+  - SCA_NOT_COMPLETED
+  - LSP_OPERATIONAL_FAILURE
+  - PAYOUT_RETURNED
+  - LIMIT_EXCEEDED
+  - ACCOUNT_CANNOT_RECEIVE
+  - ACCOUNT_INVALID
+  - COMPLIANCE_REJECTED
+  - LIGHTNING_PAYMENT_FAILED
+  - COUNTERPARTY_POST_TX_FAILED
 description: |
   Reason for failure of an outgoing transaction. This is used to provide more
   context on why a transaction failed. If the transaction is not in a failed
   state, this field is omitted.
+
+  When a payout partner rejects or fails a payment, one of the granular payout
+  reasons (`PAYOUT_RETURNED`, `LIMIT_EXCEEDED`, `ACCOUNT_CANNOT_RECEIVE`,
+  `ACCOUNT_INVALID`, `COMPLIANCE_REJECTED`) is returned when available.
+  `COUNTERPARTY_POST_TX_FAILED` is a coarse fallback used only when no granular
+  reason is available.
 
   `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
   Authentication challenge before it expired, so the transaction was never
@@ -31,19 +36,18 @@ description: |
   | Reason | Description |
   |--------|-------------|
   | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-  | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
-  | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-  | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-  | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
-  | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
-  | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
-  | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
-  | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
-  | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
-  | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
-  | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
   | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
   | `SETTLEMENT_FAILED` | The settlement leg failed |
+  | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
   | `TIMEOUT` | The transaction did not complete within its processing window |
   | `MANUAL_REFUND` | The transaction was refunded manually |
+  | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+  | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
+  | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+  | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+  | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+  | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+  | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+  | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+  | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -2,11 +2,7 @@ type: string
 enum:
   - QUOTE_EXPIRED
   - QUOTE_EXECUTION_FAILED
-  - EXECUTION_FAILED_POST_DEBIT
-  - SETTLEMENT_FAILED
   - FUNDING_AMOUNT_MISMATCH
-  - TIMEOUT
-  - MANUAL_REFUND
   - SCA_NOT_COMPLETED
   - PAYOUT_RETURNED
   - LIMIT_EXCEEDED
@@ -35,17 +31,13 @@ description: |
   | Reason | Description |
   |--------|-------------|
   | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
-  | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
-  | `SETTLEMENT_FAILED` | The settlement leg failed |
+  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. Covers any internal failure on the way to settlement, whether or not funds were debited — a debited amount is refunded automatically |
   | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
-  | `TIMEOUT` | The transaction did not complete within its processing window |
-  | `MANUAL_REFUND` | The transaction was refunded manually |
   | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
   | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
   | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
   | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
   | `ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
   | `COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
-  | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `SETTLEMENT_FAILED`. The Lightning settlement leg failed |
+  | `LIGHTNING_PAYMENT_FAILED` | Deprecated — superseded by `QUOTE_EXECUTION_FAILED`. The Lightning settlement leg failed |
   | `COUNTERPARTY_POST_TX_FAILED` | Deprecated — coarse fallback retained for historical transactions when no granular payout reason is available |

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -8,7 +8,6 @@ enum:
   - TIMEOUT
   - MANUAL_REFUND
   - SCA_NOT_COMPLETED
-  - LSP_OPERATIONAL_FAILURE
   - PAYOUT_RETURNED
   - LIMIT_EXCEEDED
   - ACCOUNT_CANNOT_RECEIVE
@@ -43,7 +42,6 @@ description: |
   | `TIMEOUT` | The transaction did not complete within its processing window |
   | `MANUAL_REFUND` | The transaction was refunded manually |
   | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
-  | `LSP_OPERATIONAL_FAILURE` | A Lightspark-internal operational issue (for example, insufficient operational balance). Not a client error — contact Lightspark to resolve |
   | `PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
   | `LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
   | `ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -36,7 +36,7 @@ description: |
   | Reason | Description |
   |--------|-------------|
   | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
-  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed. No funds were debited |
+  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
   | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
   | `SETTLEMENT_FAILED` | The settlement leg failed |
   | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -4,20 +4,46 @@ enum:
   - QUOTE_EXECUTION_FAILED
   - LIGHTNING_PAYMENT_FAILED
   - FUNDING_AMOUNT_MISMATCH
+  - COUNTERPARTY_COMPLIANCE_REJECTED
+  - COUNTERPARTY_ACCOUNT_INVALID
+  - COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE
+  - COUNTERPARTY_LIMIT_EXCEEDED
+  - COUNTERPARTY_PAYOUT_RETURNED
+  - COUNTERPARTY_CURRENCY_EXCHANGE_FAILED
+  - COUNTERPARTY_PAYOUT_EXPIRED
   - COUNTERPARTY_POST_TX_FAILED
   - SCA_NOT_COMPLETED
   - EXECUTION_FAILED_POST_DEBIT
   - SETTLEMENT_FAILED
   - TIMEOUT
   - MANUAL_REFUND
-description: >-
+description: |
   Reason for failure of an outgoing transaction. This is used to provide more
   context on why a transaction failed. If the transaction is not in a failed
   state, this field is omitted.
-
 
   `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
   Authentication challenge before it expired, so the transaction was never
   authorized and no funds were moved. Only occurs for customers in a region
   where SCA is required (e.g. the EU). Create a new quote to try again, and have
   the customer authorize it while the challenge is live.
+
+  | Reason | Description |
+  |--------|-------------|
+  | `QUOTE_EXPIRED` | The quote was not executed before its expiry window |
+  | `QUOTE_EXECUTION_FAILED` | The quote could not be executed |
+  | `LIGHTNING_PAYMENT_FAILED` | The Lightning settlement leg failed |
+  | `FUNDING_AMOUNT_MISMATCH` | The funds received did not match the expected amount |
+  | `COUNTERPARTY_COMPLIANCE_REJECTED` | The payout partner rejected the recipient on compliance grounds — sanctions, watchlist, or KYC/AML screening |
+  | `COUNTERPARTY_ACCOUNT_INVALID` | The recipient account couldn't be found or the details are wrong — bad IBAN/account number, beneficiary not found, or account closed |
+  | `COUNTERPARTY_ACCOUNT_CANNOT_RECEIVE` | The account exists but can't accept this payment — dormant, frozen, restricted, or the currency isn't supported for that account |
+  | `COUNTERPARTY_LIMIT_EXCEEDED` | The payout exceeds a recipient-, account-, or corridor-level limit at the partner |
+  | `COUNTERPARTY_PAYOUT_RETURNED` | The receiving bank accepted the payout and then returned or reversed it |
+  | `COUNTERPARTY_CURRENCY_EXCHANGE_FAILED` | The partner couldn't complete the FX conversion required for the payout |
+  | `COUNTERPARTY_PAYOUT_EXPIRED` | The partner didn't complete the payout within its processing window |
+  | `COUNTERPARTY_POST_TX_FAILED` | Generic payout failure — the partner gave no usable reason |
+  | `SCA_NOT_COMPLETED` | The customer did not complete the Strong Customer Authentication challenge before it expired |
+  | `EXECUTION_FAILED_POST_DEBIT` | Execution failed after funds were debited. The amount is refunded automatically |
+  | `SETTLEMENT_FAILED` | The settlement leg failed |
+  | `TIMEOUT` | The transaction did not complete within its processing window |
+  | `MANUAL_REFUND` | The transaction was refunded manually |


### PR DESCRIPTION
## Summary

Reworks `OutgoingTransactionFailureReason` so every value is an outcome an integrator acts on, and syncs the docs to match.

**Added** — granular payout failures, set at the payout-partner boundary:
- `PAYOUT_RETURNED` — receiving bank accepted then returned/reversed the payout
- `LIMIT_EXCEEDED` — payout exceeds a recipient-, account-, or corridor-level limit
- `ACCOUNT_CANNOT_RECEIVE` — account exists but can't accept the payment (dormant/frozen/restricted/unsupported currency)
- `ACCOUNT_INVALID` — recipient account not found or details wrong
- `COMPLIANCE_REJECTED` — rejected on compliance grounds (sanctions/watchlist/KYC-AML)

**Removed** — the four values #629 added. Each names an internal step of how a payment is processed rather than something an integrator handles differently:
- `EXECUTION_FAILED_POST_DEBIT` and `SETTLEMENT_FAILED` say where on the way to settlement the failure happened. Both collapse into `QUOTE_EXECUTION_FAILED`, whose description now covers that whole path and states that a debited amount is refunded automatically.
- `TIMEOUT` and `MANUAL_REFUND` describe operator-initiated refunds. That outcome already surfaces on the refund object, whose `reason` enum carries `TIMEOUT` and `USER_CANCELLATION`.

`LSP_OPERATIONAL_FAILURE` was on this branch earlier and is removed for the same reason: an operational failure on the provider side reaches integrators as `QUOTE_EXECUTION_FAILED`, the same outcome to act on.

**Deprecated** in the description, still returned: `LIGHTNING_PAYMENT_FAILED` (superseded by `QUOTE_EXECUTION_FAILED`) and `COUNTERPARTY_POST_TX_FAILED` (coarse fallback for historical rows). `SCA_NOT_COMPLETED` (#762) is untouched — a customer letting an SCA challenge expire is a distinct, actionable outcome.

Final enum: `QUOTE_EXPIRED`, `QUOTE_EXECUTION_FAILED`, `FUNDING_AMOUNT_MISMATCH`, `SCA_NOT_COMPLETED`, `PAYOUT_RETURNED`, `LIMIT_EXCEEDED`, `ACCOUNT_CANNOT_RECEIVE`, `ACCOUNT_INVALID`, `COMPLIANCE_REJECTED`, `LIGHTNING_PAYMENT_FAILED`, `COUNTERPARTY_POST_TX_FAILED`.

## Breaking change

Removing four values is flagged by oasdiff as `request-property-enum-value-removed` (ERR), because `failureReason` also appears in the `webhook:outgoing-payment` and `webhook:agent-action` bodies. The PR carries the `breaking-change` label and needs API-reviewer approval.

The server-side mapping for the removed values has to be updated before clients are regenerated, or `failureReason` renders empty — the regression #629 was fixing.

## Changes

- **OpenAPI** (`OutgoingTransactionFailureReason.yaml` + bundle): the enum above, with per-value descriptions and deprecation notes.
- **Docs**: synced the failure-reasons table in `transaction-lifecycle.mdx` and the list in the `error-handling.mdx` snippet to the enum — dropped the non-existent `INSUFFICIENT_BALANCE`, reordered to enum order, and fixed a `FAILED` webhook example to use `ACCOUNT_INVALID`.

Rebased onto main, which added #629's values and #762's `SCA_NOT_COMPLETED`.

## Test plan

- `make build` — bundles cleanly; clean rebuild produces no diff
- `make lint-openapi` — 0 errors (redocly + spectral)