### PR TITLE
docs: sync Coming Soon country coverage (add China)

### DIFF
--- a/mintlify/snippets/country-support.mdx
+++ b/mintlify/snippets/country-support.mdx
@@ -104,5 +104,6 @@ Grid is rapidly expanding. These corridors are next on our roadmap — get in to
 | Country | ISO Code |
 |---|---|
 | 🇨🇦 Canada | CA |
+| 🇨🇳 China | CN |
 | 🇭🇰 Hong Kong | HK |
 | 🇰🇷 South Korea | KR |


### PR DESCRIPTION
## Summary

Syncs `mintlify/snippets/country-support.mdx` against the [Grid Switch Corridor List](https://docs.google.com/spreadsheets/d/1rxdmPeFcuy8gis59tjYa96jF5g1JgVg1V6fO6pGpmoU/edit?gid=1624735184#gid=1624735184) source of truth.

The only drift is in the **Coming Soon** table. Applying the filter *Public Roadmap (col H) = Yes AND Status (col J) ≠ Live* resolves to **Canada, China, Hong Kong, South Korea**. China (row 87 — Tazapay / Scoping / Public Roadmap = Yes) was missing, so it's added.

## Changes

- Add 🇨🇳 China (CN) to the Coming Soon table, alphabetically after Canada.

## Verified already in sync (no change needed)

- **Live table** — 62 destinations; the doc's ISO set matches the sheet's `Status = Live` set exactly.
- **Header FeatureCards** and "Send payments to 62 countries" copy — unchanged (Live count is still 62).
- **Regional Summary** — Europe 32 / Middle East and Africa 15 / Asia-Pacific 10 / Americas 5 = 62.

Only `mintlify/snippets/country-support.mdx` is touched, so no OpenAPI rebundle is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ymXyjUvzaDPSTS9Rqfrh)_