### PR TITLE
feat(transactions): add POST /transactions/{transactionId}/cancel

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -326,11 +326,13 @@ resources:
       incoming_rate_details: "#/components/schemas/IncomingRateDetails"
       reconciliation_instructions: "#/components/schemas/ReconciliationInstructions"
       transaction_list_response: "#/components/schemas/TransactionListResponse"
+      cancel_transaction_request: "#/components/schemas/CancelTransactionRequest"
     methods:
       list: get /transactions
       retrieve: get /transactions/{transactionId}
       approve: post /transactions/{transactionId}/approve
       reject: post /transactions/{transactionId}/reject
+      cancel: post /transactions/{transactionId}/cancel
 
   invitations:
     models:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4304,10 +4304,10 @@ paths:
                 $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/cancel:
     post:
-      summary: Cancel an outgoing transaction
+      summary: Cancel a bank transfer
       description: |
-        Request cancellation of an outgoing bank transfer (ACH or wire) before it has settled — for example, a payment initiated outside of the receiving bank's processing window.
-        Whether a transaction can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transaction that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation is only supported for outgoing bank transfers; requests for any other transaction type are rejected.
+        Request cancellation of a pending bank transfer — an ACH transfer (push or pull) or a wire — before it has settled, for example a payment or collection initiated outside of the receiving bank's processing window.
+        Whether a transfer can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transfer that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation applies to bank-rail transfers; requests for transaction types that cannot be cancelled are rejected.
       operationId: cancelTransaction
       tags:
         - Transactions
@@ -4332,7 +4332,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OutgoingTransaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters or the transaction cannot be cancelled
           content:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -4302,6 +4302,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /transactions/{transactionId}/cancel:
+    post:
+      summary: Cancel an outgoing transaction
+      description: |
+        Request cancellation of an outgoing bank transfer (ACH or wire) before it has settled — for example, a payment initiated outside of the receiving bank's processing window.
+        Whether a transaction can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transaction that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation is only supported for outgoing bank transfers; requests for any other transaction type are rejected.
+      operationId: cancelTransaction
+      tags:
+        - Transactions
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: transactionId
+          in: path
+          description: Unique identifier of the transaction to cancel
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelTransactionRequest'
+      responses:
+        '200':
+          description: Cancellation requested successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutgoingTransaction'
+        '400':
+          description: Bad request - Invalid parameters or the transaction cannot be cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - The transaction has already settled or is otherwise past the point where it can be cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /crypto/estimate-withdrawal-fee:
     post:
       summary: Estimate crypto withdrawal fee
@@ -12145,6 +12206,7 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL | Transaction is not pending platform approval |
+            | TRANSACTION_NOT_CANCELLABLE | Transaction has already settled or is otherwise past the point where it can be cancelled |
             | UMA_ADDRESS_EXISTS | UMA address already exists |
             | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
@@ -12152,6 +12214,7 @@ components:
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
+            - TRANSACTION_NOT_CANCELLABLE
             - UMA_ADDRESS_EXISTS
             - EMAIL_OTP_EMAIL_ALREADY_EXISTS
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
@@ -20797,6 +20860,13 @@ components:
           type: string
           description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
           example: RESTRICTED_JURISDICTION
+    CancelTransactionRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Optional reason for cancelling the transaction. This is just for debugging purposes or can be used for a platform's own purposes.
+          example: REQUESTED_AFTER_HOURS
     EstimateCryptoWithdrawalFeeRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4304,10 +4304,10 @@ paths:
                 $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/cancel:
     post:
-      summary: Cancel an outgoing transaction
+      summary: Cancel a bank transfer
       description: |
-        Request cancellation of an outgoing bank transfer (ACH or wire) before it has settled — for example, a payment initiated outside of the receiving bank's processing window.
-        Whether a transaction can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transaction that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation is only supported for outgoing bank transfers; requests for any other transaction type are rejected.
+        Request cancellation of a pending bank transfer — an ACH transfer (push or pull) or a wire — before it has settled, for example a payment or collection initiated outside of the receiving bank's processing window.
+        Whether a transfer can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transfer that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation applies to bank-rail transfers; requests for transaction types that cannot be cancelled are rejected.
       operationId: cancelTransaction
       tags:
         - Transactions
