### PR TITLE
feat: sandbox simulate endpoints for the full card-event set

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -14,3 +14,11 @@ openapi.yaml:
     - '#/paths/~1quotes/post/requestBody/content/application~1json/schema'
   no-ambiguous-paths:
     - '#/paths/~1customers~1external-accounts~1{externalAccountId}'
+  paths-kebab-case:
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1balance_inquiry'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1credit_authorization'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1financial_authorization'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1financial_credit_authorization'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1authorization_advice'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1credit_authorization_advice'
+    - '#/paths/~1sandbox~1cards~1{id}~1simulate~1return_reversal'

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -165,7 +165,10 @@ rules:
   # Paths (README: Resources)
   # ============================================================
 
-  # Paths should use kebab-case (path params in {camelCase} are allowed)
+  # Paths should use kebab-case (path params in {camelCase} are allowed).
+  # The /sandbox/cards/{id}/simulate/* endpoints are exempted (second branch of
+  # the pattern): their snake_case segments mirror the card issuer's simulate
+  # routes verbatim, and the SDK must call those exact deployed URLs.
   paths-kebab-case:
     description: Path segments should use kebab-case
     message: "Path should use kebab-case (e.g., /external-accounts not /externalAccounts). See openapi/README.md#resources"
@@ -175,4 +178,4 @@ rules:
       field: "@key"
       function: pattern
       functionOptions:
-        match: "^(\\/([a-z0-9]+(-[a-z0-9]+)*|\\{[a-zA-Z0-9]+\\}))+$"
+        match: "^((\\/([a-z0-9]+(-[a-z0-9]+)*|\\{[a-zA-Z0-9]+\\}))+|\\/sandbox\\/cards\\/\\{id\\}\\/simulate\\/(balance_inquiry|credit_authorization|financial_authorization|financial_credit_authorization|authorization_advice|credit_authorization_advice|return_reversal))$"

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -7463,12 +7463,12 @@ paths:
                     mcc: '5942'
                     country: US
       responses:
-        '200':
-          description: Simulated authorization processed. Returns the resulting card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -7541,12 +7541,12 @@ paths:
                   cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 0
       responses:
-        '200':
-          description: Simulated clearing processed. Returns the updated card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -7610,12 +7610,526 @@ paths:
                   cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
       responses:
