### PR TITLE
Return transaction oneOf from POST /sandbox/send

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4760,7 +4760,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OutgoingTransaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4760,7 +4760,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OutgoingTransaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request
           content:

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -22,7 +22,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/transactions/OutgoingTransaction.yaml
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
     '400':
       description: Bad request
       content:


### PR DESCRIPTION
Changes the 200 response of `POST /sandbox/send` from `OutgoingTransaction` to `TransactionOneOf` (the discriminated transaction union: `IncomingTransaction | OutgoingTransaction | CardTransaction`, keyed on `type`).

This matches the transaction endpoints that already return the union — `POST /transfers/out` and `GET /transactions/{transactionId}` — so `/sandbox/send` describes the same transaction shape as the rest of the API.

## Changes
- `openapi/paths/sandbox/sandbox_send.yaml` — 200 response `$ref` → `TransactionOneOf`
- `openapi.yaml`, `mintlify/openapi.yaml` — regenerated via `make build`

## Breaking-change assessment

**Wire / raw-HTTP callers: non-breaking.** `OutgoingTransaction` is one of the `oneOf` members (`type: OUTGOING`), so any payload valid under the old schema is still valid under `TransactionOneOf`. The contract is widened, not narrowed — no field is removed or renamed. Callers that read the JSON directly see no difference for existing outgoing-transaction responses.

**Generated SDKs / statically-typed clients: source-breaking.** The return type widens from a single `OutgoingTransaction` to a discriminated union. In `grid-typescript` / `grid-kotlin` (and any codegen client), user code that reads `OutgoingTransaction`-specific fields (e.g. `sentAmount`, `source`) on the result will no longer type-check without first narrowing on the `type` discriminator. Regenerating the SDKs against this spec is therefore a breaking change for those consumers and should ship in a versioned SDK release.

**Version note:** `info.version` is intentionally left unchanged. Because the change is wire-compatible for existing responses, it does not on its own warrant a new dated API version / `servers.url` path. If we want the SDK-level break reflected as a distinct API version, that is a larger coordinated bump — flagging for a maintainer decision rather than doing it unilaterally here.

## Verification
- `make build` — rebundles cleanly; `TransactionOneOf` present in both bundled specs
- `make lint-openapi` / `redocly lint` — pass (only pre-existing info/warning items)

Requested by @shreyav

Original PR: https://github.com/lightsparkdev/grid-api/pull/720