@@ -4332,7 +4332,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OutgoingTransaction'
+                $ref: '#/components/schemas/TransactionOneOf'
         '400':
           description: Bad request - Invalid parameters or the transaction cannot be cancelled
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4302,6 +4302,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /transactions/{transactionId}/cancel:
+    post:
+      summary: Cancel an outgoing transaction
+      description: |
+        Request cancellation of an outgoing bank transfer (ACH or wire) before it has settled — for example, a payment initiated outside of the receiving bank's processing window.
+        Whether a transaction can still be cancelled is determined by the banking partner that is settling it: the request is forwarded to the partner's own cancellation facility, and a transaction that the partner has already processed (or that is otherwise past its cancellation window) cannot be cancelled. Cancellation is only supported for outgoing bank transfers; requests for any other transaction type are rejected.
+      operationId: cancelTransaction
+      tags:
+        - Transactions
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: transactionId
+          in: path
+          description: Unique identifier of the transaction to cancel
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelTransactionRequest'
+      responses:
+        '200':
+          description: Cancellation requested successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutgoingTransaction'
+        '400':
+          description: Bad request - Invalid parameters or the transaction cannot be cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '404':
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict - The transaction has already settled or is otherwise past the point where it can be cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /crypto/estimate-withdrawal-fee:
     post:
       summary: Estimate crypto withdrawal fee
@@ -12145,6 +12206,7 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL | Transaction is not pending platform approval |
+            | TRANSACTION_NOT_CANCELLABLE | Transaction has already settled or is otherwise past the point where it can be cancelled |
             | UMA_ADDRESS_EXISTS | UMA address already exists |
             | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
@@ -12152,6 +12214,7 @@ components:
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
+            - TRANSACTION_NOT_CANCELLABLE
             - UMA_ADDRESS_EXISTS
             - EMAIL_OTP_EMAIL_ALREADY_EXISTS
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
@@ -20797,6 +20860,13 @@ components:
           type: string
           description: Optional reason for rejecting the payment. This is just for debugging purposes or can be used for a platform's own purposes.
           example: RESTRICTED_JURISDICTION
+    CancelTransactionRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Optional reason for cancelling the transaction. This is just for debugging purposes or can be used for a platform's own purposes.
+          example: REQUESTED_AFTER_HOURS
     EstimateCryptoWithdrawalFeeRequest:
       type: object
       required:

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -15,6 +15,7 @@ properties:
       | Error Code | Description |
       |------------|-------------|
       | TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL | Transaction is not pending platform approval |
+      | TRANSACTION_NOT_CANCELLABLE | Transaction has already settled or is otherwise past the point where it can be cancelled |
       | UMA_ADDRESS_EXISTS | UMA address already exists |
       | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
       | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
@@ -22,6 +23,7 @@ properties:
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
+      - TRANSACTION_NOT_CANCELLABLE
       - UMA_ADDRESS_EXISTS
       - EMAIL_OTP_EMAIL_ALREADY_EXISTS
       - EMAIL_OTP_CREDENTIAL_SET_CHANGED

--- a/openapi/components/schemas/transactions/CancelTransactionRequest.yaml
+++ b/openapi/components/schemas/transactions/CancelTransactionRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  reason:
+    type: string
+    description: >-
+      Optional reason for cancelling the transaction. This is just for
+      debugging purposes or can be used for a platform's own purposes.
+    example: REQUESTED_AFTER_HOURS

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -231,6 +231,8 @@ paths:
     $ref: paths/transactions/transactions_{transactionId}_approve.yaml
   /transactions/{transactionId}/reject:
     $ref: paths/transactions/transactions_{transactionId}_reject.yaml
+  /transactions/{transactionId}/cancel:
+    $ref: paths/transactions/transactions_{transactionId}_cancel.yaml
   /crypto/estimate-withdrawal-fee:
     $ref: paths/crypto/crypto_estimate-withdrawal-fee.yaml
   /sandbox/webhooks/test:

--- a/openapi/paths/transactions/transactions_{transactionId}_cancel.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_cancel.yaml
@@ -1,16 +1,16 @@
 post:
-  summary: Cancel an outgoing transaction
+  summary: Cancel a bank transfer
   description: >
-    Request cancellation of an outgoing bank transfer (ACH or wire) before it
-    has settled — for example, a payment initiated outside of the receiving
-    bank's processing window.
+    Request cancellation of a pending bank transfer — an ACH transfer (push or
+    pull) or a wire — before it has settled, for example a payment or
+    collection initiated outside of the receiving bank's processing window.
 
-    Whether a transaction can still be cancelled is determined by the banking
+    Whether a transfer can still be cancelled is determined by the banking
     partner that is settling it: the request is forwarded to the partner's own