-        '200':
-          description: Simulated return processed. Returns the updated card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/balance_inquiry:
+    post:
+      summary: Simulate a card balance inquiry
+      description: |
+        Simulate a balance-inquiry authorization against a card in the sandbox environment. A balance inquiry is always a `0`-amount authorization, so the request carries no `amount` — only the `merchant`. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardBalanceInquiry
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a balance inquiry against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardBalanceInquiryRequest'
+            examples:
+              balanceInquiry:
+                summary: Balance inquiry at a fuel pump
+                value:
+                  merchant:
+                    descriptor: SHELL OIL 12345678
+                    mcc: '5541'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/credit_authorization:
+    post:
+      summary: Simulate a card credit authorization
+      description: |
+        Simulate an inbound credit authorization (a merchant-initiated credit to the card, e.g. a refund pushed as an authorization) in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardCreditAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a credit authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              creditAuth:
+                summary: $25.00 credit authorization
+                value:
+                  amount: 2500
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME MARKETPLACE
+                    mcc: '5942'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/financial_authorization:
+    post:
+      summary: Simulate a card financial authorization
+      description: |
+        Simulate a single-message financial authorization (an authorization that clears in the same message, e.g. an ATM withdrawal or other dual-message-exempt flow) against a card in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardFinancialAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a financial authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              financialAuth:
+                summary: $80.00 single-message ATM withdrawal
+                value:
+                  amount: 8000
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ATM WITHDRAWAL 24TH ST
+                    mcc: '6011'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/financial_credit_authorization:
+    post:
+      summary: Simulate a card financial credit authorization
+      description: |
+        Simulate a single-message financial credit authorization (a credit to the card that clears in the same message, e.g. an ATM deposit or push credit) against a card in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardFinancialCreditAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a financial credit authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              financialCreditAuth:
+                summary: $40.00 single-message push credit
+                value:
+                  amount: 4000
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME PAYOUTS
+                    mcc: '6012'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_advice:
+    post:
+      summary: Simulate a card authorization advice
+      description: |
+        Simulate an `AUTHORIZATION_ADVICE` that re-sizes an existing open authorization on a `CardTransaction` in the sandbox environment. The `amount` is the new *total* authorized amount the advice re-sizes to. The parent transaction must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationAdvice
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the advice applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationAdviceRequest'
+            examples:
+              resizeUp:
+                summary: Re-size an open auth up to a new total of $20.00
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  amount: 2000
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/credit_authorization_advice:
+    post:
+      summary: Simulate a card credit authorization advice
+      description: |
+        Simulate a network-initiated `CREDIT_AUTHORIZATION_ADVICE` against a card in the sandbox environment. Like `simulate/credit_authorization`, it is keyed by the card (PAN) and `merchant` rather than an existing transaction. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardCreditAuthorizationAdvice
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the advice applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              creditAdvice:
+                summary: $25.00 credit authorization advice
+                value:
+                  amount: 2500
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME MARKETPLACE
+                    mcc: '5942'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/return_reversal:
+    post:
+      summary: Simulate a card return reversal
+      description: |
+        Simulate a `RETURN_REVERSAL` against an existing `REFUNDED` card transaction in the sandbox environment — reversing a previously settled return. The parent transaction must be in `REFUNDED` state. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Note: authorization reversal / void has no dedicated card-issuer simulate path (the void simulator emits a distinct `VOID` event), so — like authorization expiry — it is not exposed here.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardReturnReversal
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the return reversal applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardTransactionRefRequest'
+            examples:
+              returnReversal:
+                summary: Reverse a settled return on a refunded transaction
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -20681,7 +21195,7 @@ components:
         - amount
         - currency
         - merchant
-      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization`. Drives the same internal authorization + reconcile paths that the issuer would call in production. The decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the endpoint documentation for the suffix table.
+      description: 'Sandbox-only request body shared by the card authorization-family simulate endpoints: `simulate/authorization`, `simulate/credit_authorization`, `simulate/financial_authorization`, `simulate/financial_credit_authorization`, and `simulate/credit_authorization_advice`. Drives the same internal authorization + reconcile paths that the issuer would call in production. The decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` documentation for the suffix table.'
       properties:
         amount:
           type: integer
@@ -20693,6 +21207,16 @@ components:
           $ref: '#/components/schemas/Currency'
         merchant:
           $ref: '#/components/schemas/CardMerchant'
+    SandboxCardSimulationResponse:
+      type: object
+      required:
+        - issuerTransactionToken
+      description: Response body for the sandbox card-event simulators. The simulate call pokes the card issuer's sandbox; the resulting card operation is delivered asynchronously via the issuer's events webhook, never synchronously in this response.
+      properties:
+        issuerTransactionToken:
+          type: string
+          description: The card issuer's transaction token for the simulated event. Correlates the eventual webhook-delivered card operation back to this simulate call.
+          example: f3a1c2d4-5b6e-7890-abcd-ef0123456789
     SandboxCardClearingRequest:
       type: object
       required:
@@ -20727,6 +21251,41 @@ components:
           description: Return amount in the smallest unit of the transaction's currency. Must be less than or equal to the net settled amount (settled minus previously-refunded).
           exclusiveMinimum: 0
           example: 1500
