### PR TITLE
feat(cli): support signed-retry on customers update (email/phone changes)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -118,6 +118,11 @@ grid customers kyc-link \
 # Update customer (--type is the required discriminator)
 grid customers update <customerId> --type INDIVIDUAL --full-name "Jane Doe"
 
+# Changing --email or --phone-number for an Embedded Wallet customer is a
+# signed-retry operation: the first call returns a 202 challenge; re-run with
+# --wallet-signature <stamp> --request-id <id> to complete (see the signing
+# note under Auth). Update email and phone in separate calls.
+
 # Contact verification (only required in some regulatory jurisdictions)
 grid customers verify-email <customerId>
 grid customers confirm-email <customerId> --code 123456

--- a/cli/src/commands/customers.ts
+++ b/cli/src/commands/customers.ts
@@ -10,6 +10,7 @@ import {
 } from "../validation";
 import { confirm } from "../prompt";
 import { parseList } from "../parse";
+import { addSignedOptions, signedHeaders, signedOptionsError } from "../signed";
 
 interface Customer {
   id: string;
@@ -317,7 +318,7 @@ export function registerCustomersCommand(
     .option("--address-state <state>", "State/Province")
     .option("--address-postal <code>", "Postal code")
     .option("--address-country <country>", "Country code");
-  businessOptions(updateCmd).action(async (customerId: string, options) => {
+  addSignedOptions(businessOptions(updateCmd)).action(async (customerId: string, options) => {
     const opts = program.opts<GlobalOptions>();
     const client = getClient(opts);
     if (!client) return;
@@ -338,6 +339,8 @@ export function registerCustomersCommand(
           "Update --email and --phone-number in separate calls, not together",
       });
     }
+    const signedError = signedOptionsError(options);
+    if (signedError) validations.push({ valid: false, error: signedError });
     const validation = validateAll(validations);
     if (!validation.valid) {
       output(formatError(validation.error!));
@@ -362,7 +365,8 @@ export function registerCustomersCommand(
 
     const response = await client.patch<Customer>(
       `/customers/${customerId}`,
-      body
+      body,
+      signedHeaders(options)
     );
     outputResponse(response);
   });

--- a/cli/test/customers.test.ts
+++ b/cli/test/customers.test.ts
@@ -39,6 +39,59 @@ describe("customers update", () => {
   });
 });
 
+describe("customers update signed retry", () => {
+  it("forwards --wallet-signature and --request-id as headers", async () => {
+    const { request } = await runCli([
+      "customers",
+      "update",
+      "cust_7",
+      "--type",
+      "INDIVIDUAL",
+      "--email",
+      "ada@example.com",
+      "--wallet-signature",
+      "stamp",
+      "--request-id",
+      "req-1",
+    ]);
+
+    expect(request?.method).toBe("PATCH");
+    expect(request?.path).toBe("/grid/v1/customers/cust_7");
+    expect(request?.headers["Grid-Wallet-Signature"]).toBe("stamp");
+    expect(request?.headers["Request-Id"]).toBe("req-1");
+  });
+
+  it("rejects --wallet-signature without --request-id", async () => {
+    const { calls } = await runCli([
+      "customers",
+      "update",
+      "cust_7",
+      "--type",
+      "INDIVIDUAL",
+      "--email",
+      "ada@example.com",
+      "--wallet-signature",
+      "stamp",
+    ]);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects --request-id without --wallet-signature", async () => {
+    const { calls } = await runCli([
+      "customers",
+      "update",
+      "cust_7",
+      "--type",
+      "INDIVIDUAL",
+      "--email",
+      "ada@example.com",
+      "--request-id",
+      "req-1",
+    ]);
+    expect(calls).toBe(0);
+  });
+});
+
 describe("customers update validation", () => {
   it("rejects updating email and phoneNumber in the same call", async () => {
     const { calls } = await runCli([


### PR DESCRIPTION
## Summary

Changing `--email` or `--phone-number` for an Embedded Wallet customer is a signed-retry operation — the first `PATCH /customers/{id}` returns a `202` challenge, and completion requires a `Grid-Wallet-Signature` + `Request-Id`. `customers update` now accepts `--wallet-signature` / `--request-id` and forwards them, matching the other signed operations (the CLI forwards a caller-supplied stamp; it does not compute it).

Addresses the follow-up flagged on #705's review.

## Test plan

- `cd cli && npm run build` — clean compile.
- `npm test` — new test asserts `customers update` forwards the signed-retry headers (68 total).

Original PR: https://github.com/lightsparkdev/grid-api/pull/706