### PR TITLE
feat(samples): add KYC onboarding flow to the sample app

### DIFF
--- a/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
+++ b/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
@@ -1,0 +1,593 @@
+# KYC Onboarding Sample Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "KYC Onboarding" flow to the Grid API sample app demonstrating the hosted KYC link: create customer → generate hosted link → track `kycStatus` via polling and webhooks.
+
+**Architecture:** Two thin proxy routes are added to the Kotlin (Ktor) backend that call the Grid Kotlin SDK (`getKycLink`, `retrieve`). The React frontend gains a three-step wizard flow reusing the existing `StepWizard`/`JsonEditor`/`ResponsePanel` components; the existing `WebhookStream` panel already surfaces `CUSTOMER.KYC_*` events.
+
+**Tech Stack:** Kotlin + Ktor + `com.lightspark.grid:lightspark-grid-kotlin:1.7.1` (backend); React 18 + TypeScript + Vite + Tailwind (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-07-21-kyc-sample-flow-design.md`
+
+## Global Constraints
+
+- All work happens in the worktree `/Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow` on branch `kyc-sample-flow` (Graphite-tracked, parent `main`). All paths below are relative to the worktree root.
+- Commits: stage files **individually by name** (never `git add -A`/`.`), commit with `gt modify --commit -m "<msg>"` (Graphite repo; keeps everything on this one branch). End every commit message with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Backend e2e tests hit the real Grid sandbox and require env vars `GRID_CLIENT_ID`, `GRID_CLIENT_SECRET`, `GRID_WEBHOOK_PUBKEY`. If they are not set in your shell, check the main clone's `samples/kotlin` run configuration or ask the user — do not fabricate values. If credentials are unavailable, `./gradlew build -x test` (compile only) is the fallback verification and the test run must be flagged as skipped in your report.
+- SDK naming gotcha: `CustomerGetKycLinkParams.Builder.platformCustomerId(...)` fills the `{customerId}` **path segment** of `POST /customers/{customerId}/kyc-link` despite its name. Pass the Grid customer ID (e.g. `Customer:0195...`) to it.
+- The frontend build (`npm run build`) runs `tsc -b` — it is the type-check gate. `node_modules` may be missing in the worktree; run `npm install` in `samples/frontend` first if so.
+
+---
+
+### Task 1: Backend routes — generate KYC link + retrieve customer
+
+**Files:**
+- Modify: `samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt`
+- Test: `samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt`
+
+**Interfaces:**
+- Consumes: existing helpers `GridClientBuilder.client`, `JsonUtils`, `Log`, `optText` (all already imported or importable in `Customers.kt`).
+- Produces (relied on by Tasks 2–3):
+  - `POST /api/customers/{customerId}/kyc-link` — body `{ "redirectUri"?: string }`; 201 with Grid's `CustomerGetKycLinkResponse` JSON (`kycUrl`, `expiresAt`, `provider`, `token?`); errors as `{"error": "..."}` with 500.
+  - `GET /api/customers/{customerId}` — 200 with the full customer JSON incl. `kycStatus`; errors as `{"error": "..."}` with 500.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `EndToEndTest.kt` (inside the `EndToEndTest` class, after the existing tests):
+
+```kotlin
+    @Test
+    fun `generate KYC link and retrieve customer`() = testApplication {
+        configureApp()
+
+        // Step 1: Create customer
+        val customerResponse = client.post("/api/customers") {
+            contentType(ContentType.Application.Json)
+            setBody("""
+                {
+                    "platformCustomerId": "test_kyc_${System.currentTimeMillis()}",
+                    "customerType": "INDIVIDUAL",
+                    "fullName": "Kyc Test User",
+                    "nationality": "US",
+                    "birthDate": "1990-01-01",
+                    "address": {
+                        "country": "US",
+                        "line1": "123 Test St",
+                        "postalCode": "10001",
+                        "city": "New York",
+                        "state": "NY"
+                    }
+                }
+            """)
+        }
+        assertEquals(HttpStatusCode.Created, customerResponse.status)
+        val customerId = parseJson(customerResponse.bodyAsText()).get("id").asText()
+
+        // Step 2: Generate a hosted KYC link
+        val linkResponse = client.post("/api/customers/$customerId/kyc-link") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"redirectUri": "http://localhost:5173/onboarding-complete"}""")
+        }
+        assertEquals(HttpStatusCode.Created, linkResponse.status)
+        val link = parseJson(linkResponse.bodyAsText())
+        assertNotNull(link.get("kycUrl")?.asText(), "Response should include kycUrl")
+        assertNotNull(link.get("expiresAt")?.asText(), "Response should include expiresAt")
+
+        // Step 3: Retrieve the customer and check kycStatus is present
+        val getResponse = client.get("/api/customers/$customerId")
+        assertEquals(HttpStatusCode.OK, getResponse.status)
+        val fetched = parseJson(getResponse.bodyAsText())
+        assertEquals(customerId, fetched.get("id")?.asText())
+        assertNotNull(fetched.get("kycStatus")?.asText(), "Customer should include kycStatus")
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd samples/kotlin && ./gradlew test --tests "*generate KYC*"
+```
+Expected: FAIL — the kyc-link POST returns 404 (route not registered), so the `assertEquals(HttpStatusCode.Created, linkResponse.status)` assertion fails with `expected: 201 Created, actual: 404 Not Found`. (Customer creation itself should succeed; if it fails with an auth error, the sandbox env vars are missing — see Global Constraints.)
+
+- [ ] **Step 3: Implement the routes**
+
+In `Customers.kt`, add one import (alphabetical position after the existing `customers` imports):
+
+```kotlin
+import com.lightspark.grid.models.customers.CustomerGetKycLinkParams
+```
+
+Then add the two handlers inside the existing `route("/api/customers") { ... }` block, after the existing `post { ... }` handler:
+
+```kotlin
+        get("/{customerId}") {
+            try {
+                val customerId = call.parameters["customerId"]
+                    ?: return@get call.respondText(
+                        """{"error": "customerId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+
+                Log.gridRequest("customers.retrieve", customerId)
+                val customer = GridClientBuilder.client.customers().retrieve(customerId)
+                val responseJson = JsonUtils.prettyPrint(customer)
+                Log.gridResponse("customers.retrieve", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("customers.retrieve", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        post("/{customerId}/kyc-link") {
+            try {
+                val customerId = call.parameters["customerId"]
+                    ?: return@post call.respondText(
+                        """{"error": "customerId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+
+                val body = call.receiveText()
+                Log.incoming("POST", "/api/customers/$customerId/kyc-link", body)
+                val json = if (body.isBlank()) {
+                    JsonUtils.mapper.createObjectNode()
+                } else {
+                    JsonUtils.mapper.readTree(body)
+                }
+
+                val params = CustomerGetKycLinkParams.builder()
+                    // Fills the {customerId} path segment (SDK names it platformCustomerId).
+                    .platformCustomerId(customerId)
+                    .apply {
+                        json.optText("redirectUri")?.let { redirectUri(it) }
+                    }
+                    .build()
+
+                Log.gridRequest("customers.getKycLink", customerId)
+                val link = GridClientBuilder.client.customers().getKycLink(params)
+                val responseJson = JsonUtils.prettyPrint(link)
+                Log.gridResponse("customers.getKycLink", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+            } catch (e: Exception) {
+                Log.gridError("customers.getKycLink", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+```
+
+Note: `customers().retrieve(customerId)` is the SDK's string-overload (`retrieve(String, RequestOptions = none)`); no params object needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd samples/kotlin && ./gradlew test --tests "*generate KYC*"
+```
+Expected: `BUILD SUCCESSFUL`, 1 test passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow
+git add samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
+gt modify --commit -m "feat(samples): add kyc-link and get-customer backend routes
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Frontend step — Generate KYC Link
+
+**Files:**
+- Create: `samples/frontend/src/steps/CreateKycLink.tsx`
+
+**Interfaces:**
+- Consumes: `apiPost` from `src/lib/api.ts`; `JsonEditor`, `ResponsePanel` components; backend route from Task 1.
+- Produces: `export default function CreateKycLink({ customerId, disabled, onComplete }: Props)` where `Props = { customerId: string | null; disabled: boolean; onComplete: (response: Record<string, unknown>) => void }`. Calls `onComplete` with the kyc-link response JSON on every successful generation. Used by Task 4.
+
+- [ ] **Step 1: Write the component**
+
+Create `samples/frontend/src/steps/CreateKycLink.tsx`:
+
+```tsx
+import { useState } from 'react'
+import JsonEditor from '../components/JsonEditor'
+import ResponsePanel from '../components/ResponsePanel'
+import { apiPost } from '../lib/api'
+
+const DEFAULT_BODY = JSON.stringify({
+  redirectUri: 'http://localhost:5173/onboarding-complete',
+}, null, 2)
+
+interface Props {
+  customerId: string | null
+  disabled: boolean
+  onComplete: (response: Record<string, unknown>) => void
+}
+
+export default function CreateKycLink({ customerId, disabled, onComplete }: Props) {
+  const [body, setBody] = useState(DEFAULT_BODY)
+  const [response, setResponse] = useState<string | null>(null)
+  const [kycUrl, setKycUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    setKycUrl(null)
+    try {
+      const data = await apiPost<Record<string, unknown>>(
+        `/api/customers/${customerId}/kyc-link`,
+        JSON.parse(body),
+      )
+      setResponse(JSON.stringify(data, null, 2))
+      setKycUrl(data.kycUrl as string)
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Generate a single-use hosted verification link for this customer. Each link expires —
+        re-run this step to mint a fresh one.
+      </p>
+      <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
+      <button
+        onClick={submit}
+        disabled={disabled || loading}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Generating...' : 'Generate KYC Link'}
+      </button>
+      {kycUrl && (
+        <p className="mt-3 text-sm">
+          <a
+            href={kycUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline break-all"
+          >
+            Open hosted KYC flow ↗
+          </a>
+        </p>
+      )}
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run:
+```bash
+cd samples/frontend && npm run build
+```
+Expected: `tsc -b` and `vite build` succeed. (`CreateKycLink` is not imported anywhere yet — that's fine; it only needs to compile.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow
+git add samples/frontend/src/steps/CreateKycLink.tsx
+gt modify --commit -m "feat(samples): add Generate KYC Link step component
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Frontend step — Track KYC Status
+
+**Files:**
+- Create: `samples/frontend/src/steps/CheckKycStatus.tsx`
+
+**Interfaces:**
+- Consumes: `apiGet` from `src/lib/api.ts`; `ResponsePanel`; backend GET route from Task 1.
+- Produces: `export default function CheckKycStatus({ customerId, disabled, onComplete }: Props)` with the same `Props` shape as Task 2. Calls `onComplete` exactly once, the first time a terminal `kycStatus` (`APPROVED` or `REJECTED`) is observed. Used by Task 4.
+
+- [ ] **Step 1: Write the component**
+
+Create `samples/frontend/src/steps/CheckKycStatus.tsx`:
+
+```tsx
+import { useState } from 'react'
+import ResponsePanel from '../components/ResponsePanel'
+import { apiGet } from '../lib/api'
+
+const STATUS_STYLES: Record<string, string> = {
+  APPROVED: 'bg-green-600/20 border-green-600/40 text-green-300',
+  PENDING: 'bg-amber-600/20 border-amber-600/40 text-amber-300',
+  REJECTED: 'bg-red-600/20 border-red-600/40 text-red-300',
+  HOLD: 'bg-red-600/20 border-red-600/40 text-red-300',
+  UNVERIFIED: 'bg-gray-600/20 border-gray-600/40 text-gray-300',
+}
+
+interface Props {
+  customerId: string | null
+  disabled: boolean
+  onComplete: (response: Record<string, unknown>) => void
+}
+
+export default function CheckKycStatus({ customerId, disabled, onComplete }: Props) {
+  const [status, setStatus] = useState<string | null>(null)
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [completed, setCompleted] = useState(false)
+
+  const refresh = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await apiGet<Record<string, unknown>>(`/api/customers/${customerId}`)
+      setResponse(JSON.stringify(data, null, 2))
+      const kycStatus = data.kycStatus as string | undefined
+      setStatus(kycStatus ?? null)
+      if (!completed && (kycStatus === 'APPROVED' || kycStatus === 'REJECTED')) {
+        setCompleted(true)
+        onComplete(data)
+      }
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Complete verification in the hosted flow (previous step), then refresh to poll the
+        customer&apos;s <code className="text-gray-300">kycStatus</code>. Status changes also
+        arrive live as <code className="text-gray-300">CUSTOMER.KYC_*</code> events in the
+        webhook panel below.
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={refresh}
+          disabled={disabled || loading}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+        >
+          {loading ? 'Refreshing...' : 'Refresh Status'}
+        </button>
+        {status && (
+          <span
+            className={`px-3 py-1 rounded border text-xs font-semibold tracking-wide ${
+              STATUS_STYLES[status] ?? STATUS_STYLES.UNVERIFIED
+            }`}
+          >
+            {status}
+          </span>
+        )}
+      </div>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run:
+```bash
+cd samples/frontend && npm run build
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow
+git add samples/frontend/src/steps/CheckKycStatus.tsx
+gt modify --commit -m "feat(samples): add Track KYC Status step component
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire up the KYC Onboarding flow
+
+**Files:**
+- Create: `samples/frontend/src/flows/KycOnboardingFlow.tsx`
+- Modify: `samples/frontend/src/components/Sidebar.tsx` (FlowKey union at line 1, FLOWS array)
+- Modify: `samples/frontend/src/App.tsx` (imports, FLOW_META, render switch)
+
+**Interfaces:**
+- Consumes: `CreateCustomer` (existing), `CreateKycLink` (Task 2), `CheckKycStatus` (Task 3), `StepWizard` (existing: takes `steps: { title, summary, content }[]` and `activeStep`).
+- Produces: sidebar flow key `'kyc-onboarding'`.
+
+- [ ] **Step 1: Write the flow component**
+
+Create `samples/frontend/src/flows/KycOnboardingFlow.tsx`. Note the deliberate `disabled` gating: steps 2 and 3 stay enabled once reached (`activeStep < n` rather than `!==`), so a user can regenerate an expired link or re-poll status at any time.
+
+```tsx
+import { useState } from 'react'
+import StepWizard from '../components/StepWizard'
+import CreateCustomer from '../steps/CreateCustomer'
+import CreateKycLink from '../steps/CreateKycLink'
+import CheckKycStatus from '../steps/CheckKycStatus'
+
+export default function KycOnboardingFlow() {
+  const [activeStep, setActiveStep] = useState(0)
+  const [customerId, setCustomerId] = useState<string | null>(null)
+  const [kycLinkGenerated, setKycLinkGenerated] = useState(false)
+  const [finalStatus, setFinalStatus] = useState<string | null>(null)
+
+  const steps = [
+    {
+      title: '1. Create Customer',
+      summary: customerId ? `ID: ${customerId}` : null,
+      content: (
+        <CreateCustomer
+          disabled={activeStep !== 0}
+          onComplete={(data) => {
+            setCustomerId(data.id as string)
+            setActiveStep(1)
+          }}
+        />
+      ),
+    },
+    {
+      title: '2. Generate KYC Link',
+      summary: kycLinkGenerated ? 'Link generated' : null,
+      content: (
+        <CreateKycLink
+          customerId={customerId}
+          disabled={activeStep < 1}
+          onComplete={() => {
+            setKycLinkGenerated(true)
+            setActiveStep((s) => Math.max(s, 2))
+          }}
+        />
+      ),
+    },
+    {
+      title: '3. Track KYC Status',
+      summary: finalStatus ? `Status: ${finalStatus}` : null,
+      content: (
+        <CheckKycStatus
+          customerId={customerId}
+          disabled={activeStep < 2}
+          onComplete={(data) => {
+            setFinalStatus(data.kycStatus as string)
+          }}
+        />
+      ),
+    },
+  ]
+
+  return <StepWizard steps={steps} activeStep={activeStep} />
+}
+```
+
+- [ ] **Step 2: Register the flow in the sidebar**
+
+In `samples/frontend/src/components/Sidebar.tsx`:
+
+Change line 1 to:
+```tsx
+export type FlowKey = 'payout' | 'usdc-payout' | 'exchange-rates' | 'embedded-wallet' | 'kyc-onboarding'
+```
+
+Add to the `FLOWS` array, after the `payout` entry (payouts context — KYC precedes payouts logically):
+```tsx
+  {
+    key: 'kyc-onboarding',
+    label: 'KYC Onboarding',
+    description: "Verify a customer's identity with a hosted KYC link",
+  },
+```
+
+- [ ] **Step 3: Register the flow in App.tsx**
+
+In `samples/frontend/src/App.tsx`:
+
+Add the import after the `PayoutFlow` import:
+```tsx
+import KycOnboardingFlow from './flows/KycOnboardingFlow'
+```
+
+Add to `FLOW_META` (after the `payout` entry):
+```tsx
+  'kyc-onboarding': {
+    title: 'KYC Onboarding',
+    subtitle: "Verify a customer's identity with a hosted KYC link",
+  },
+```
+
+Add to the render switch in `<main>` (after the `payout` line):
+```tsx
+          {activeFlow === 'kyc-onboarding' && <KycOnboardingFlow key="kyc-onboarding" />}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run:
+```bash
+cd samples/frontend && npm run build
+```
+Expected: build succeeds. (TypeScript's exhaustive `Record<FlowKey, ...>` on `FLOW_META` is the safety net — if the new key were missing there, `tsc` would fail.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow
+git add samples/frontend/src/flows/KycOnboardingFlow.tsx samples/frontend/src/components/Sidebar.tsx samples/frontend/src/App.tsx
+gt modify --commit -m "feat(samples): add KYC Onboarding flow to sample frontend
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: README contract table + full verification
+
+**Files:**
+- Modify: `samples/README.md` (API contract table)
+
+**Interfaces:**
+- Consumes: routes from Task 1.
+- Produces: documentation only.
+
+- [ ] **Step 1: Update the API contract table**
+
+In `samples/README.md`, add two rows to the "Adding a New Language Backend" table, after the `POST /api/customers` row:
+
+```markdown
+| GET  | `/api/customers/{id}` | Get a customer (incl. `kycStatus`) |
+| POST | `/api/customers/{id}/kyc-link` | Generate a hosted KYC link |
+```
+
+- [ ] **Step 2: Full verification**
+
+Run both builds from the worktree root:
+```bash
+cd samples/kotlin && ./gradlew build
+cd ../frontend && npm run build
+```
+Expected: both succeed. `./gradlew build` runs the e2e tests — if sandbox credentials are unavailable, run `./gradlew build -x test` and flag it (see Global Constraints).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow
+git add samples/README.md
+gt modify --commit -m "docs(samples): document kyc-link and get-customer endpoints in API contract
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Manual acceptance check (after all tasks)
+
+Not automatable — walk once by hand:
+
+1. `cd samples/kotlin && ./gradlew run` (backend on :8080) and `cd samples/frontend && npm run dev` (frontend on :5173).
+2. Select **KYC Onboarding** in the sidebar; create the default customer.
+3. Generate the KYC link; click it — the hosted (sandbox SUMSUB) flow opens in a new tab.
+4. Refresh status in step 3 — badge shows `PENDING`; complete or abandon the hosted flow and observe badge/webhook updates (`CUSTOMER.KYC_*` in the WebhookStream panel).

--- a/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
+++ b/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
@@ -15,7 +15,8 @@
 - All work happens in the worktree `/Users/pengying/Src/grid-api/.worktrees/kyc-sample-flow` on branch `kyc-sample-flow` (Graphite-tracked, parent `main`). All paths below are relative to the worktree root.
 - Commits: stage files **individually by name** (never `git add -A`/`.`), commit with `gt modify --commit -m "<msg>"` (Graphite repo; keeps everything on this one branch). End every commit message with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
 - Backend e2e tests hit the real Grid sandbox and require env vars `GRID_CLIENT_ID`, `GRID_CLIENT_SECRET`, `GRID_WEBHOOK_PUBKEY`. If they are not set in your shell, check the main clone's `samples/kotlin` run configuration or ask the user — do not fabricate values. If credentials are unavailable, `./gradlew build -x test` (compile only) is the fallback verification and the test run must be flagged as skipped in your report.
-- SDK naming gotcha: `CustomerGetKycLinkParams.Builder.platformCustomerId(...)` fills the `{customerId}` **path segment** of `POST /customers/{customerId}/kyc-link` despite its name. Pass the Grid customer ID (e.g. `Customer:0195...`) to it.
+- SDK gotcha (verified by capturing the SDK's raw HTTP request): SDK 1.7.1's `getKycLink` sends `GET /customers/kyc-link?platformCustomerId=...` — an obsolete endpoint shape the current API does not serve (it matches `GET /customers/{id}` with id="kyc-link" → 404 CUSTOMER_NOT_FOUND). Upgrading to SDK 1.8/1.9 fixes the path but breaks 4 other sample route files (84 compile errors) — out of scope. The kyc-link route therefore calls the REST endpoint directly with JDK `java.net.http.HttpClient` (no new dependency). `customers().retrieve(id)` builds the correct path and stays on the SDK.
+- Environment facts verified via curl against the dev sandbox: `email` is required on customer create (platform supports embedded wallets); `redirectUri` on kyc-link must be a public https URL (provider rejects http:// and localhost), so the sample omits it; this platform creates customers with `kycStatus: APPROVED` (regulated-platform behavior).
 - The frontend build (`npm run build`) runs `tsc -b` — it is the type-check gate. `node_modules` may be missing in the worktree; run `npm install` in `samples/frontend` first if so.
 
 ---
@@ -29,7 +30,7 @@
 **Interfaces:**
 - Consumes: existing helpers `GridClientBuilder.client`, `JsonUtils`, `Log`, `optText` (all already imported or importable in `Customers.kt`).
 - Produces (relied on by Tasks 2–3):
-  - `POST /api/customers/{customerId}/kyc-link` — body `{ "redirectUri"?: string }`; 201 with Grid's `CustomerGetKycLinkResponse` JSON (`kycUrl`, `expiresAt`, `provider`, `token?`); errors as `{"error": "..."}` with 500.
+  - `POST /api/customers/{customerId}/kyc-link` — body `{ "redirectUri"?: string }`; 201 with Grid's KYC link JSON (`kycUrl`, `expiresAt`, `provider`, `token?`); Grid API errors pass through with their original status (400/404/409); transport errors as `{"error": "..."}` with 500.
   - `GET /api/customers/{customerId}` — 200 with the full customer JSON incl. `kycStatus`; errors as `{"error": "..."}` with 500.
 
 - [ ] **Step 1: Write the failing test**
@@ -49,6 +50,7 @@ Append to `EndToEndTest.kt` (inside the `EndToEndTest` class, after the existing
                     "platformCustomerId": "test_kyc_${System.currentTimeMillis()}",
                     "customerType": "INDIVIDUAL",
                     "fullName": "Kyc Test User",
+                    "email": "kyctest.${System.currentTimeMillis()}@lightspark.com",
                     "nationality": "US",
                     "birthDate": "1990-01-01",
                     "address": {
@@ -64,10 +66,11 @@ Append to `EndToEndTest.kt` (inside the `EndToEndTest` class, after the existing
         assertEquals(HttpStatusCode.Created, customerResponse.status)
         val customerId = parseJson(customerResponse.bodyAsText()).get("id").asText()
 
-        // Step 2: Generate a hosted KYC link
+        // Step 2: Generate a hosted KYC link. No redirectUri: the KYC provider
+        // requires a public https URL, which a local sample doesn't have.
         val linkResponse = client.post("/api/customers/$customerId/kyc-link") {
             contentType(ContentType.Application.Json)
-            setBody("""{"redirectUri": "http://localhost:5173/onboarding-complete"}""")
+            setBody("""{}""")
         }
         assertEquals(HttpStatusCode.Created, linkResponse.status)
         val link = parseJson(linkResponse.bodyAsText())
@@ -93,10 +96,24 @@ Expected: FAIL — the kyc-link POST returns 404 (route not registered), so the 
 
 - [ ] **Step 3: Implement the routes**
 
-In `Customers.kt`, add one import (alphabetical position after the existing `customers` imports):
+In `Customers.kt`, add these imports (JDK HTTP client for the kyc-link call — see the SDK gotcha in Global Constraints; `com.grid.sample.Config` goes with the other `com.grid.sample` imports, `java.*` at the bottom):
 
 ```kotlin
-import com.lightspark.grid.models.customers.CustomerGetKycLinkParams
+import com.grid.sample.Config
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Base64
+```
+
+And a file-level constant + client below the imports, above `fun Route.customerRoutes()`:
+
+```kotlin
+// SDK 1.7.1 predates the current POST /customers/{id}/kyc-link endpoint shape,
+// so the kyc-link route below calls the REST API directly.
+private val DEFAULT_GRID_API_BASE_URL = "https://api.lightspark.com/grid/2025-10-13"
+private val kycHttpClient: HttpClient by lazy { HttpClient.newHttpClient() }
 ```
 
 Then add the two handlers inside the existing `route("/api/customers") { ... }` block, after the existing `post { ... }` handler:
@@ -136,30 +153,31 @@ Then add the two handlers inside the existing `route("/api/customers") { ... }` 
                         HttpStatusCode.BadRequest
                     )
 
-                val body = call.receiveText()
+                val body = call.receiveText().ifBlank { "{}" }
                 Log.incoming("POST", "/api/customers/$customerId/kyc-link", body)
-                val json = if (body.isBlank()) {
-                    JsonUtils.mapper.createObjectNode()
-                } else {
-                    JsonUtils.mapper.readTree(body)
-                }
 
-                val params = CustomerGetKycLinkParams.builder()
-                    // Fills the {customerId} path segment (SDK names it platformCustomerId).
-                    .platformCustomerId(customerId)
-                    .apply {
-                        json.optText("redirectUri")?.let { redirectUri(it) }
-                    }
+                val baseUrl = Config.apiBaseUrl ?: DEFAULT_GRID_API_BASE_URL
+                val auth = Base64.getEncoder()
+                    .encodeToString("${Config.apiTokenId}:${Config.apiClientSecret}".toByteArray())
+                val request = HttpRequest.newBuilder()
+                    .uri(URI.create("$baseUrl/customers/$customerId/kyc-link"))
+                    .header("Authorization", "Basic $auth")
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
                     .build()
 
-                Log.gridRequest("customers.getKycLink", customerId)
-                val link = GridClientBuilder.client.customers().getKycLink(params)
-                val responseJson = JsonUtils.prettyPrint(link)
-                Log.gridResponse("customers.getKycLink", responseJson)
+                Log.gridRequest("customers.kycLink", body)
+                val response = kycHttpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                Log.gridResponse("customers.kycLink", response.body())
 
-                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+                // Pass Grid's status through (201 on success; 400/404/409 errors verbatim).
+                call.respondText(
+                    response.body(),
+                    ContentType.Application.Json,
+                    HttpStatusCode.fromValue(response.statusCode())
+                )
             } catch (e: Exception) {
-                Log.gridError("customers.getKycLink", e)
+                Log.gridError("customers.kycLink", e)
                 call.respondText(
                     """{"error": "${e.message}"}""",
                     ContentType.Application.Json,
@@ -169,7 +187,7 @@ Then add the two handlers inside the existing `route("/api/customers") { ... }` 
         }
 ```
 
-Note: `customers().retrieve(customerId)` is the SDK's string-overload (`retrieve(String, RequestOptions = none)`); no params object needed.
+Note: `customers().retrieve(customerId)` is the SDK's string-overload (`retrieve(String, RequestOptions = none)`); no params object needed. The kyc-link handler deliberately does NOT use the SDK — see the SDK gotcha in Global Constraints.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -210,9 +228,9 @@ import JsonEditor from '../components/JsonEditor'
 import ResponsePanel from '../components/ResponsePanel'
 import { apiPost } from '../lib/api'
 
-const DEFAULT_BODY = JSON.stringify({
-  redirectUri: 'http://localhost:5173/onboarding-complete',
-}, null, 2)
+// redirectUri is optional and must be a public https URL (the KYC provider
+// rejects http:// and localhost), so the local sample omits it by default.
+const DEFAULT_BODY = '{}'
 
 interface Props {
   customerId: string | null
@@ -251,7 +269,8 @@ export default function CreateKycLink({ customerId, disabled, onComplete }: Prop
     <div>
       <p className="text-sm text-gray-400 mb-2">
         Generate a single-use hosted verification link for this customer. Each link expires —
-        re-run this step to mint a fresh one.
+        re-run this step to mint a fresh one. Optionally set <code className="text-gray-300">redirectUri</code>{' '}
+        to return the customer to your app afterwards (must be a public https URL).
       </p>
       <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
       <button
@@ -590,4 +609,4 @@ Not automatable — walk once by hand:
 1. `cd samples/kotlin && ./gradlew run` (backend on :8080) and `cd samples/frontend && npm run dev` (frontend on :5173).
 2. Select **KYC Onboarding** in the sidebar; create the default customer.
 3. Generate the KYC link; click it — the hosted (sandbox SUMSUB) flow opens in a new tab.
-4. Refresh status in step 3 — badge shows `PENDING`; complete or abandon the hosted flow and observe badge/webhook updates (`CUSTOMER.KYC_*` in the WebhookStream panel).
+4. Refresh status in step 3 — on unregulated platforms the badge shows `PENDING` until the hosted flow completes; on regulated/dev platforms (like the checked-in dev credentials) customers are created `APPROVED`, so the badge is green immediately. `CUSTOMER.KYC_*` webhooks appear in the WebhookStream panel when status changes.

--- a/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
+++ b/docs/superpowers/plans/2026-07-21-kyc-sample-flow.md
@@ -246,6 +246,7 @@ export default function CreateKycLink({ customerId, disabled, onComplete }: Prop
   const [loading, setLoading] = useState(false)
 
   const submit = async () => {
+    if (!customerId) return
     setLoading(true)
     setError(null)
     setResponse(null)
@@ -358,6 +359,7 @@ export default function CheckKycStatus({ customerId, disabled, onComplete }: Pro
   const [completed, setCompleted] = useState(false)
 
   const refresh = async () => {
+    if (!customerId) return
     setLoading(true)
     setError(null)
     try {

--- a/docs/superpowers/specs/2026-07-21-kyc-sample-flow-design.md
+++ b/docs/superpowers/specs/2026-07-21-kyc-sample-flow-design.md
@@ -1,0 +1,108 @@
+# KYC Onboarding Flow for the Grid API Sample — Design
+
+**Date:** 2026-07-21
+**Status:** Approved approach (A) — hosted KYC link, new sidebar flow
+
+## Goal
+
+Add a "KYC Onboarding" flow to the sample app (`samples/`) demonstrating the hosted
+KYC link integration: create a customer, generate a hosted verification link, and
+track the customer's `kycStatus` to a terminal state via both polling and webhooks.
+
+## Background
+
+The sample app is a React step-wizard frontend (`samples/frontend`) backed by a
+Kotlin (Ktor) proxy (`samples/kotlin`) that calls the Grid API via the Kotlin SDK
+(`com.lightspark.grid:lightspark-grid-kotlin:1.7.1`). Webhook events from Grid are
+already streamed to the browser via SSE and shown in the `WebhookStream` panel.
+
+The Grid API's hosted KYC flow is two calls:
+
+1. `POST /customers` — create the customer (`kycStatus` starts `PENDING`).
+2. `POST /customers/{customerId}/kyc-link` — returns a single-use `kycUrl`,
+   `expiresAt`, `provider`, and (for SUMSUB) an SDK `token`.
+
+The customer completes verification at `kycUrl`; status changes arrive as
+`CUSTOMER.KYC_PENDING` / `CUSTOMER.KYC_APPROVED` / `CUSTOMER.KYC_REJECTED` webhooks
+and are readable at any time via `GET /customers/{customerId}`.
+
+The Kotlin SDK 1.7.1 exposes both operations: `customers().getKycLink(...)` and
+`customers().retrieve(...)`.
+
+## Design
+
+### Frontend (`samples/frontend`)
+
+New flow `src/flows/KycOnboardingFlow.tsx`, registered in `App.tsx` (`FLOW_META`)
+and `components/Sidebar.tsx` with key `kyc-onboarding`, title "KYC Onboarding",
+subtitle along the lines of "Verify a customer's identity with a hosted KYC link".
+
+Three steps, following the existing `StepWizard` pattern:
+
+1. **Create Customer** — reuses the existing `steps/CreateCustomer.tsx` component
+   unchanged.
+2. **Generate KYC Link** — new `steps/CreateKycLink.tsx`. Editable JSON body
+   defaulting to `{ "redirectUri": "http://localhost:5173/onboarding-complete" }`.
+   Calls `POST /api/customers/{id}/kyc-link`. On success renders:
+   - `kycUrl` as a clickable link (opens in a new tab),
+   - `provider`, `expiresAt`, and `token` (when present) in the response panel,
+   - helper text: the link is single-use; re-run the step to mint a fresh one.
+3. **Track KYC Status** — new `steps/CheckKycStatus.tsx`. A "Refresh Status"
+   button calls `GET /api/customers/{id}` and renders the current `kycStatus` as a
+   colored badge (`PENDING` amber, `APPROVED` green, `REJECTED`/`HOLD` red,
+   `UNVERIFIED` gray) plus the full customer JSON. Helper text points at the
+   WebhookStream panel, where `CUSTOMER.KYC_*` events appear live. The step (and
+   the flow) completes when a terminal status (`APPROVED`/`REJECTED`) is observed;
+   refreshing remains available regardless.
+
+`src/lib/api.ts` already provides `apiGet` and `apiPost`; no changes needed there.
+
+### Backend (`samples/kotlin`)
+
+Two new routes following the existing pattern in `routes/Customers.kt`
+(receive JSON → build SDK params → log request/response → return pretty JSON):
+
+- `POST /api/customers/{id}/kyc-link` — optional body with `redirectUri`; calls
+  `customers().getKycLink(...)`; returns the SDK response (201).
+- `GET /api/customers/{id}` — calls `customers().retrieve(...)`; returns the
+  customer JSON (200).
+
+Both live in `routes/Customers.kt` alongside the existing create route. Errors
+follow the existing pattern: log via `Log.gridError` and return
+`{"error": "..."}` with a 500 (the Grid error message passes through verbatim,
+so a 409 for required contact verification is visible to the user).
+
+### Docs
+
+`samples/README.md` API-contract table gains:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/customers/{id}/kyc-link` | Generate a hosted KYC link |
+| GET  | `/api/customers/{id}` | Get a customer (incl. `kycStatus`) |
+
+### Out of scope
+
+- **Contact verification** (`verify-email` / `verify-phone`). The default sample
+  customer is US-based and does not require it. If Grid returns the 409, the step
+  surfaces the error message verbatim — that is the intended behavior.
+- **API-driven verification** (`POST /verifications`, beneficial owners,
+  documents / KYB). A candidate follow-up flow.
+- **Embedding the SUMSUB SDK** via the returned `token` — the sample links out to
+  the hosted URL only, but displays the token so developers can see it exists.
+
+## Error handling
+
+- Backend passes Grid API error messages through to the frontend (existing
+  pattern); the frontend `ResponsePanel` already renders errors.
+- The KYC link being single-use/expired is handled by re-running step 2.
+- A missed webhook does not dead-end the flow: step 3's polling always works.
+
+## Testing
+
+- Manual: run the Kotlin backend + Vite frontend against sandbox, walk the flow,
+  open the `kycUrl`, and confirm the status badge and webhook events update.
+- The existing Playwright e2e (`e2e/payout-flow.spec.ts`) is untouched. A new e2e
+  spec is not included: completing the hosted provider flow is an external
+  interaction that can't be automated reliably from the sample. Step-level
+  behavior (link rendered, status refresh) is verified manually.

--- a/samples/README.md
+++ b/samples/README.md
@@ -21,6 +21,8 @@ Each backend must implement the same API contract:
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/customers` | Create a customer |
+| GET  | `/api/customers/{id}` | Get a customer (incl. `kycStatus`) |
+| POST | `/api/customers/{id}/kyc-link` | Generate a hosted KYC link |
 | POST | `/api/customers/{id}/external-accounts` | Create an external account |
 | POST | `/api/quotes` | Create a quote |
 | POST | `/api/sandbox/send-funds` | Simulate sandbox funding |

--- a/samples/frontend/src/App.tsx
+++ b/samples/frontend/src/App.tsx
@@ -5,11 +5,16 @@ import PayoutFlow from './flows/PayoutFlow'
 import UsdcPayoutFlow from './flows/UsdcPayoutFlow'
 import ExchangeRatesFlow from './flows/ExchangeRatesFlow'
 import EmbeddedWalletFlow from './flows/EmbeddedWalletFlow'
+import KycOnboardingFlow from './flows/KycOnboardingFlow'
 
 const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
   payout: {
     title: 'Payout to Bank Account',
     subtitle: 'Send a real time payment funded with USDC',
+  },
+  'kyc-onboarding': {
+    title: 'KYC Onboarding',
+    subtitle: "Verify a customer's identity with a hosted KYC link",
   },
   'usdc-payout': {
     title: 'Send USDC to a Wallet',
@@ -40,6 +45,7 @@ export default function App() {
         <main className="flex-1 p-6 min-h-[calc(100vh-73px)] max-w-5xl">
           <h2 className="text-lg font-semibold mb-4">{meta.title}</h2>
           {activeFlow === 'payout' && <PayoutFlow key="payout" />}
+          {activeFlow === 'kyc-onboarding' && <KycOnboardingFlow key="kyc-onboarding" />}
           {activeFlow === 'usdc-payout' && <UsdcPayoutFlow key="usdc-payout" />}
           {activeFlow === 'exchange-rates' && <ExchangeRatesFlow key="exchange-rates" />}
           {activeFlow === 'embedded-wallet' && <EmbeddedWalletFlow key="embedded-wallet" />}

--- a/samples/frontend/src/App.tsx
+++ b/samples/frontend/src/App.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import Sidebar, { FlowKey } from './components/Sidebar'
 import WebhookStream from './components/WebhookStream'
 import PayoutFlow from './flows/PayoutFlow'
+import KycOnboardingFlow from './flows/KycOnboardingFlow'
 import UsdcPayoutFlow from './flows/UsdcPayoutFlow'
 import ExchangeRatesFlow from './flows/ExchangeRatesFlow'
 import EmbeddedWalletFlow from './flows/EmbeddedWalletFlow'
-import KycOnboardingFlow from './flows/KycOnboardingFlow'
 
 const FLOW_META: Record<FlowKey, { title: string; subtitle: string }> = {
   payout: {

--- a/samples/frontend/src/components/Sidebar.tsx
+++ b/samples/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-export type FlowKey = 'payout' | 'usdc-payout' | 'exchange-rates' | 'embedded-wallet'
+export type FlowKey = 'payout' | 'usdc-payout' | 'exchange-rates' | 'embedded-wallet' | 'kyc-onboarding'
 
 interface FlowEntry {
   key: FlowKey
@@ -16,6 +16,11 @@ const FLOWS: FlowEntry[] = [
     key: 'payout',
     label: 'Payout to Bank Account',
     description: 'Send a real-time payment funded with USDC',
+  },
+  {
+    key: 'kyc-onboarding',
+    label: 'KYC Onboarding',
+    description: "Verify a customer's identity with a hosted KYC link",
   },
   {
     key: 'usdc-payout',

--- a/samples/frontend/src/components/Sidebar.tsx
+++ b/samples/frontend/src/components/Sidebar.tsx
@@ -13,14 +13,14 @@ const FLOWS: FlowEntry[] = [
     description: 'Look up FX rates and fees for a corridor',
   },
   {
-    key: 'payout',
-    label: 'Payout to Bank Account',
-    description: 'Send a real-time payment funded with USDC',
-  },
-  {
     key: 'kyc-onboarding',
     label: 'KYC Onboarding',
     description: "Verify a customer's identity with a hosted KYC link",
+  },
+  {
+    key: 'payout',
+    label: 'Payout to Bank Account',
+    description: 'Send a real-time payment funded with USDC',
   },
   {
     key: 'usdc-payout',

--- a/samples/frontend/src/flows/KycOnboardingFlow.tsx
+++ b/samples/frontend/src/flows/KycOnboardingFlow.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react'
 import StepWizard from '../components/StepWizard'
 import CreateCustomer from '../steps/CreateCustomer'
 import CreateKycLink from '../steps/CreateKycLink'
+import OpenKycLink from '../steps/OpenKycLink'
 import CheckKycStatus from '../steps/CheckKycStatus'
 
 export default function KycOnboardingFlow() {
   const [activeStep, setActiveStep] = useState(0)
   const [customerId, setCustomerId] = useState<string | null>(null)
-  const [kycLinkGenerated, setKycLinkGenerated] = useState(false)
   const [kycUrl, setKycUrl] = useState<string | null>(null)
+  const [expiresAt, setExpiresAt] = useState<string | null>(null)
   const [finalStatus, setFinalStatus] = useState<string | null>(null)
 
   const steps = [
@@ -27,26 +28,38 @@ export default function KycOnboardingFlow() {
     },
     {
       title: '2. Generate KYC Link',
-      summary: kycLinkGenerated ? 'Link generated' : null,
+      summary: kycUrl ? 'Link generated' : null,
       content: (
         <CreateKycLink
           customerId={customerId}
           disabled={activeStep < 1}
           onComplete={(data) => {
-            setKycLinkGenerated(true)
             setKycUrl((data.kycUrl as string) ?? null)
+            setExpiresAt((data.expiresAt as string) ?? null)
             setActiveStep((s) => Math.max(s, 2))
           }}
         />
       ),
     },
     {
-      title: '3. Track KYC Status',
+      title: '3. Complete Hosted Verification',
+      summary: kycUrl,
+      content: (
+        <OpenKycLink
+          kycUrl={kycUrl}
+          expiresAt={expiresAt}
+          disabled={activeStep < 2}
+          onComplete={() => setActiveStep((s) => Math.max(s, 3))}
+        />
+      ),
+    },
+    {
+      title: '4. Track KYC Status',
       summary: finalStatus ? `Status: ${finalStatus}` : null,
       content: (
         <CheckKycStatus
           customerId={customerId}
-          disabled={activeStep < 2}
+          disabled={activeStep < 3}
           onComplete={(data) => {
             setFinalStatus(data.kycStatus as string)
           }}
@@ -55,22 +68,5 @@ export default function KycOnboardingFlow() {
     },
   ]
 
-  return (
-    <>
-      <StepWizard steps={steps} activeStep={activeStep} />
-      {kycUrl && (
-        <p className="mt-4 text-sm text-gray-400">
-          Hosted KYC link:{' '}
-          <a
-            href={kycUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-400 hover:text-blue-300 underline break-all"
-          >
-            {kycUrl}
-          </a>
-        </p>
-      )}
-    </>
-  )
+  return <StepWizard steps={steps} activeStep={activeStep} />
 }

--- a/samples/frontend/src/flows/KycOnboardingFlow.tsx
+++ b/samples/frontend/src/flows/KycOnboardingFlow.tsx
@@ -8,6 +8,7 @@ export default function KycOnboardingFlow() {
   const [activeStep, setActiveStep] = useState(0)
   const [customerId, setCustomerId] = useState<string | null>(null)
   const [kycLinkGenerated, setKycLinkGenerated] = useState(false)
+  const [kycUrl, setKycUrl] = useState<string | null>(null)
   const [finalStatus, setFinalStatus] = useState<string | null>(null)
 
   const steps = [
@@ -31,8 +32,9 @@ export default function KycOnboardingFlow() {
         <CreateKycLink
           customerId={customerId}
           disabled={activeStep < 1}
-          onComplete={() => {
+          onComplete={(data) => {
             setKycLinkGenerated(true)
+            setKycUrl((data.kycUrl as string) ?? null)
             setActiveStep((s) => Math.max(s, 2))
           }}
         />
@@ -53,5 +55,22 @@ export default function KycOnboardingFlow() {
     },
   ]
 
-  return <StepWizard steps={steps} activeStep={activeStep} />
+  return (
+    <>
+      <StepWizard steps={steps} activeStep={activeStep} />
+      {kycUrl && (
+        <p className="mt-4 text-sm text-gray-400">
+          Hosted KYC link:{' '}
+          <a
+            href={kycUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline break-all"
+          >
+            {kycUrl}
+          </a>
+        </p>
+      )}
+    </>
+  )
 }

--- a/samples/frontend/src/flows/KycOnboardingFlow.tsx
+++ b/samples/frontend/src/flows/KycOnboardingFlow.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import StepWizard from '../components/StepWizard'
+import CreateCustomer from '../steps/CreateCustomer'
+import CreateKycLink from '../steps/CreateKycLink'
+import CheckKycStatus from '../steps/CheckKycStatus'
+
+export default function KycOnboardingFlow() {
+  const [activeStep, setActiveStep] = useState(0)
+  const [customerId, setCustomerId] = useState<string | null>(null)
+  const [kycLinkGenerated, setKycLinkGenerated] = useState(false)
+  const [finalStatus, setFinalStatus] = useState<string | null>(null)
+
+  const steps = [
+    {
+      title: '1. Create Customer',
+      summary: customerId ? `ID: ${customerId}` : null,
+      content: (
+        <CreateCustomer
+          disabled={activeStep !== 0}
+          onComplete={(data) => {
+            setCustomerId(data.id as string)
+            setActiveStep(1)
+          }}
+        />
+      ),
+    },
+    {
+      title: '2. Generate KYC Link',
+      summary: kycLinkGenerated ? 'Link generated' : null,
+      content: (
+        <CreateKycLink
+          customerId={customerId}
+          disabled={activeStep < 1}
+          onComplete={() => {
+            setKycLinkGenerated(true)
+            setActiveStep((s) => Math.max(s, 2))
+          }}
+        />
+      ),
+    },
+    {
+      title: '3. Track KYC Status',
+      summary: finalStatus ? `Status: ${finalStatus}` : null,
+      content: (
+        <CheckKycStatus
+          customerId={customerId}
+          disabled={activeStep < 2}
+          onComplete={(data) => {
+            setFinalStatus(data.kycStatus as string)
+          }}
+        />
+      ),
+    },
+  ]
+
+  return <StepWizard steps={steps} activeStep={activeStep} />
+}

--- a/samples/frontend/src/steps/CheckKycStatus.tsx
+++ b/samples/frontend/src/steps/CheckKycStatus.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import ResponsePanel from '../components/ResponsePanel'
+import { apiGet } from '../lib/api'
+
+const STATUS_STYLES: Record<string, string> = {
+  APPROVED: 'bg-green-600/20 border-green-600/40 text-green-300',
+  PENDING: 'bg-amber-600/20 border-amber-600/40 text-amber-300',
+  REJECTED: 'bg-red-600/20 border-red-600/40 text-red-300',
+  HOLD: 'bg-red-600/20 border-red-600/40 text-red-300',
+  UNVERIFIED: 'bg-gray-600/20 border-gray-600/40 text-gray-300',
+}
+
+interface Props {
+  customerId: string | null
+  disabled: boolean
+  onComplete: (response: Record<string, unknown>) => void
+}
+
+export default function CheckKycStatus({ customerId, disabled, onComplete }: Props) {
+  const [status, setStatus] = useState<string | null>(null)
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [completed, setCompleted] = useState(false)
+
+  const refresh = async () => {
+    if (!customerId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await apiGet<Record<string, unknown>>(`/api/customers/${customerId}`)
+      setResponse(JSON.stringify(data, null, 2))
+      const kycStatus = data.kycStatus as string | undefined
+      setStatus(kycStatus ?? null)
+      if (!completed && (kycStatus === 'APPROVED' || kycStatus === 'REJECTED')) {
+        setCompleted(true)
+        onComplete(data)
+      }
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Complete verification in the hosted flow (previous step), then refresh to poll the
+        customer&apos;s <code className="text-gray-300">kycStatus</code>. Status changes also
+        arrive live as <code className="text-gray-300">CUSTOMER.KYC_*</code> events in the
+        webhook panel below.
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={refresh}
+          disabled={disabled || loading}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+        >
+          {loading ? 'Refreshing...' : 'Refresh Status'}
+        </button>
+        {status && (
+          <span
+            className={`px-3 py-1 rounded border text-xs font-semibold tracking-wide ${
+              STATUS_STYLES[status] ?? STATUS_STYLES.UNVERIFIED
+            }`}
+          >
+            {status}
+          </span>
+        )}
+      </div>
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/CreateKycLink.tsx
+++ b/samples/frontend/src/steps/CreateKycLink.tsx
@@ -21,6 +21,7 @@ export default function CreateKycLink({ customerId, disabled, onComplete }: Prop
   const [loading, setLoading] = useState(false)
 
   const submit = async () => {
+    if (!customerId) return
     setLoading(true)
     setError(null)
     setResponse(null)

--- a/samples/frontend/src/steps/CreateKycLink.tsx
+++ b/samples/frontend/src/steps/CreateKycLink.tsx
@@ -1,11 +1,6 @@
 import { useState } from 'react'
-import JsonEditor from '../components/JsonEditor'
 import ResponsePanel from '../components/ResponsePanel'
 import { apiPost } from '../lib/api'
-
-// redirectUri is optional and must be a public https URL (the KYC provider
-// rejects http:// and localhost), so the local sample omits it by default.
-const DEFAULT_BODY = '{}'
 
 interface Props {
   customerId: string | null
@@ -14,9 +9,7 @@ interface Props {
 }
 
 export default function CreateKycLink({ customerId, disabled, onComplete }: Props) {
-  const [body, setBody] = useState(DEFAULT_BODY)
   const [response, setResponse] = useState<string | null>(null)
-  const [kycUrl, setKycUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -25,14 +18,11 @@ export default function CreateKycLink({ customerId, disabled, onComplete }: Prop
     setLoading(true)
     setError(null)
     setResponse(null)
-    setKycUrl(null)
     try {
-      const data = await apiPost<Record<string, unknown>>(
-        `/api/customers/${customerId}/kyc-link`,
-        JSON.parse(body),
-      )
+      // No request body: redirectUri is optional and must be a public https URL
+      // (the KYC provider rejects http:// and localhost), so the local sample omits it.
+      const data = await apiPost<Record<string, unknown>>(`/api/customers/${customerId}/kyc-link`)
       setResponse(JSON.stringify(data, null, 2))
-      setKycUrl(data.kycUrl as string)
       onComplete(data)
     } catch (e) {
       setError((e as Error).message)
@@ -45,29 +35,15 @@ export default function CreateKycLink({ customerId, disabled, onComplete }: Prop
     <div>
       <p className="text-sm text-gray-400 mb-2">
         Generate a single-use hosted verification link for this customer. Each link expires —
-        re-run this step to mint a fresh one. Optionally set <code className="text-gray-300">redirectUri</code>{' '}
-        to return the customer to your app afterwards (must be a public https URL).
+        re-run this step to mint a fresh one.
       </p>
-      <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
       <button
         onClick={submit}
         disabled={disabled || loading}
-        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
       >
         {loading ? 'Generating...' : 'Generate KYC Link'}
       </button>
-      {kycUrl && (
-        <p className="mt-3 text-sm">
-          <a
-            href={kycUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-400 hover:text-blue-300 underline break-all"
-          >
-            Open hosted KYC flow ↗
-          </a>
-        </p>
-      )}
       <ResponsePanel response={response} error={error} />
     </div>
   )

--- a/samples/frontend/src/steps/CreateKycLink.tsx
+++ b/samples/frontend/src/steps/CreateKycLink.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import JsonEditor from '../components/JsonEditor'
+import ResponsePanel from '../components/ResponsePanel'
+import { apiPost } from '../lib/api'
+
+// redirectUri is optional and must be a public https URL (the KYC provider
+// rejects http:// and localhost), so the local sample omits it by default.
+const DEFAULT_BODY = '{}'
+
+interface Props {
+  customerId: string | null
+  disabled: boolean
+  onComplete: (response: Record<string, unknown>) => void
+}
+
+export default function CreateKycLink({ customerId, disabled, onComplete }: Props) {
+  const [body, setBody] = useState(DEFAULT_BODY)
+  const [response, setResponse] = useState<string | null>(null)
+  const [kycUrl, setKycUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const submit = async () => {
+    setLoading(true)
+    setError(null)
+    setResponse(null)
+    setKycUrl(null)
+    try {
+      const data = await apiPost<Record<string, unknown>>(
+        `/api/customers/${customerId}/kyc-link`,
+        JSON.parse(body),
+      )
+      setResponse(JSON.stringify(data, null, 2))
+      setKycUrl(data.kycUrl as string)
+      onComplete(data)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Generate a single-use hosted verification link for this customer. Each link expires —
+        re-run this step to mint a fresh one. Optionally set <code className="text-gray-300">redirectUri</code>{' '}
+        to return the customer to your app afterwards (must be a public https URL).
+      </p>
+      <JsonEditor value={body} onChange={setBody} disabled={disabled || loading} />
+      <button
+        onClick={submit}
+        disabled={disabled || loading}
+        className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-medium"
+      >
+        {loading ? 'Generating...' : 'Generate KYC Link'}
+      </button>
+      {kycUrl && (
+        <p className="mt-3 text-sm">
+          <a
+            href={kycUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline break-all"
+          >
+            Open hosted KYC flow ↗
+          </a>
+        </p>
+      )}
+      <ResponsePanel response={response} error={error} />
+    </div>
+  )
+}

--- a/samples/frontend/src/steps/OpenKycLink.tsx
+++ b/samples/frontend/src/steps/OpenKycLink.tsx
@@ -5,6 +5,10 @@ interface Props {
   onComplete: () => void
 }
 
+// Sumsub sandbox behavior (https://docs.sumsub.com/docs/test-in-sandbox):
+// no real checks run — outcomes are driven by which test document you upload.
+const SUMSUB_TEMPLATES_URL = 'https://docs.sumsub.com/docs/verification-document-templates'
+
 export default function OpenKycLink({ kycUrl, expiresAt, disabled, onComplete }: Props) {
   return (
     <div>
@@ -25,6 +29,42 @@ export default function OpenKycLink({ kycUrl, expiresAt, disabled, onComplete }:
             Open hosted KYC flow ↗
           </a>
           <p className="mt-2 text-xs text-gray-500 font-mono break-all">{kycUrl}</p>
+          <div className="mt-3 rounded border border-gray-800 bg-gray-900/50 p-3 text-xs text-gray-400 space-y-1.5">
+            <p className="font-semibold text-gray-300">Sample data for the sandbox Sumsub flow</p>
+            <p>
+              Sandbox runs no real checks — the outcome depends on the document you upload.
+              Any other image (even a photo of your cat) is accepted with mock data
+              (&ldquo;Mock firstName / Mock lastName&rdquo;).
+            </p>
+            <ul className="list-disc pl-4 space-y-1">
+              <li>
+                <span className="text-green-400">To pass:</span> select <span className="text-gray-300">Germany</span> as
+                the issuing country, pick <span className="text-gray-300">ID card</span> or{' '}
+                <span className="text-gray-300">passport</span>, and upload the accepted Germany
+                templates from Sumsub&apos;s collection. China ID and India Aadhaar templates also pass.
+              </li>
+              <li>
+                <span className="text-red-400">To fail:</span> upload a rejected template — Spain or
+                California documents trigger a resubmission request; the Cyprus ID card causes a
+                final rejection.
+              </li>
+              <li>
+                For the selfie/liveness step, any live camera face works in sandbox.
+              </li>
+            </ul>
+            <p>
+              Download the test documents from{' '}
+              <a
+                href={SUMSUB_TEMPLATES_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                Sumsub&apos;s verification document templates ↗
+              </a>
+              .
+            </p>
+          </div>
         </>
       ) : (
         <p className="text-sm text-gray-500">Generate a link in the previous step first.</p>

--- a/samples/frontend/src/steps/OpenKycLink.tsx
+++ b/samples/frontend/src/steps/OpenKycLink.tsx
@@ -1,0 +1,34 @@
+interface Props {
+  kycUrl: string | null
+  expiresAt: string | null
+  disabled: boolean
+  onComplete: () => void
+}
+
+export default function OpenKycLink({ kycUrl, expiresAt, disabled, onComplete }: Props) {
+  return (
+    <div>
+      <p className="text-sm text-gray-400 mb-2">
+        Send the customer to the hosted verification flow. The link is single-use
+        {expiresAt ? ` and expires at ${expiresAt}` : ''} — regenerate one in the previous
+        step if it lapses.
+      </p>
+      {kycUrl && !disabled ? (
+        <>
+          <a
+            href={kycUrl}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => onComplete()}
+            className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium"
+          >
+            Open hosted KYC flow ↗
+          </a>
+          <p className="mt-2 text-xs text-gray-500 font-mono break-all">{kycUrl}</p>
+        </>
+      ) : (
+        <p className="text-sm text-gray-500">Generate a link in the previous step first.</p>
+      )}
+    </div>
+  )
+}

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
@@ -3,9 +3,9 @@ package com.grid.sample.routes
 import com.fasterxml.jackson.databind.JsonNode
 import com.lightspark.grid.models.customers.CustomerCreateParams
 import com.lightspark.grid.models.customers.CustomerCreateParams.CreateCustomerRequest
-import com.lightspark.grid.models.customers.CustomerGetKycLinkParams
 import com.lightspark.grid.models.customers.IndividualCustomerFields
 import com.lightspark.grid.models.customers.externalaccounts.Address
+import com.grid.sample.Config
 import com.grid.sample.GridClientBuilder
 import com.grid.sample.JsonUtils
 import com.grid.sample.Log
@@ -15,7 +15,17 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.LocalDate
+import java.util.Base64
+
+// SDK 1.7.1 predates the current POST /customers/{id}/kyc-link endpoint shape,
+// so the kyc-link route below calls the REST API directly.
+private val DEFAULT_GRID_API_BASE_URL = "https://api.lightspark.com/grid/2025-10-13"
+private val kycHttpClient: HttpClient by lazy { HttpClient.newHttpClient() }
 
 fun Route.customerRoutes() {
     route("/api/customers") {
@@ -108,30 +118,31 @@ fun Route.customerRoutes() {
                         HttpStatusCode.BadRequest
                     )
 
-                val body = call.receiveText()
+                val body = call.receiveText().ifBlank { "{}" }
                 Log.incoming("POST", "/api/customers/$customerId/kyc-link", body)
-                val json = if (body.isBlank()) {
-                    JsonUtils.mapper.createObjectNode()
-                } else {
-                    JsonUtils.mapper.readTree(body)
-                }
 
-                val params = CustomerGetKycLinkParams.builder()
-                    // Fills the {customerId} path segment (SDK names it platformCustomerId).
-                    .platformCustomerId(customerId)
-                    .apply {
-                        json.optText("redirectUri")?.let { redirectUri(it) }
-                    }
+                val baseUrl = Config.apiBaseUrl ?: DEFAULT_GRID_API_BASE_URL
+                val auth = Base64.getEncoder()
+                    .encodeToString("${Config.apiTokenId}:${Config.apiClientSecret}".toByteArray())
+                val request = HttpRequest.newBuilder()
+                    .uri(URI.create("$baseUrl/customers/$customerId/kyc-link"))
+                    .header("Authorization", "Basic $auth")
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
                     .build()
 
-                Log.gridRequest("customers.getKycLink", customerId)
-                val link = GridClientBuilder.client.customers().getKycLink(params)
-                val responseJson = JsonUtils.prettyPrint(link)
-                Log.gridResponse("customers.getKycLink", responseJson)
+                Log.gridRequest("customers.kycLink", body)
+                val response = kycHttpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                Log.gridResponse("customers.kycLink", response.body())
 
-                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+                // Pass Grid's status through (201 on success; 400/404/409 errors verbatim).
+                call.respondText(
+                    response.body(),
+                    ContentType.Application.Json,
+                    HttpStatusCode.fromValue(response.statusCode())
+                )
             } catch (e: Exception) {
-                Log.gridError("customers.getKycLink", e)
+                Log.gridError("customers.kycLink", e)
                 call.respondText(
                     """{"error": "${e.message}"}""",
                     ContentType.Application.Json,

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
@@ -24,6 +24,7 @@ import java.util.Base64
 
 // SDK 1.7.1 predates the current POST /customers/{id}/kyc-link endpoint shape,
 // so the kyc-link route below calls the REST API directly.
+// NOTE: keep DEFAULT_GRID_API_BASE_URL in sync with the SDK's default base URL when bumping the SDK.
 private val DEFAULT_GRID_API_BASE_URL = "https://api.lightspark.com/grid/2025-10-13"
 private val kycHttpClient: HttpClient by lazy { HttpClient.newHttpClient() }
 

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/Customers.kt
@@ -3,6 +3,7 @@ package com.grid.sample.routes
 import com.fasterxml.jackson.databind.JsonNode
 import com.lightspark.grid.models.customers.CustomerCreateParams
 import com.lightspark.grid.models.customers.CustomerCreateParams.CreateCustomerRequest
+import com.lightspark.grid.models.customers.CustomerGetKycLinkParams
 import com.lightspark.grid.models.customers.IndividualCustomerFields
 import com.lightspark.grid.models.customers.externalaccounts.Address
 import com.grid.sample.GridClientBuilder
@@ -65,6 +66,72 @@ fun Route.customerRoutes() {
                 call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
             } catch (e: Exception) {
                 Log.gridError("customers.create", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        get("/{customerId}") {
+            try {
+                val customerId = call.parameters["customerId"]
+                    ?: return@get call.respondText(
+                        """{"error": "customerId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+
+                Log.gridRequest("customers.retrieve", customerId)
+                val customer = GridClientBuilder.client.customers().retrieve(customerId)
+                val responseJson = JsonUtils.prettyPrint(customer)
+                Log.gridResponse("customers.retrieve", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.OK)
+            } catch (e: Exception) {
+                Log.gridError("customers.retrieve", e)
+                call.respondText(
+                    """{"error": "${e.message}"}""",
+                    ContentType.Application.Json,
+                    HttpStatusCode.InternalServerError
+                )
+            }
+        }
+
+        post("/{customerId}/kyc-link") {
+            try {
+                val customerId = call.parameters["customerId"]
+                    ?: return@post call.respondText(
+                        """{"error": "customerId is required"}""",
+                        ContentType.Application.Json,
+                        HttpStatusCode.BadRequest
+                    )
+
+                val body = call.receiveText()
+                Log.incoming("POST", "/api/customers/$customerId/kyc-link", body)
+                val json = if (body.isBlank()) {
+                    JsonUtils.mapper.createObjectNode()
+                } else {
+                    JsonUtils.mapper.readTree(body)
+                }
+
+                val params = CustomerGetKycLinkParams.builder()
+                    // Fills the {customerId} path segment (SDK names it platformCustomerId).
+                    .platformCustomerId(customerId)
+                    .apply {
+                        json.optText("redirectUri")?.let { redirectUri(it) }
+                    }
+                    .build()
+
+                Log.gridRequest("customers.getKycLink", customerId)
+                val link = GridClientBuilder.client.customers().getKycLink(params)
+                val responseJson = JsonUtils.prettyPrint(link)
+                Log.gridResponse("customers.getKycLink", responseJson)
+
+                call.respondText(responseJson, ContentType.Application.Json, HttpStatusCode.Created)
+            } catch (e: Exception) {
+                Log.gridError("customers.getKycLink", e)
                 call.respondText(
                     """{"error": "${e.message}"}""",
                     ContentType.Application.Json,

--- a/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
+++ b/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
@@ -325,4 +325,52 @@ class EndToEndTest {
         }
         assertEquals(HttpStatusCode.OK, fundResponse.status, "Sandbox funding failed: ${fundResponse.bodyAsText()}")
     }
+
+    @Test
+    fun `generate KYC link and retrieve customer`() = testApplication {
+        configureApp()
+
+        // Step 1: Create customer
+        val customerResponse = client.post("/api/customers") {
+            contentType(ContentType.Application.Json)
+            setBody("""
+                {
+                    "platformCustomerId": "test_kyc_${System.currentTimeMillis()}",
+                    "customerType": "INDIVIDUAL",
+                    "fullName": "Kyc Test User",
+                    "email": "kyctest.${System.currentTimeMillis()}@lightspark.com",
+                    "nationality": "US",
+                    "birthDate": "1990-01-01",
+                    "address": {
+                        "country": "US",
+                        "line1": "123 Test St",
+                        "postalCode": "10001",
+                        "city": "New York",
+                        "state": "NY"
+                    }
+                }
+            """)
+        }
+        assertEquals(HttpStatusCode.Created, customerResponse.status)
+        val customerJson = parseJson(customerResponse.bodyAsText())
+        val customerId = customerJson.get("platformCustomerId").asText()
+
+        // Step 2: Generate a hosted KYC link
+        val linkResponse = client.post("/api/customers/$customerId/kyc-link") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"redirectUri": "http://localhost:5173/onboarding-complete"}""")
+        }
+        assertEquals(HttpStatusCode.Created, linkResponse.status)
+        val link = parseJson(linkResponse.bodyAsText())
+        assertNotNull(link.get("kycUrl")?.asText(), "Response should include kycUrl")
+        assertNotNull(link.get("expiresAt")?.asText(), "Response should include expiresAt")
+
+        // Step 3: Retrieve the customer and check kycStatus is present
+        val gridCustomerId = customerJson.get("id").asText()
+        val getResponse = client.get("/api/customers/$gridCustomerId")
+        assertEquals(HttpStatusCode.OK, getResponse.status)
+        val fetched = parseJson(getResponse.bodyAsText())
+        assertEquals(gridCustomerId, fetched.get("id")?.asText())
+        assertNotNull(fetched.get("kycStatus")?.asText(), "Customer should include kycStatus")
+    }
 }

--- a/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
+++ b/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
@@ -353,12 +353,13 @@ class EndToEndTest {
         }
         assertEquals(HttpStatusCode.Created, customerResponse.status)
         val customerJson = parseJson(customerResponse.bodyAsText())
-        val customerId = customerJson.get("platformCustomerId").asText()
+        val customerId = customerJson.get("id").asText()
 
-        // Step 2: Generate a hosted KYC link
+        // Step 2: Generate a hosted KYC link. No redirectUri: the KYC provider
+        // requires a public https URL, which a local sample doesn't have.
         val linkResponse = client.post("/api/customers/$customerId/kyc-link") {
             contentType(ContentType.Application.Json)
-            setBody("""{"redirectUri": "http://localhost:5173/onboarding-complete"}""")
+            setBody("""{}""")
         }
         assertEquals(HttpStatusCode.Created, linkResponse.status)
         val link = parseJson(linkResponse.bodyAsText())
@@ -366,11 +367,10 @@ class EndToEndTest {
         assertNotNull(link.get("expiresAt")?.asText(), "Response should include expiresAt")
 
         // Step 3: Retrieve the customer and check kycStatus is present
-        val gridCustomerId = customerJson.get("id").asText()
-        val getResponse = client.get("/api/customers/$gridCustomerId")
+        val getResponse = client.get("/api/customers/$customerId")
         assertEquals(HttpStatusCode.OK, getResponse.status)
         val fetched = parseJson(getResponse.bodyAsText())
-        assertEquals(gridCustomerId, fetched.get("id")?.asText())
+        assertEquals(customerId, fetched.get("id")?.asText())
         assertNotNull(fetched.get("kycStatus")?.asText(), "Customer should include kycStatus")
     }
 }

--- a/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
+++ b/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
@@ -363,14 +363,14 @@ class EndToEndTest {
         }
         assertEquals(HttpStatusCode.Created, linkResponse.status)
         val link = parseJson(linkResponse.bodyAsText())
-        assertNotNull(link.get("kycUrl")?.asText(), "Response should include kycUrl")
-        assertNotNull(link.get("expiresAt")?.asText(), "Response should include expiresAt")
+        assertNotNull(link.optText("kycUrl"), "Response should include kycUrl")
+        assertNotNull(link.optText("expiresAt"), "Response should include expiresAt")
 
         // Step 3: Retrieve the customer and check kycStatus is present
         val getResponse = client.get("/api/customers/$customerId")
         assertEquals(HttpStatusCode.OK, getResponse.status)
         val fetched = parseJson(getResponse.bodyAsText())
         assertEquals(customerId, fetched.get("id")?.asText())
-        assertNotNull(fetched.get("kycStatus")?.asText(), "Customer should include kycStatus")
+        assertNotNull(fetched.optText("kycStatus"), "Customer should include kycStatus")
     }
 }


### PR DESCRIPTION
## Summary

Adds a **KYC Onboarding** flow to the sample app demonstrating the hosted KYC link integration: create a customer, generate a hosted verification link, complete verification with Sumsub, and track `kycStatus` via both polling and webhooks.

### Backend (`samples/kotlin`)
- `GET /api/customers/{id}` — retrieve a customer (incl. `kycStatus`) via the SDK.
- `POST /api/customers/{id}/kyc-link` — generates the hosted link via a **direct REST call**: SDK 1.7.1's `getKycLink` builds an obsolete request shape (`GET /customers/kyc-link?platformCustomerId=...`, verified by capturing its raw HTTP request), and upgrading to SDK 1.8/1.9 breaks four other sample route files. Grid API errors pass through with their original status codes.
- New e2e test covering create → kyc-link → retrieve, passing against the live sandbox.

### Frontend (`samples/frontend`)
- New sidebar flow (listed above Payout): **Create Customer → Generate KYC Link → Complete Hosted Verification → Track KYC Status**.
- Generate KYC Link is a single button — no request body (`redirectUri` is optional and must be a public https URL, so the local sample omits it).
- The **Complete Hosted Verification** step exposes the returned `kycUrl` and expiry as its own wizard step, and includes **Sumsub sandbox test data** guidance (per [Test in Sandbox](https://docs.sumsub.com/docs/test-in-sandbox) / [document templates](https://docs.sumsub.com/docs/verification-document-templates)): accepted templates (Germany ID/passport, China ID, India Aadhaar) pass, rejected templates (Spain/California → resubmission, Cyprus ID → final rejection), anything else gets mock data.
- Steps 2–4 stay enabled once reached so an expired link can be regenerated and status re-polled.
- `CUSTOMER.KYC_*` webhook events surface in the existing WebhookStream panel.

### Docs
- README API-contract table updated; design spec + implementation plan committed under `docs/superpowers/`.

### Verified environment behavior (baked into defaults)
- `email` is required on customer create (platform supports embedded wallets).
- `redirectUri` must be a public https URL (provider rejects http:// and localhost) — omitted by default.
- The dev platform creates customers with `kycStatus: APPROVED` (regulated-platform behavior).

## Test plan
- [x] `./gradlew test --tests "*generate KYC*"` — passes against live sandbox
- [x] `npm run build` (tsc + vite) — clean
- [x] Manual: full 4-step flow walked in-browser — customer created, link generated, hosted Sumsub flow opened, status badge shows `APPROVED`, webhooks stream live

Note: 5 pre-existing e2e tests fail identically on `main` (they create customers without the now-required `email` field) — unrelated to this PR, follow-up ticket suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)