+    SandboxCardBalanceInquiryRequest:
+      type: object
+      required:
+        - merchant
+      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/balance_inquiry`. Drives a balance-inquiry authorization against the card. A balance inquiry is always a `0`-amount authorization, so it carries no `amount`.
+      properties:
+        merchant:
+          $ref: '#/components/schemas/CardMerchant'
+    SandboxCardAuthorizationAdviceRequest:
+      type: object
+      required:
+        - cardTransactionId
+        - amount
+      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization_advice`. Drives an `AUTHORIZATION_ADVICE` that re-sizes an existing open authorization.
+      properties:
+        cardTransactionId:
+          type: string
+          description: The id of the `CardTransaction` the advice re-sizes. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+        amount:
+          type: integer
+          format: int64
+          description: The new *total* authorized amount, in the smallest unit of the transaction's currency, that the advice re-sizes the authorization to.
+          exclusiveMinimum: 0
+          example: 2000
+    SandboxCardTransactionRefRequest:
+      type: object
+      required:
+        - cardTransactionId
+      description: Sandbox-only request body for simulate endpoints keyed only by an existing card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+      properties:
+        cardTransactionId:
+          type: string
+          description: The id of the `CardTransaction` to act against.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
     StablecoinProvider:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7463,12 +7463,12 @@ paths:
                     mcc: '5942'
                     country: US
       responses:
-        '200':
-          description: Simulated authorization processed. Returns the resulting card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -7541,12 +7541,12 @@ paths:
                   cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 0
       responses:
-        '200':
-          description: Simulated clearing processed. Returns the updated card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -7610,12 +7610,526 @@ paths:
                   cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
       responses:
-        '200':
-          description: Simulated return processed. Returns the updated card transaction.
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CardTransaction'
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/balance_inquiry:
+    post:
+      summary: Simulate a card balance inquiry
+      description: |
+        Simulate a balance-inquiry authorization against a card in the sandbox environment. A balance inquiry is always a `0`-amount authorization, so the request carries no `amount` — only the `merchant`. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardBalanceInquiry
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a balance inquiry against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardBalanceInquiryRequest'
+            examples:
+              balanceInquiry:
+                summary: Balance inquiry at a fuel pump
+                value:
+                  merchant:
+                    descriptor: SHELL OIL 12345678
+                    mcc: '5541'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/credit_authorization:
+    post:
+      summary: Simulate a card credit authorization
+      description: |
+        Simulate an inbound credit authorization (a merchant-initiated credit to the card, e.g. a refund pushed as an authorization) in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardCreditAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a credit authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              creditAuth:
+                summary: $25.00 credit authorization
+                value:
+                  amount: 2500
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME MARKETPLACE
+                    mcc: '5942'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/financial_authorization:
+    post:
+      summary: Simulate a card financial authorization
+      description: |
+        Simulate a single-message financial authorization (an authorization that clears in the same message, e.g. an ATM withdrawal or other dual-message-exempt flow) against a card in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardFinancialAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a financial authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              financialAuth:
+                summary: $80.00 single-message ATM withdrawal
+                value:
+                  amount: 8000
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ATM WITHDRAWAL 24TH ST
+                    mcc: '6011'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/financial_credit_authorization:
+    post:
+      summary: Simulate a card financial credit authorization
+      description: |
+        Simulate a single-message financial credit authorization (a credit to the card that clears in the same message, e.g. an ATM deposit or push credit) against a card in the sandbox environment. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardFinancialCreditAuthorization
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card to simulate a financial credit authorization against.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              financialCreditAuth:
+                summary: $40.00 single-message push credit
+                value:
+                  amount: 4000
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME PAYOUTS
+                    mcc: '6012'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_advice:
+    post:
+      summary: Simulate a card authorization advice
+      description: |
+        Simulate an `AUTHORIZATION_ADVICE` that re-sizes an existing open authorization on a `CardTransaction` in the sandbox environment. The `amount` is the new *total* authorized amount the advice re-sizes to. The parent transaction must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationAdvice
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the advice applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationAdviceRequest'
+            examples:
+              resizeUp:
+                summary: Re-size an open auth up to a new total of $20.00
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  amount: 2000
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/credit_authorization_advice:
+    post:
+      summary: Simulate a card credit authorization advice
+      description: |
+        Simulate a network-initiated `CREDIT_AUTHORIZATION_ADVICE` against a card in the sandbox environment. Like `simulate/credit_authorization`, it is keyed by the card (PAN) and `merchant` rather than an existing transaction. Drives the same internal paths the card issuer would call in production. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        As with `simulate/authorization`, the decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` suffix table.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardCreditAuthorizationAdvice
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the advice applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardAuthorizationRequest'
+            examples:
+              creditAdvice:
+                summary: $25.00 credit authorization advice
+                value:
+                  amount: 2500
+                  currency:
+                    code: USD
+                  merchant:
+                    descriptor: ACME MARKETPLACE
+                    mcc: '5942'
+                    country: US
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card not found (also returned in production for this path)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/return_reversal:
+    post:
+      summary: Simulate a card return reversal
+      description: |
+        Simulate a `RETURN_REVERSAL` against an existing `REFUNDED` card transaction in the sandbox environment — reversing a previously settled return. The parent transaction must be in `REFUNDED` state. The resulting card operation is delivered asynchronously via the issuer's events webhook.
+
+        Note: authorization reversal / void has no dedicated card-issuer simulate path (the void simulator emits a distinct `VOID` event), so — like authorization expiry — it is not exposed here.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardReturnReversal
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the return reversal applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardTransactionRefRequest'
+            examples:
+              returnReversal:
+                summary: Reverse a settled return on a refunded transaction
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
           content:
@@ -20681,7 +21195,7 @@ components:
         - amount
         - currency
         - merchant
-      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization`. Drives the same internal authorization + reconcile paths that the issuer would call in production. The decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the endpoint documentation for the suffix table.
+      description: 'Sandbox-only request body shared by the card authorization-family simulate endpoints: `simulate/authorization`, `simulate/credit_authorization`, `simulate/financial_authorization`, `simulate/financial_credit_authorization`, and `simulate/credit_authorization_advice`. Drives the same internal authorization + reconcile paths that the issuer would call in production. The decisioning outcome is controlled by the last three characters of `merchant.descriptor` — see the `simulate/authorization` documentation for the suffix table.'
       properties:
         amount:
           type: integer