-    cancellation facility, and a transaction that the partner has already
+    cancellation facility, and a transfer that the partner has already
     processed (or that is otherwise past its cancellation window) cannot be
-    cancelled. Cancellation is only supported for outgoing bank transfers;
-    requests for any other transaction type are rejected.
+    cancelled. Cancellation applies to bank-rail transfers; requests for
+    transaction types that cannot be cancelled are rejected.
   operationId: cancelTransaction
   tags:
     - Transactions
@@ -35,7 +35,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/transactions/OutgoingTransaction.yaml
+            $ref: ../../components/schemas/transactions/TransactionOneOf.yaml
     '400':
       description: Bad request - Invalid parameters or the transaction cannot be cancelled
       content:

--- a/openapi/paths/transactions/transactions_{transactionId}_cancel.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_cancel.yaml
@@ -1,0 +1,70 @@
+post:
+  summary: Cancel an outgoing transaction
+  description: >
+    Request cancellation of an outgoing bank transfer (ACH or wire) before it
+    has settled — for example, a payment initiated outside of the receiving
+    bank's processing window.
+
+    Whether a transaction can still be cancelled is determined by the banking
+    partner that is settling it: the request is forwarded to the partner's own
+    cancellation facility, and a transaction that the partner has already
+    processed (or that is otherwise past its cancellation window) cannot be
+    cancelled. Cancellation is only supported for outgoing bank transfers;
+    requests for any other transaction type are rejected.
+  operationId: cancelTransaction
+  tags:
+    - Transactions
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: transactionId
+      in: path
+      description: Unique identifier of the transaction to cancel
+      required: true
+      schema:
+        type: string
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/transactions/CancelTransactionRequest.yaml
+  responses:
+    '200':
+      description: Cancellation requested successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/transactions/OutgoingTransaction.yaml
+    '400':
+      description: Bad request - Invalid parameters or the transaction cannot be cancelled
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error400.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '404':
+      description: Transaction not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict - The transaction has already settled or is otherwise past the
+        point where it can be cancelled.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
## Summary

Adds a `cancelTransaction` endpoint — `POST /transactions/{transactionId}/cancel` — for requesting cancellation of a pending bank transfer (an ACH push/pull or a wire, incoming or outgoing) before it settles, e.g. a payment or collection initiated outside the receiving bank's processing window.

Whether a transfer can still be cancelled is delegated to the banking partner settling it: the request is forwarded to the partner's own cancellation facility, so Grid does not track per-rail cancellation windows itself. A transfer the partner has already processed (or that is otherwise past its window) cannot be cancelled. Cancellation applies to bank-rail transfers; transaction types that cannot be cancelled are rejected.

## Changes

- `openapi/paths/transactions/transactions_{transactionId}_cancel.yaml` (new) — the `cancelTransaction` operation: optional `CancelTransactionRequest` body, returns `TransactionOneOf` on 200, with 400/401/404/409/500 responses.
- `openapi/components/schemas/transactions/CancelTransactionRequest.yaml` (new) — optional `reason` field, mirroring `RejectPaymentRequest`.
- `openapi/components/schemas/errors/Error409.yaml` — adds a `TRANSACTION_NOT_CANCELLABLE` code for the settled/past-window case.
- `openapi/openapi.yaml` — registers the new path.
- `.stainless/stainless.yml` — registers `cancel` under the `transactions` resource + the request model, so SDKs gain a `transactions.cancel(...)` method.
- `openapi.yaml`, `mintlify/openapi.yaml` — regenerated bundles (`make build`).

No `info.version` bump — the change is purely additive.

## Verification

- `make build` regenerates the bundle cleanly.
- `make lint-openapi` passes (exit 0); remaining output is the pre-existing example/description info+warning noise on `*Beneficiary` schemas.

## Review notes

- Scope generalized from outgoing-only to any bank-rail transfer (incl. ACH pulls / collections), and the 200 response switched to `TransactionOneOf` for future compatibility and consistency with the generic transaction path (per @shreyav's review + the requester).
- `CancelTransactionRequest.reason` is a free-form string mirroring `RejectPaymentRequest.reason` (platform-defined debugging/reference field) — not an enum, to avoid over-constraining integrators.
- Backend handling is a follow-up; a changelog entry should land when the endpoint is live end-to-end (mirroring how `approve`/`reject` are already in the spec ahead of their backend).

Requested by @aaryamanbhute
