### PR TITLE
[mnm] Require at least one API token permission

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -16144,7 +16144,8 @@ components:
           example: Sandbox read-only
         permissions:
           type: array
-          description: A list of permissions to grant to the token
+          description: A non-empty list of permissions to grant to the token
+          minItems: 1
           items:
             $ref: '#/components/schemas/Permission'
     InternalAccountUpdateRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16144,7 +16144,8 @@ components:
           example: Sandbox read-only
         permissions:
           type: array
-          description: A list of permissions to grant to the token
+          description: A non-empty list of permissions to grant to the token
+          minItems: 1
           items:
             $ref: '#/components/schemas/Permission'
     InternalAccountUpdateRequest:

--- a/openapi/components/schemas/tokens/ApiTokenCreateRequest.yaml
+++ b/openapi/components/schemas/tokens/ApiTokenCreateRequest.yaml
@@ -9,6 +9,7 @@ properties:
     example: Sandbox read-only
   permissions:
     type: array
-    description: A list of permissions to grant to the token
+    description: A non-empty list of permissions to grant to the token
+    minItems: 1
     items:
       $ref: ./Permission.yaml


### PR DESCRIPTION
## Reason The Grid API contract currently requires the `permissions` field 
when creating an API token but permits an empty array. Empty permissions 
are unsafe because the server's legacy authorization semantics treat an 
empty permission collection as unrestricted. Finding: 
https://makenomistakes.dev.dev.sparkinfra.net/projects/1f18060f-a9e3-6106-9b61-dcf74283b763/findings/1f184828-d02b-6808-b94f-644eaf0a9f28 
Server-side fix: https://github.com/lightsparkdev/webdev/pull/30795 ## 
Overview - Require at least one entry in 
`ApiTokenCreateRequest.permissions` with `minItems: 1`. - Describe the 
field as a non-empty list. - Regenerate the root and Mintlify OpenAPI 
bundles. ## Test Plan - `make build` - `make lint` (0 errors; existing 
warnings and informational findings remain)