@@ -20693,6 +21207,16 @@ components:
           $ref: '#/components/schemas/Currency'
         merchant:
           $ref: '#/components/schemas/CardMerchant'
+    SandboxCardSimulationResponse:
+      type: object
+      required:
+        - issuerTransactionToken
+      description: Response body for the sandbox card-event simulators. The simulate call pokes the card issuer's sandbox; the resulting card operation is delivered asynchronously via the issuer's events webhook, never synchronously in this response.
+      properties:
+        issuerTransactionToken:
+          type: string
+          description: The card issuer's transaction token for the simulated event. Correlates the eventual webhook-delivered card operation back to this simulate call.
+          example: f3a1c2d4-5b6e-7890-abcd-ef0123456789
     SandboxCardClearingRequest:
       type: object
       required:
@@ -20727,6 +21251,41 @@ components:
           description: Return amount in the smallest unit of the transaction's currency. Must be less than or equal to the net settled amount (settled minus previously-refunded).
           exclusiveMinimum: 0
           example: 1500
+    SandboxCardBalanceInquiryRequest:
+      type: object
+      required:
+        - merchant
+      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/balance_inquiry`. Drives a balance-inquiry authorization against the card. A balance inquiry is always a `0`-amount authorization, so it carries no `amount`.
+      properties:
+        merchant:
+          $ref: '#/components/schemas/CardMerchant'
+    SandboxCardAuthorizationAdviceRequest:
+      type: object
+      required:
+        - cardTransactionId
+        - amount
+      description: Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization_advice`. Drives an `AUTHORIZATION_ADVICE` that re-sizes an existing open authorization.
+      properties:
+        cardTransactionId:
+          type: string
+          description: The id of the `CardTransaction` the advice re-sizes. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+        amount:
+          type: integer
+          format: int64
+          description: The new *total* authorized amount, in the smallest unit of the transaction's currency, that the advice re-sizes the authorization to.
+          exclusiveMinimum: 0
+          example: 2000
+    SandboxCardTransactionRefRequest:
+      type: object
+      required:
+        - cardTransactionId
+      description: Sandbox-only request body for simulate endpoints keyed only by an existing card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+      properties:
+        cardTransactionId:
+          type: string
+          description: The id of the `CardTransaction` to act against.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
     StablecoinProvider:
       type: string
       enum:

