### PR TITLE
feat(cli): add customer contact-verification commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -115,8 +115,14 @@ grid customers kyc-link \
   --customer-id <id> \
   --redirect-url https://example.com/kyc-complete
 
-# Update customer
-grid customers update <customerId> --full-name "Jane Doe"
+# Update customer (--type is the required discriminator)
+grid customers update <customerId> --type INDIVIDUAL --full-name "Jane Doe"
+
+# Contact verification (only required in some regulatory jurisdictions)
+grid customers verify-email <customerId>
+grid customers confirm-email <customerId> --code 123456
+grid customers verify-phone <customerId>
+grid customers confirm-phone <customerId> --code 123456
 
 # Delete customer (prompts for confirmation)
 grid customers delete <customerId>

--- a/cli/src/commands/customers.ts
+++ b/cli/src/commands/customers.ts
@@ -419,4 +419,64 @@ export function registerCustomersCommand(
       );
       outputResponse(response);
     });
+
+  customersCmd
+    .command("verify-email <customerId>")
+    .description("Send an email verification code to a customer")
+    .action(async (customerId: string) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.post<void>(
+        `/customers/${customerId}/verify-email`
+      );
+      outputResponse(response);
+    });
+
+  customersCmd
+    .command("confirm-email <customerId>")
+    .description("Confirm a customer's email verification code")
+    .requiredOption("--code <code>", "The verification code the customer received")
+    .action(async (customerId: string, options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.post<Customer>(
+        `/customers/${customerId}/verify-email/confirm`,
+        { code: options.code }
+      );
+      outputResponse(response);
+    });
+
+  customersCmd
+    .command("verify-phone <customerId>")
+    .description("Send a phone verification code to a customer")
+    .action(async (customerId: string) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.post<void>(
+        `/customers/${customerId}/verify-phone`
+      );
+      outputResponse(response);
+    });
+
+  customersCmd
+    .command("confirm-phone <customerId>")
+    .description("Confirm a customer's phone verification code")
+    .requiredOption("--code <code>", "The verification code the customer received")
+    .action(async (customerId: string, options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.post<Customer>(
+        `/customers/${customerId}/verify-phone/confirm`,
+        { code: options.code }
+      );
+      outputResponse(response);
+    });
 }

--- a/cli/test/customers-verification.test.ts
+++ b/cli/test/customers-verification.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { runCli } from "./helpers";
+
+describe("customers verify-email", () => {
+  it("posts to the verify-email endpoint", async () => {
+    const { request } = await runCli(["customers", "verify-email", "cust_1"]);
+
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/customers/cust_1/verify-email");
+  });
+});
+
+describe("customers confirm-email", () => {
+  it("posts the code to the verify-email/confirm endpoint", async () => {
+    const { request } = await runCli([
+      "customers",
+      "confirm-email",
+      "cust_1",
+      "--code",
+      "123456",
+    ]);
+
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/customers/cust_1/verify-email/confirm");
+    expect(request?.body).toMatchObject({ code: "123456" });
+  });
+});
+
+describe("customers verify-phone", () => {
+  it("posts to the verify-phone endpoint", async () => {
+    const { request } = await runCli(["customers", "verify-phone", "cust_1"]);
+
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/customers/cust_1/verify-phone");
+  });
+});
+
+describe("customers confirm-phone", () => {
+  it("posts the code to the verify-phone/confirm endpoint", async () => {
+    const { request } = await runCli([
+      "customers",
+      "confirm-phone",
+      "cust_1",
+      "--code",
+      "654321",
+    ]);
+
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/customers/cust_1/verify-phone/confirm");
+    expect(request?.body).toMatchObject({ code: "654321" });
+  });
+});


### PR DESCRIPTION
## Summary

Adds customer **contact-verification** commands to the Grid CLI — the email/phone verification flow required in some regulatory jurisdictions (e.g. EU). Stacked on the CLI drift-fix PR.

New commands:

- `grid customers verify-email <customerId>` — `POST /customers/{id}/verify-email`
- `grid customers confirm-email <customerId> --code <code>` — `POST /customers/{id}/verify-email/confirm`
- `grid customers verify-phone <customerId>` — `POST /customers/{id}/verify-phone`
- `grid customers confirm-phone <customerId> --code <code>` — `POST /customers/{id}/verify-phone/confirm`

## Test plan

- `cd cli && npm run build` — clean compile.
- `npm test` — includes 4 new boundary tests asserting each command's method/path/body (34 tests total with the parent branch).

Original PR: https://github.com/lightsparkdev/grid-api/pull/703