### PR TITLE
Lower wallet demo earnings APY from 5% to 3%

### DIFF
--- a/components/grid-wallet-demo/src/apps/aurora/wallet/WalletInsightCards.tsx
+++ b/components/grid-wallet-demo/src/apps/aurora/wallet/WalletInsightCards.tsx
@@ -48,7 +48,7 @@ export interface WalletInsightCardsProps {
   earningsTodayCents?: number;
   /** A month of accrued yield (daily compounding) — the headline figure. */
   earningsMonthCents?: number;
-  /** APY shown on the earnings card, percent (e.g. 5 → "5.00% APY"). */
+  /** APY shown on the earnings card, percent (e.g. 3 → "3.00% APY"). */
   apyPercent?: number;
 }
 

--- a/components/grid-wallet-demo/src/apps/shared/wallet/activity.ts
+++ b/components/grid-wallet-demo/src/apps/shared/wallet/activity.ts
@@ -12,7 +12,7 @@ import type {
 } from './types';
 
 /** Yield rate shown on the Earnings card; today's accrual = balance × this ÷ 365. */
-export const EARNINGS_APY_PERCENT = 5;
+export const EARNINGS_APY_PERCENT = 3;
 /** Bars in the Weekly activity chart — one per recent card charge. */
 export const WEEKLY_BAR_COUNT = 14;
 


### PR DESCRIPTION
A prospect noticed the 5% APY on the earnings card in the Global accounts playground and asked how it's achievable — sales asked us to bring it down to 3%.

All yield math in the wallet demo (today's accrual and the daily-compounded monthly earnings in `useWalletHome`) derives from the single `EARNINGS_APY_PERCENT` constant in `apps/shared/wallet/activity.ts`, and every skin renders the `apyPercent` the hook passes down, so this one-line change updates the displayed rate and all computed earnings across every skin. Also updated a doc-comment example to match.

Made with [Cursor](https://cursor.com)