--- a/openapi/components/schemas/cards/SandboxCardAuthorizationAdviceRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardAuthorizationAdviceRequest.yaml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - cardTransactionId
+  - amount
+description: >-
+  Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization_advice`.
+  Drives an `AUTHORIZATION_ADVICE` that re-sizes an existing open authorization.
+properties:
+  cardTransactionId:
+    type: string
+    description: >-
+      The id of the `CardTransaction` the advice re-sizes. Must be in
+      `AUTHORIZED` or `PARTIALLY_SETTLED` state.
+    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+  amount:
+    type: integer
+    format: int64
+    description: >-
+      The new *total* authorized amount, in the smallest unit of the
+      transaction's currency, that the advice re-sizes the authorization to.
+    exclusiveMinimum: 0
+    example: 2000

--- a/openapi/components/schemas/cards/SandboxCardAuthorizationRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardAuthorizationRequest.yaml
@@ -4,11 +4,14 @@ required:
   - currency
   - merchant
 description: >-
-  Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/authorization`.
-  Drives the same internal authorization + reconcile paths that the issuer
-  would call in production. The decisioning outcome is controlled by the
-  last three characters of `merchant.descriptor` — see the endpoint
-  documentation for the suffix table.
+  Sandbox-only request body shared by the card authorization-family simulate
+  endpoints: `simulate/authorization`, `simulate/credit_authorization`,
+  `simulate/financial_authorization`, `simulate/financial_credit_authorization`,
+  and `simulate/credit_authorization_advice`. Drives the same internal
+  authorization + reconcile paths that the issuer would call in production. The
+  decisioning outcome is controlled by the last three characters of
+  `merchant.descriptor` — see the `simulate/authorization` documentation for the
+  suffix table.
 properties:
   amount:
     type: integer

--- a/openapi/components/schemas/cards/SandboxCardBalanceInquiryRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardBalanceInquiryRequest.yaml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - merchant
+description: >-
+  Sandbox-only request body for `POST /sandbox/cards/{id}/simulate/balance_inquiry`.
+  Drives a balance-inquiry authorization against the card. A balance inquiry is
+  always a `0`-amount authorization, so it carries no `amount`.
+properties:
+  merchant:
+    $ref: ./CardMerchant.yaml

--- a/openapi/components/schemas/cards/SandboxCardSimulationResponse.yaml
+++ b/openapi/components/schemas/cards/SandboxCardSimulationResponse.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - issuerTransactionToken
+description: >-
+  Response body for the sandbox card-event simulators. The simulate call pokes
+  the card issuer's sandbox; the resulting card operation is delivered
+  asynchronously via the issuer's events webhook, never synchronously in this
+  response.
+properties:
+  issuerTransactionToken:
+    type: string
+    description: >-
+      The card issuer's transaction token for the simulated event. Correlates
+      the eventual webhook-delivered card operation back to this simulate call.
+    example: f3a1c2d4-5b6e-7890-abcd-ef0123456789

--- a/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - cardTransactionId
+description: >-
+  Sandbox-only request body for simulate endpoints keyed only by an existing
+  card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+properties:
+  cardTransactionId:
+    type: string
+    description: >-
+      The id of the `CardTransaction` to act against.
+    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -312,6 +312,20 @@ paths:
     $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
   /sandbox/cards/{id}/simulate/return:
     $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_return.yaml
+  /sandbox/cards/{id}/simulate/balance_inquiry:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_balance_inquiry.yaml
+  /sandbox/cards/{id}/simulate/credit_authorization:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization.yaml
+  /sandbox/cards/{id}/simulate/financial_authorization:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_authorization.yaml
+  /sandbox/cards/{id}/simulate/financial_credit_authorization:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_credit_authorization.yaml
+  /sandbox/cards/{id}/simulate/authorization_advice:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
+  /sandbox/cards/{id}/simulate/credit_authorization_advice:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
+  /sandbox/cards/{id}/simulate/return_reversal:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
   /stablecoin-provider-accounts:
     $ref: paths/stablecoins/stablecoin-provider-accounts.yaml
   /stablecoin-provider-accounts/{stablecoinProviderAccountId}:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
