### PR TITLE
feat(cli): add exchange-rates, crypto, discoveries, uma-providers, tokens, and internal-account update/export

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -389,6 +389,44 @@ grid sandbox receive \
   --currency USD
 ```
 
+### Exchange Rates & Lookups
+
+```bash
+# Exchange rates (--destination-currency is repeatable)
+grid exchange-rates --source-currency USD --destination-currency EUR --destination-currency MXN
+
+# Estimate a crypto withdrawal fee
+grid crypto estimate-fee \
+  --internal-account-id <id> --currency USDC --crypto-network SOLANA \
+  --amount 5000 --destination-address <address>
+
+# Discover receiving institutions
+grid discoveries --country PH --currency PHP
+
+# List counterparty (UMA) providers
+grid uma-providers [--country-code US] [--currency-code USD]
+```
+
+### API Tokens
+
+```bash
+grid tokens list [--name <name>]
+grid tokens get <tokenId>
+# clientSecret is returned only once at creation — store it securely
+grid tokens create --name "CI token" --permissions VIEW,TRANSACT
+grid tokens revoke <tokenId>
+```
+
+### Internal Account Management
+
+```bash
+# Both are signed-retry operations — run once to get the 202 challenge, then
+# re-run with --wallet-signature <stamp> --request-id <id> (see the signing note
+# under Auth). The CLI does not compute the stamp, generate keys, or decrypt.
+grid internal-accounts update <id> --private-enabled true
+grid internal-accounts export <id> --client-public-key <hex>
+```
+
 ## Output Format
 
 All commands output JSON:

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -18,6 +18,11 @@ export interface PaginatedResponse<T> {
   totalCount?: number;
 }
 
+export type QueryParams = Record<
+  string,
+  string | number | boolean | string[] | undefined
+>;
+
 export class GridClient {
   private config: GridConfig;
   private timeoutMs: number;
@@ -34,7 +39,7 @@ export class GridClient {
 
   private buildUrl(
     path: string,
-    params?: Record<string, string | number | boolean | undefined>
+    params?: QueryParams
   ): string {
     const baseUrl = this.config.baseUrl.endsWith("/")
       ? this.config.baseUrl
@@ -43,7 +48,11 @@ export class GridClient {
     const url = new URL(fullPath, baseUrl);
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined) {
+        if (value === undefined) return;
+        // Array values become repeated query params (e.g. destinationCurrency).
+        if (Array.isArray(value)) {
+          value.forEach((v) => url.searchParams.append(key, String(v)));
+        } else {
           url.searchParams.append(key, String(value));
         }
       });
@@ -55,7 +64,7 @@ export class GridClient {
     method: string,
     path: string,
     options?: {
-      params?: Record<string, string | number | boolean | undefined>;
+      params?: QueryParams;
       body?: unknown;
       headers?: Record<string, string | undefined>;
     }
@@ -141,7 +150,7 @@ export class GridClient {
 
   async get<T>(
     path: string,
-    params?: Record<string, string | number | boolean | undefined>,
+    params?: QueryParams,
     headers?: Record<string, string | undefined>
   ): Promise<ApiResponse<T>> {
     return this.request<T>("GET", path, { params, headers });

--- a/cli/src/commands/crypto.ts
+++ b/cli/src/commands/crypto.ts
@@ -1,0 +1,62 @@
+import { Command } from "commander";
+import { GridClient } from "../client";
+import { outputResponse, formatError, output } from "../output";
+import { GlobalOptions } from "../index";
+
+interface EstimateCryptoWithdrawalFeeResponse {
+  networkFee: number;
+  networkFeeAsset: string;
+  applicationFee: number;
+  totalFee: number;
+  netAmount: number;
+}
+
+export function registerCryptoCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  const cryptoCmd = program
+    .command("crypto")
+    .description("Crypto helper commands");
+
+  cryptoCmd
+    .command("estimate-fee")
+    .description("Estimate the fee for a crypto withdrawal")
+    .requiredOption("--internal-account-id <id>", "Source internal account ID")
+    .requiredOption("--currency <code>", "Currency code (e.g. USDC)")
+    .requiredOption("--crypto-network <network>", "Crypto network (e.g. SOLANA)")
+    .requiredOption("--amount <number>", "Amount in the smallest unit")
+    .requiredOption("--destination-address <address>", "Destination address")
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      // A crypto amount must be a positive integer in the smallest unit;
+      // reject trailing garbage (e.g. "10foo") and out-of-range values that
+      // parseInt would otherwise accept or truncate.
+      if (!/^\d+$/.test(options.amount)) {
+        output(formatError("--amount must be a positive integer"));
+        process.exitCode = 1;
+        return;
+      }
+      const amount = Number(options.amount);
+      if (!Number.isSafeInteger(amount) || amount < 1) {
+        output(formatError("--amount is out of range"));
+        process.exitCode = 1;
+        return;
+      }
+
+      const response = await client.post<EstimateCryptoWithdrawalFeeResponse>(
+        "/crypto/estimate-withdrawal-fee",
+        {
+          internalAccountId: options.internalAccountId,
+          currency: options.currency,
+          cryptoNetwork: options.cryptoNetwork,
+          amount,
+          destinationAddress: options.destinationAddress,
+        }
+      );
+      outputResponse(response);
+    });
+}

--- a/cli/src/commands/discoveries.ts
+++ b/cli/src/commands/discoveries.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import { GridClient } from "../client";
+import { outputResponse } from "../output";
+import { GlobalOptions } from "../index";
+
+interface Discovery {
+  bankName: string;
+  displayName: string;
+  country: string;
+  currency: string;
+}
+
+export function registerDiscoveriesCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  program
+    .command("discoveries")
+    .description("List available receiving institutions")
+    .option("--country <code>", "Filter by country (ISO 3166-1 alpha-2)")
+    .option("--currency <code>", "Filter by currency (ISO 4217)")
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.get<{ data: Discovery[] }>("/discoveries", {
+        country: options.country,
+        currency: options.currency,
+      });
+      outputResponse(response);
+    });
+}

--- a/cli/src/commands/exchange-rates.ts
+++ b/cli/src/commands/exchange-rates.ts
@@ -1,0 +1,73 @@
+import { Command } from "commander";
+import { GridClient } from "../client";
+import { outputResponse, formatError, output } from "../output";
+import { GlobalOptions } from "../index";
+
+interface Currency {
+  code: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+}
+
+interface ExchangeRate {
+  sourceCurrency: Currency;
+  sendingAmount: number;
+  destinationCurrency: Currency;
+  destinationPaymentRail: string;
+  receivingAmount: number;
+  exchangeRate: number;
+  updatedAt: string;
+}
+
+function collect(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+export function registerExchangeRatesCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  program
+    .command("exchange-rates")
+    .description("Get exchange rates")
+    .option("--source-currency <code>", "Source currency code")
+    .option(
+      "--destination-currency <code>",
+      "Destination currency code (repeatable)",
+      collect
+    )
+    .option("--sending-amount <number>", "Sending amount in the smallest unit")
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      let sendingAmount: number | undefined;
+      if (options.sendingAmount !== undefined) {
+        // Amount is in the smallest unit — reject decimals/negatives/garbage
+        // rather than letting parseInt truncate them.
+        if (!/^\d+$/.test(options.sendingAmount)) {
+          output(formatError("--sending-amount must be a positive integer"));
+          process.exitCode = 1;
+          return;
+        }
+        sendingAmount = Number(options.sendingAmount);
+        if (!Number.isSafeInteger(sendingAmount) || sendingAmount < 1) {
+          output(formatError("--sending-amount is out of range"));
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      const response = await client.get<{ data: ExchangeRate[] }>(
+        "/exchange-rates",
+        {
+          sourceCurrency: options.sourceCurrency,
+          destinationCurrency: options.destinationCurrency,
+          sendingAmount,
+        }
+      );
+      outputResponse(response);
+    });
+}

--- a/cli/src/commands/internal-accounts.ts
+++ b/cli/src/commands/internal-accounts.ts
@@ -1,0 +1,68 @@
+import { Command } from "commander";
+import { GridClient } from "../client";
+import { outputResponse, formatError, output } from "../output";
+import { GlobalOptions } from "../index";
+import { addSignedOptions, signedHeaders, validateSignedOptions } from "../signed";
+
+export function registerInternalAccountsCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  const internalAccountsCmd = program
+    .command("internal-accounts")
+    .description("Internal account update/export commands");
+
+  addSignedOptions(
+    internalAccountsCmd
+      .command("update <internalAccountId>")
+      .description("Update an internal account")
+      .option("--private-enabled <true|false>", "Enable/disable Embedded Wallet privacy")
+  ).action(async (internalAccountId: string, options) => {
+    const opts = program.opts<GlobalOptions>();
+    const client = getClient(opts);
+    if (!client) return;
+    if (!validateSignedOptions(options)) return;
+
+    if (options.privateEnabled === undefined) {
+      output(formatError("Provide --private-enabled <true|false>"));
+      process.exitCode = 1;
+      return;
+    }
+    if (options.privateEnabled !== "true" && options.privateEnabled !== "false") {
+      output(formatError("--private-enabled must be true or false"));
+      process.exitCode = 1;
+      return;
+    }
+
+    const response = await client.patch(
+      `/internal-accounts/${internalAccountId}`,
+      { privateEnabled: options.privateEnabled === "true" },
+      signedHeaders(options)
+    );
+    outputResponse(response);
+  });
+
+  addSignedOptions(
+    internalAccountsCmd
+      .command("export <internalAccountId>")
+      .description(
+        "Export an internal account's wallet credentials — returns an HPKE-sealed ciphertext you decrypt client-side with the matching private key"
+      )
+      .requiredOption(
+        "--client-public-key <hex>",
+        "Ephemeral client P-256 public key (uncompressed SEC1 hex); discard the private key after decrypting"
+      )
+  ).action(async (internalAccountId: string, options) => {
+    const opts = program.opts<GlobalOptions>();
+    const client = getClient(opts);
+    if (!client) return;
+    if (!validateSignedOptions(options)) return;
+
+    const response = await client.post(
+      `/internal-accounts/${internalAccountId}/export`,
+      { clientPublicKey: options.clientPublicKey },
+      signedHeaders(options)
+    );
+    outputResponse(response);
+  });
+}

--- a/cli/src/commands/tokens.ts
+++ b/cli/src/commands/tokens.ts
@@ -1,0 +1,123 @@
+import { Command } from "commander";
+import { GridClient, PaginatedResponse } from "../client";
+import { outputResponse, formatError, output } from "../output";
+import { GlobalOptions } from "../index";
+import { confirm } from "../prompt";
+import { parseList } from "../parse";
+
+interface ApiToken {
+  id: string;
+  name: string;
+  permissions: string[];
+  clientId: string;
+  clientSecret?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function registerTokensCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  const tokensCmd = program
+    .command("tokens")
+    .description("API token management commands");
+
+  tokensCmd
+    .command("list")
+    .description("List API tokens")
+    .option("--name <name>", "Filter by name")
+    .option("--created-after <ts>", "Filter by creation date (RFC 3339)")
+    .option("--created-before <ts>", "Filter by creation date (RFC 3339)")
+    .option("--updated-after <ts>", "Filter by update date (RFC 3339)")
+    .option("--updated-before <ts>", "Filter by update date (RFC 3339)")
+    .option("-l, --limit <number>", "Maximum results (default 20, max 100)", "20")
+    .option("--cursor <cursor>", "Pagination cursor")
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const limit = parseInt(options.limit, 10);
+      if (Number.isNaN(limit)) {
+        output(formatError("--limit must be a number"));
+        process.exitCode = 1;
+        return;
+      }
+
+      const response = await client.get<PaginatedResponse<ApiToken>>("/tokens", {
+        name: options.name,
+        createdAfter: options.createdAfter,
+        createdBefore: options.createdBefore,
+        updatedAfter: options.updatedAfter,
+        updatedBefore: options.updatedBefore,
+        limit,
+        cursor: options.cursor,
+      });
+      outputResponse(response);
+    });
+
+  tokensCmd
+    .command("get <tokenId>")
+    .description("Get an API token")
+    .action(async (tokenId: string) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const response = await client.get<ApiToken>(`/tokens/${tokenId}`);
+      outputResponse(response);
+    });
+
+  tokensCmd
+    .command("create")
+    .description(
+      "Create an API token — the clientSecret is returned only once, store it securely"
+    )
+    .requiredOption("--name <name>", "Token name")
+    .requiredOption(
+      "--permissions <list>",
+      "Comma-separated permissions (VIEW, TRANSACT, MANAGE)"
+    )
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const permissions = parseList(options.permissions);
+      if (!permissions) {
+        output(formatError("--permissions must list at least one permission"));
+        process.exitCode = 1;
+        return;
+      }
+
+      const response = await client.post<ApiToken>("/tokens", {
+        name: options.name,
+        permissions,
+      });
+      outputResponse(response);
+    });
+
+  tokensCmd
+    .command("revoke <tokenId>")
+    .description("Revoke (delete) an API token")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .action(async (tokenId: string, options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      if (!options.yes) {
+        const confirmed = await confirm(
+          `Revoke API token ${tokenId}? This cannot be undone.`
+        );
+        if (!confirmed) {
+          console.log("Aborted.");
+          return;
+        }
+      }
+
+      const response = await client.delete<void>(`/tokens/${tokenId}`);
+      outputResponse(response);
+    });
+}

--- a/cli/src/commands/uma-providers.ts
+++ b/cli/src/commands/uma-providers.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { GridClient, PaginatedResponse } from "../client";
+import { outputResponse, formatError, output } from "../output";
+import { GlobalOptions } from "../index";
+
+interface UmaProvider {
+  name?: string;
+  domain?: string;
+  supportedRegions?: string[];
+  lei?: string;
+  allowListStatus?: boolean;
+}
+
+export function registerUmaProvidersCommand(
+  program: Command,
+  getClient: (opts: GlobalOptions) => GridClient | null
+): void {
+  program
+    .command("uma-providers")
+    .description("List available counterparty (UMA) providers")
+    .option("--country-code <code>", "Filter by country code")
+    .option("--currency-code <code>", "Filter by currency code")
+    .option("--has-blocked-providers", "Only providers with blocked entries")
+    .option("-l, --limit <number>", "Maximum results (default 20, max 100)", "20")
+    .option("--cursor <cursor>", "Pagination cursor")
+    .option("--sort <order>", "Sort order: asc or desc")
+    .action(async (options) => {
+      const opts = program.opts<GlobalOptions>();
+      const client = getClient(opts);
+      if (!client) return;
+
+      const limit = parseInt(options.limit, 10);
+      if (Number.isNaN(limit)) {
+        output(formatError("--limit must be a number"));
+        process.exitCode = 1;
+        return;
+      }
+
+      const response = await client.get<PaginatedResponse<UmaProvider>>(
+        "/uma-providers",
+        {
+          countryCode: options.countryCode,
+          currencyCode: options.currencyCode,
+          hasBlockedProviders: options.hasBlockedProviders ? true : undefined,
+          limit,
+          cursor: options.cursor,
+          sortOrder: options.sort,
+        }
+      );
+      outputResponse(response);
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -70,6 +70,18 @@ export async function buildProgram(): Promise<Command> {
   const { registerReceiverCommand } = await import("./commands/receiver");
   const { registerCardsCommand } = await import("./commands/cards");
   const { registerAuthCommand } = await import("./commands/auth");
+  const { registerExchangeRatesCommand } = await import(
+    "./commands/exchange-rates"
+  );
+  const { registerCryptoCommand } = await import("./commands/crypto");
+  const { registerDiscoveriesCommand } = await import("./commands/discoveries");
+  const { registerUmaProvidersCommand } = await import(
+    "./commands/uma-providers"
+  );
+  const { registerInternalAccountsCommand } = await import(
+    "./commands/internal-accounts"
+  );
+  const { registerTokensCommand } = await import("./commands/tokens");
 
   registerConfigureCommand(program);
   registerConfigCommand(program, getClient);
@@ -82,6 +94,12 @@ export async function buildProgram(): Promise<Command> {
   registerReceiverCommand(program, getClient);
   registerCardsCommand(program, getClient);
   registerAuthCommand(program, getClient);
+  registerExchangeRatesCommand(program, getClient);
+  registerCryptoCommand(program, getClient);
+  registerDiscoveriesCommand(program, getClient);
+  registerUmaProvidersCommand(program, getClient);
+  registerInternalAccountsCommand(program, getClient);
+  registerTokensCommand(program, getClient);
 
   const customersCmd = program.commands.find((c) => c.name() === "customers");
   const transactionsCmd = program.commands.find(

--- a/cli/test/quick-wins.test.ts
+++ b/cli/test/quick-wins.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import { runCli } from "./helpers";
+
+describe("exchange-rates", () => {
+  it("passes source, repeated destination, and sending amount", async () => {
+    const { request } = await runCli([
+      "exchange-rates",
+      "--source-currency",
+      "USD",
+      "--destination-currency",
+      "EUR",
+      "--destination-currency",
+      "MXN",
+      "--sending-amount",
+      "10000",
+    ]);
+
+    expect(request?.path).toBe("/grid/v1/exchange-rates");
+    expect(request?.url.searchParams.getAll("destinationCurrency")).toEqual([
+      "EUR",
+      "MXN",
+    ]);
+    expect(request?.query.sourceCurrency).toBe("USD");
+    expect(request?.query.sendingAmount).toBe("10000");
+  });
+});
+
+describe("crypto estimate-fee", () => {
+  it("builds the estimate request body", async () => {
+    const { request } = await runCli([
+      "crypto",
+      "estimate-fee",
+      "--internal-account-id",
+      "InternalAccount:1",
+      "--currency",
+      "USDC",
+      "--crypto-network",
+      "SOLANA",
+      "--amount",
+      "5000",
+      "--destination-address",
+      "sol-addr",
+    ]);
+
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/crypto/estimate-withdrawal-fee");
+    expect(request?.body).toMatchObject({
+      internalAccountId: "InternalAccount:1",
+      currency: "USDC",
+      cryptoNetwork: "SOLANA",
+      amount: 5000,
+      destinationAddress: "sol-addr",
+    });
+  });
+});
+
+describe("exchange-rates validation", () => {
+  it("rejects a non-integer --sending-amount", async () => {
+    const { calls } = await runCli([
+      "exchange-rates",
+      "--source-currency",
+      "USD",
+      "--destination-currency",
+      "EUR",
+      "--sending-amount",
+      "10.5",
+    ]);
+    expect(calls).toBe(0);
+  });
+});
+
+describe("crypto estimate-fee validation", () => {
+  it("rejects a non-integer amount instead of truncating it", async () => {
+    const { calls } = await runCli([
+      "crypto",
+      "estimate-fee",
+      "--internal-account-id",
+      "InternalAccount:1",
+      "--currency",
+      "USDC",
+      "--crypto-network",
+      "SOLANA",
+      "--amount",
+      "10foo",
+      "--destination-address",
+      "sol-addr",
+    ]);
+    expect(calls).toBe(0);
+  });
+});
+
+describe("discoveries", () => {
+  it("passes country and currency filters", async () => {
+    const { request } = await runCli([
+      "discoveries",
+      "--country",
+      "PH",
+      "--currency",
+      "PHP",
+    ]);
+    expect(request?.path).toBe("/grid/v1/discoveries");
+    expect(request?.query).toMatchObject({ country: "PH", currency: "PHP" });
+  });
+});
+
+describe("uma-providers", () => {
+  it("passes filters and pagination", async () => {
+    const { request } = await runCli([
+      "uma-providers",
+      "--country-code",
+      "US",
+      "--has-blocked-providers",
+    ]);
+    expect(request?.path).toBe("/grid/v1/uma-providers");
+    expect(request?.query).toMatchObject({
+      countryCode: "US",
+      hasBlockedProviders: "true",
+    });
+  });
+});
+
+describe("internal-accounts update", () => {
+  it("sends privateEnabled and forwards signed headers", async () => {
+    const { request } = await runCli([
+      "internal-accounts",
+      "update",
+      "InternalAccount:1",
+      "--private-enabled",
+      "true",
+      "--wallet-signature",
+      "stamp",
+      "--request-id",
+      "req-1",
+    ]);
+    expect(request?.method).toBe("PATCH");
+    expect(request?.path).toBe("/grid/v1/internal-accounts/InternalAccount:1");
+    expect(request?.body).toMatchObject({ privateEnabled: true });
+    expect(request?.headers["Grid-Wallet-Signature"]).toBe("stamp");
+  });
+
+  it("rejects a non-boolean --private-enabled", async () => {
+    const { calls } = await runCli([
+      "internal-accounts",
+      "update",
+      "InternalAccount:1",
+      "--private-enabled",
+      "yes",
+    ]);
+    expect(calls).toBe(0);
+  });
+});
+
+describe("internal-accounts export", () => {
+  it("sends clientPublicKey with signed headers", async () => {
+    const { request } = await runCli([
+      "internal-accounts",
+      "export",
+      "InternalAccount:1",
+      "--client-public-key",
+      "04abcd",
+      "--wallet-signature",
+      "stamp",
+      "--request-id",
+      "req-1",
+    ]);
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe(
+      "/grid/v1/internal-accounts/InternalAccount:1/export"
+    );
+    expect(request?.body).toMatchObject({ clientPublicKey: "04abcd" });
+    expect(request?.headers["Request-Id"]).toBe("req-1");
+  });
+});
+
+describe("tokens", () => {
+  it("create sends name and parsed permissions", async () => {
+    const { request } = await runCli([
+      "tokens",
+      "create",
+      "--name",
+      "CI token",
+      "--permissions",
+      "VIEW,TRANSACT",
+    ]);
+    expect(request?.method).toBe("POST");
+    expect(request?.path).toBe("/grid/v1/tokens");
+    expect(request?.body).toMatchObject({
+      name: "CI token",
+      permissions: ["VIEW", "TRANSACT"],
+    });
+  });
+
+  it("revoke issues a DELETE", async () => {
+    const { request } = await runCli(["tokens", "revoke", "Token:1", "--yes"]);
+    expect(request?.method).toBe("DELETE");
+    expect(request?.path).toBe("/grid/v1/tokens/Token:1");
+  });
+});


### PR DESCRIPTION
## Summary

Rounds out the Grid CLI with the high-value "quick win" endpoints from the audit. Stacked on #704.

### New commands

- `grid exchange-rates` — `GET /exchange-rates` (`--source-currency`, repeatable `--destination-currency`, `--sending-amount`)
- `grid crypto estimate-fee` — `POST /crypto/estimate-withdrawal-fee`
- `grid discoveries` — `GET /discoveries` (receiving-institution lookup)
- `grid uma-providers` — `GET /uma-providers` (counterparty providers, paginated)
- `grid tokens list|get|create|revoke` — API token management (`create` returns the `clientSecret` **once** — noted in help/output)
- `grid internal-accounts update|export` — the two signed internal-account operations, reusing the `--wallet-signature` / `--request-id` header support (they surface the `202` challenge like the other signed ops; the CLI does not compute the stamp, generate keys, or decrypt)

### Supporting change

- `buildUrl` now sends array query params as repeated keys (for `exchange-rates --destination-currency`).

## Test plan

- `cd cli && npm run build` — clean compile.
- `npm test` — 9 new boundary tests (67 total with the rest of the stack), asserting each command's method/path/query/body/headers.

## Follow-up (noted, not in this PR)

`customers update` can hit a signed-retry (`202`) when changing email/phone for Embedded-Wallet customers; it doesn't yet accept `--wallet-signature`/`--request-id`. Worth wiring up in a follow-up (needs the signed helper positioned in the stack).

Original PR: https://github.com/lightsparkdev/grid-api/pull/705