### PR TITLE
ci: move workflows to ARC runners

### DIFF
--- a/.github/workflows/check-docs-config.yml
+++ b/.github/workflows/check-docs-config.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-openapi-reference:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-1
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       changed_files: ${{ steps.check.outputs.changed_files }}
@@ -60,7 +60,7 @@ jobs:
   sync-docs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -17,12 +17,12 @@ on:
 jobs:
   build:
     name: Build OpenAPI Documentation
-    runs-on: ubuntu-24.04
+    runs-on: arc-runner-1
     steps:
       - run: echo "Skipping Build OpenAPI Documentation - no relevant changes"
 
   lint:
     name: Lint Code & Documentation
-    runs-on: ubuntu-24.04
+    runs-on: arc-runner-1
     steps:
       - run: echo "Skipping Lint Code & Documentation - no relevant changes"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   lint:
     name: Lint Code & Documentation
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     
     steps:
       - name: Checkout code

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   detect:
     name: Detect breaking changes
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     steps:
       - name: Checkout base spec
         uses: actions/checkout@v4
@@ -33,10 +33,11 @@ jobs:
       - name: Install oasdiff
         env:
           OASDIFF_VERSION: 1.16.0
-          OASDIFF_SHA256: 2f424431c441a85e2d73ff884609f55c98c283ca2ce3d88537a7a029379dd521
+          OASDIFF_SHA256: f2c99138434b3f1244555b38eef7d5532435617ffb3c47526ddf29fa02e3be63
         run: |
+          # arm64 build required: this job runs on an arm64 ARC runner
           curl -fsSL \
-            "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_arm64.tar.gz" \
             -o /tmp/oasdiff.tgz
           echo "${OASDIFF_SHA256}  /tmp/oasdiff.tgz" | sha256sum -c -
           tar -xzf /tmp/oasdiff.tgz -C /tmp oasdiff

--- a/.github/workflows/openapi-build.yml
+++ b/.github/workflows/openapi-build.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     name: Build OpenAPI Documentation
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/stainless-action.yml
+++ b/.github/workflows/stainless-action.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   preview:
     if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     permissions:
       contents: read
       pull-requests: write
@@ -41,7 +41,7 @@ jobs:
 
   merge:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-2
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Why

GitHub-hosted runners have had repeated availability incidents — most recently today (2026-07-24), when jobs sat stuck in `queued` ([thread](https://lightsparkgroup.slack.com/archives/C03HYQQ2HT6/p1784910539043679)). The in-cluster ARC scale sets stayed healthy through it, so work that *can* move should.

This repo turned out to be fully portable: every action in use is pure-JS or composite, and nothing needs a docker daemon.

## What changed

All 10 jobs across 7 workflows:

| Workflow | Job(s) | New runner |
|---|---|---|
| `check-docs-config.yml` | `check-openapi-reference` | `arc-runner-1` |
| `dummy.yml` | `build`, `lint` (echo stubs) | `arc-runner-1` |
| `lint.yml` | `lint` | `arc-runner-2` |
| `openapi-build.yml` | `build` | `arc-runner-2` |
| `openapi-breaking-changes.yml` | `detect` | `arc-runner-2` |
| `stainless-action.yml` | `preview`, `merge` | `arc-runner-2` |
| `docs-sync.yml` | `detect-changes`, `sync-docs` | `arc-runner-2` |

### ⚠️ One non-mechanical change worth reviewing closely

`openapi-breaking-changes.yml` downloaded the **amd64** `oasdiff` binary, which cannot execute on an arm64 ARC runner. This PR switches it to the arm64 asset **and updates the pinned checksum**:

```
- oasdiff_1.16.0_linux_amd64.tar.gz  sha256 2f424431c441a85e...
+ oasdiff_1.16.0_linux_arm64.tar.gz  sha256 f2c99138434b3f12...
```

The new checksum was computed by downloading the arm64 tarball and independently cross-checked against the release's own `checksums.txt` — both agree. `OASDIFF_VERSION` is unchanged (1.16.0), and the arm64 tarball has the identical internal layout (`LICENSE` + `oasdiff`), so the extraction line needed no change.

## Notes

- `lint.yml` runs `sudo apt-get install -y libsecret-1-dev`. This works on ARC — `sudo` is available (the org's shared `start-postgres` action relies on it).
- `dummy.yml`'s two `name:` values are byte-identical to before, so the required-status-check names still match their real counterparts in `lint.yml` / `openapi-build.yml`.
- `stainless-api/upload-openapi-spec-action/{preview,merge}@v1` are both `using: node20` with bundled `dist/*.js` — nothing is downloaded, so no arch exposure.
- Old action versions (`actions/checkout@v3`, `actions/setup-node@v3`) were deliberately **not** bumped — out of scope for this change.

## What to watch

- **If jobs sit in `queued` forever, it's org runner-group visibility, not this diff** (couldn't confirm the Default group's repo allowlist without `admin:org`; every other converted repo in the org works fine).
- **`stainless-action.yml` is on the SDK-generation path.** If Stainless ever regenerates that workflow file from its template, the `runs-on` may silently revert to `ubuntu-latest`. Worth confirming whether that file is Stainless-managed or hand-maintained here.

## Rollback

Revert the commit. Note that reverting restores the amd64 oasdiff download, which is correct for `ubuntu-latest` — the arch and the runner must be reverted together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