@@ -63,12 +63,15 @@ post:
                 mcc: '5942'
                 country: US
   responses:
-    '200':
-      description: Simulated authorization processed. Returns the resulting card transaction.
+    '202':
+      description: >-
+        Simulation accepted. The resulting card operation is delivered
+        asynchronously via the issuer's events webhook. Returns the issuer
+        transaction token that correlates the simulated event.
       content:
         application/json:
           schema:
-            $ref: ../../../components/schemas/cards/CardTransaction.yaml
+            $ref: ../../../components/schemas/cards/SandboxCardSimulationResponse.yaml
     '400':
       description: Bad request - Invalid parameters
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
@@ -1,14 +1,16 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card authorization advice
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate an `AUTHORIZATION_ADVICE` that re-sizes an existing open
+    authorization on a `CardTransaction` in the sandbox environment. The
+    `amount` is the new *total* authorized amount the advice re-sizes to. The
+    parent transaction must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state. The
+    resulting card operation is delivered asynchronously via the issuer's events
+    webhook.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardAuthorizationAdvice
   tags:
     - Sandbox
   security:
@@ -17,7 +19,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card the advice applies to.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +28,13 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardAuthorizationAdviceRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          resizeUp:
+            summary: Re-size an open auth up to a new total of $20.00
             value:
               cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              amount: 2000
   responses:
     '202':
       description: >-

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_balance_inquiry.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_balance_inquiry.yaml
@@ -1,14 +1,15 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card balance inquiry
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate a balance-inquiry authorization against a card in the sandbox
+    environment. A balance inquiry is always a `0`-amount authorization, so the
+    request carries no `amount` — only the `merchant`. Drives the same internal
+    paths the card issuer would call in production. The resulting card operation
+    is delivered asynchronously via the issuer's events webhook.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardBalanceInquiry
   tags:
     - Sandbox
   security:
@@ -17,7 +18,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card to simulate a balance inquiry against.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +27,15 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardBalanceInquiryRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          balanceInquiry:
+            summary: Balance inquiry at a fuel pump
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              merchant:
+                descriptor: SHELL OIL 12345678
+                mcc: '5541'
+                country: US
   responses:
     '202':
       description: >-
@@ -62,7 +65,7 @@ post:
           schema:
             $ref: ../../../components/schemas/errors/Error403.yaml
     '404':
-      description: Card or card transaction not found
+      description: Card not found (also returned in production for this path)
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
@@ -49,12 +49,15 @@ post:
               cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 0
   responses:
-    '200':
-      description: Simulated clearing processed. Returns the updated card transaction.
+    '202':
+      description: >-
+        Simulation accepted. The resulting card operation is delivered
+        asynchronously via the issuer's events webhook. Returns the issuer
+        transaction token that correlates the simulated event.
       content:
         application/json:
           schema:
-            $ref: ../../../components/schemas/cards/CardTransaction.yaml
+            $ref: ../../../components/schemas/cards/SandboxCardSimulationResponse.yaml
     '400':
       description: Bad request - Invalid parameters
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization.yaml
@@ -1,14 +1,20 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card credit authorization
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate an inbound credit authorization (a merchant-initiated credit to
+    the card, e.g. a refund pushed as an authorization) in the sandbox
+    environment. Drives the same internal paths the card issuer would call in
+    production. The resulting card operation is delivered asynchronously via the
+    issuer's events webhook.
+
+
+    As with `simulate/authorization`, the decisioning outcome is controlled by
+    the last three characters of `merchant.descriptor` — see the
+    `simulate/authorization` suffix table.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardCreditAuthorization
   tags:
     - Sandbox
   security:
@@ -17,7 +23,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card to simulate a credit authorization against.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +32,18 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardAuthorizationRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          creditAuth:
+            summary: $25.00 credit authorization
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              amount: 2500
+              currency:
+                code: USD
+              merchant:
+                descriptor: ACME MARKETPLACE
+                mcc: '5942'
+                country: US
   responses:
     '202':
       description: >-
