### PR TITLE
feat(customers): require businessInfo when creating a business customer

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11599,6 +11599,8 @@ components:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/BusinessCustomerFields'
         - type: object
+          required:
+            - businessInfo
           properties:
             businessInfo:
               $ref: '#/components/schemas/BusinessInfo'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11599,6 +11599,8 @@ components:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/BusinessCustomerFields'
         - type: object
+          required:
+            - businessInfo
           properties:
             businessInfo:
               $ref: '#/components/schemas/BusinessInfo'

--- a/openapi/components/schemas/customers/BusinessCustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/BusinessCustomerCreateRequest.yaml
@@ -3,6 +3,8 @@ allOf:
   - $ref: ./CustomerCreateRequest.yaml
   - $ref: ./BusinessCustomerFields.yaml
   - type: object
+    required:
+      - businessInfo
     properties:
       businessInfo:
         $ref: ./BusinessInfo.yaml


### PR DESCRIPTION
## Summary

Makes `businessInfo` a required field when creating a business customer via `POST /customers`.

Previously `businessInfo` was optional on `BusinessCustomerCreateRequest`, even though the nested object already requires `legalName`, `taxId`, and `incorporatedOn`. A business customer can't be meaningfully onboarded without it, so this tightens the schema to reject requests that omit it entirely.

## Changes

- `openapi/components/schemas/customers/BusinessCustomerCreateRequest.yaml` — add `businessInfo` to the `required` list on the business-specific `allOf` member. This applies only to the `BUSINESS` branch of the create request; individual customers are unaffected.
- Regenerated `openapi.yaml` and `mintlify/openapi.yaml` via `make build`.

`make lint` passes (only pre-existing, unrelated `schema-properties-*` warnings remain).

Note: `info.version` / `servers.url` are unchanged — the spec date-version tracks published API versions, and bumping it implies a new server path, which is a separate coordinated rollout.

Requested by @shreyav

Original PR: https://github.com/lightsparkdev/grid-api/pull/716