@@ -62,7 +73,7 @@ post:
           schema:
             $ref: ../../../components/schemas/errors/Error403.yaml
     '404':
-      description: Card or card transaction not found
+      description: Card not found (also returned in production for this path)
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
@@ -1,14 +1,21 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card credit authorization advice
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate a network-initiated `CREDIT_AUTHORIZATION_ADVICE` against a card in
+    the sandbox environment. Like `simulate/credit_authorization`, it is keyed
+    by the card (PAN) and `merchant` rather than an existing transaction. Drives
+    the same internal paths the card issuer would call in production. The
+    resulting card operation is delivered asynchronously via the issuer's events
+    webhook.
+
+
+    As with `simulate/authorization`, the decisioning outcome is controlled by
+    the last three characters of `merchant.descriptor` — see the
+    `simulate/authorization` suffix table.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardCreditAuthorizationAdvice
   tags:
     - Sandbox
   security:
@@ -17,7 +24,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card the advice applies to.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +33,18 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardAuthorizationRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          creditAdvice:
+            summary: $25.00 credit authorization advice
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              amount: 2500
+              currency:
+                code: USD
+              merchant:
+                descriptor: ACME MARKETPLACE
+                mcc: '5942'
+                country: US
   responses:
     '202':
       description: >-
@@ -62,7 +74,7 @@ post:
           schema:
             $ref: ../../../components/schemas/errors/Error403.yaml
     '404':
-      description: Card or card transaction not found
+      description: Card not found (also returned in production for this path)
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_authorization.yaml
@@ -1,14 +1,21 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card financial authorization
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate a single-message financial authorization (an authorization that
+    clears in the same message, e.g. an ATM withdrawal or other
+    dual-message-exempt flow) against a card in the sandbox environment. Drives
+    the same internal paths the card issuer would call in production. The
+    resulting card operation is delivered asynchronously via the issuer's events
+    webhook.
+
+
+    As with `simulate/authorization`, the decisioning outcome is controlled by
+    the last three characters of `merchant.descriptor` — see the
+    `simulate/authorization` suffix table.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardFinancialAuthorization
   tags:
     - Sandbox
   security:
@@ -17,7 +24,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card to simulate a financial authorization against.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +33,18 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardAuthorizationRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          financialAuth:
+            summary: $80.00 single-message ATM withdrawal
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              amount: 8000
+              currency:
+                code: USD
+              merchant:
+                descriptor: ATM WITHDRAWAL 24TH ST
+                mcc: '6011'
+                country: US
   responses:
     '202':
       description: >-
@@ -62,7 +74,7 @@ post:
           schema:
             $ref: ../../../components/schemas/errors/Error403.yaml
     '404':
-      description: Card or card transaction not found
+      description: Card not found (also returned in production for this path)
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_credit_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_credit_authorization.yaml
@@ -1,14 +1,20 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card financial credit authorization
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate a single-message financial credit authorization (a credit to the
+    card that clears in the same message, e.g. an ATM deposit or push credit)
+    against a card in the sandbox environment. Drives the same internal paths
+    the card issuer would call in production. The resulting card operation is
+    delivered asynchronously via the issuer's events webhook.
+
+
+    As with `simulate/authorization`, the decisioning outcome is controlled by
+    the last three characters of `merchant.descriptor` — see the
+    `simulate/authorization` suffix table.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardFinancialCreditAuthorization
   tags:
     - Sandbox
   security:
@@ -17,7 +23,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card to simulate a financial credit authorization against.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +32,18 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardAuthorizationRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          financialCreditAuth:
+            summary: $40.00 single-message push credit
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
+              amount: 4000
+              currency:
+                code: USD
+              merchant:
+                descriptor: ACME PAYOUTS
+                mcc: '6012'
+                country: US
   responses:
     '202':
       description: >-
@@ -62,7 +73,7 @@ post:
           schema:
             $ref: ../../../components/schemas/errors/Error403.yaml
     '404':
-      description: Card or card transaction not found
+      description: Card not found (also returned in production for this path)
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
@@ -1,14 +1,19 @@
 post:
-  summary: Simulate a card return
+  summary: Simulate a card return reversal
   description: >
-    Simulate a merchant-initiated `RETURN` against an existing settled
-    card transaction in the sandbox environment. Creates a `CardRefund` on
-    the parent and either flips the parent to `REFUNDED` (full refund) or
-    keeps it `SETTLED` with a non-zero `refundedAmount` (partial refund).
+    Simulate a `RETURN_REVERSAL` against an existing `REFUNDED` card
+    transaction in the sandbox environment — reversing a previously settled
+    return. The parent transaction must be in `REFUNDED` state. The resulting
+    card operation is delivered asynchronously via the issuer's events webhook.
+
+
+    Note: authorization reversal / void has no dedicated card-issuer simulate
+    path (the void simulator emits a distinct `VOID` event), so — like
+    authorization expiry — it is not exposed here.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturn
+  operationId: sandboxSimulateCardReturnReversal
   tags:
     - Sandbox
   security:
@@ -17,7 +22,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return applies to.
+      description: The id of the card the return reversal applies to.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -26,13 +31,12 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardReturnRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardTransactionRefRequest.yaml
         examples:
-          fullRefund:
-            summary: Full refund of a $15.00 settled transaction
+          returnReversal:
+            summary: Reverse a settled return on a refunded transaction
             value:
               cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
-              amount: 1500
   responses:
     '202':
       description: >-


### PR DESCRIPTION
## Summary

Adds the 7 remaining sandbox card-event simulate endpoints, completing the set alongside the existing `authorization`, `clearing`, and `return` simulators. Each is `POST`, sandbox-only, and returns `202` with `{ "issuerTransactionToken": string }` — the simulate call drives the card issuer's sandbox and the resulting card operation is delivered asynchronously via webhook.

New endpoints (all under `/sandbox/cards/{id}/simulate/`):

| Path | Request body |
|------|--------------|
| `balance_inquiry` | `SandboxCardBalanceInquiryRequest` (`merchant` only — a $0 inquiry) |
| `credit_authorization` | `SandboxCardAuthorizationRequest` |
| `financial_authorization` | `SandboxCardAuthorizationRequest` |
| `financial_credit_authorization` | `SandboxCardAuthorizationRequest` |
| `authorization_advice` | `SandboxCardAuthorizationAdviceRequest` (`cardTransactionId` + new total `amount`) |
| `credit_authorization_advice` | `SandboxCardAuthorizationRequest` |
| `return_reversal` | `SandboxCardTransactionRefRequest` (`cardTransactionId`) |

New schemas: `SandboxCardBalanceInquiryRequest`, `SandboxCardAuthorizationAdviceRequest`, `SandboxCardTransactionRefRequest`, and a shared `SandboxCardSimulationResponse` (`{ issuerTransactionToken }`). `SandboxCardAuthorizationRequest` and `CardMerchant` are reused.

**Response correction to the existing 3 simulators:** they were documented as `200` returning a full `CardTransaction`, but these simulators are asynchronous — they return an issuer transaction token and deliver the resulting card operation over webhook. This PR corrects `authorization`, `clearing`, and `return` to `202` / `SandboxCardSimulationResponse` so the whole simulate family is consistent.

**Intentionally excluded:** authorization expiry and authorization reversal / void — neither has a card-issuer simulate path.

## Notes

- The `simulate/*` path segments are snake_case to match the card issuer's simulate routes verbatim, so they're exempted from the repo's kebab-case path convention (scoped carve-outs in `.spectral.yaml` and `.redocly.lint-ignore.yaml`, not a global relaxation).
- No `info.version` bump: no breaking change to an existing published contract — this documents new endpoints and corrects the stale response shape on the existing simulators.

## Test plan

- `make build` — rebundles `openapi.yaml` + `mintlify/openapi.yaml`; both contain the 7 new paths, 7 operationIds, and the 4 new schemas.
- `make lint` — passes (Redocly + Spectral + markdown), 0 errors.


Original PR: https://github.com/lightsparkdev/grid-api/pull/684