### PR TITLE
Add Spark quote destinations

### DIFF
--- a/mintlify/global-accounts/index.mdx
+++ b/mintlify/global-accounts/index.mdx
@@ -25,7 +25,7 @@ import Concepts from '/snippets/global-accounts/concepts.mdx';
     Give each customer a branded account experience backed by Grid account infrastructure.
   </FeatureCard>
   <FeatureCard icon="/images/icons/coins.svg" title="Stablecoin balances">
-    Hold dollar-denominated value and use Grid quotes to move between account balances and supported rails.
+    Hold dollar-denominated value and use Grid quotes to move between account balances, other Global Accounts, Spark addresses, and supported rails.
   </FeatureCard>
   <FeatureCard icon="/images/icons/globe.svg" title="Local off-ramps">
     Let customers move value to supported local bank rails, including corridors such as PIX, UPI, SEPA, FPS, and more.

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3575,12 +3575,13 @@ paths:
     post:
       summary: Create a transfer quote
       description: |
-        Generate a quote for a cross-currency transfer between any combination of accounts
-        and UMA addresses. This endpoint handles currency exchange and provides the necessary
-        instructions to execute the transfer.
+        Generate a quote for a transfer between accounts, Spark addresses, and UMA
+        addresses. This endpoint handles currency exchange where needed and provides
+        the necessary instructions to execute the transfer.
 
         **Transfer Types Supported:**
         - **Account to Account**: Transfer between internal/external accounts with currency exchange.
+        - **Embedded Wallet to Spark Address**: Send the source Spark token directly to any compatible Spark address.
         - **Account to UMA**: Transfer from an internal account to an UMA address.
         - **UMA to Account or UMA to UMA**: This transfer type will only be funded by payment instructions, not from an internal account.
 
@@ -3589,8 +3590,11 @@ paths:
         - **Currency Exchange**: Handles all cross-currency transfers with real-time exchange rates
         - **Payment Instructions**: For UMA or customer ID sources, provides banking details needed for execution
 
-        **Important:** If you are transferring funds in the same currency (no exchange required),
-        use the `/transfer-in` or `/transfer-out` endpoints instead.
+        **Important:** For most same-currency account transfers, use `/transfer-in`
+        or `/transfer-out`. Embedded Wallet transfers to another Embedded Wallet or
+        Spark address use this quote flow because the wallet owner must sign the
+        `payloadToSign` returned by the quote and then call
+        `POST /quotes/{quoteId}/execute`.
       operationId: createQuote
       tags:
         - Cross-Currency Transfers
@@ -3638,6 +3642,18 @@ paths:
                   lockedCurrencySide: SENDING
                   lockedCurrencyAmount: 1000
                   description: 'Payment for invoice #1234'
+              embeddedWalletToSparkAddress:
+                summary: Send USDB from an Embedded Wallet to a Spark address
+                value:
+                  source:
+                    sourceType: ACCOUNT
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  destination:
+                    destinationType: SPARK_ADDRESS
+                    sparkAddress: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+                  lockedCurrencySide: SENDING
+                  lockedCurrencyAmount: 10000000
+                  description: Wallet transfer
               realTimeFundingToSparkWallet:
                 summary: Real-time funding to Spark Wallet as an on-ramp flow. Immediate execution.
                 value:
@@ -19736,6 +19752,7 @@ components:
       type: string
       enum:
         - ACCOUNT
+        - SPARK_ADDRESS
         - UMA_ADDRESS
       description: Type of transaction destination
       example: ACCOUNT
@@ -19796,6 +19813,27 @@ components:
               $ref: '#/components/schemas/OnChainTransaction'
               description: On-chain transaction that delivered funds to this destination, when the destination is an external crypto wallet. Populated once the crypto transfer has settled.
           description: Destination account details
+    SparkAddressTransactionDestination:
+      title: Spark Address Destination
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionDestination'
+        - type: object
+          required:
+            - destinationType
+            - sparkAddress
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - SPARK_ADDRESS
+            sparkAddress:
+              type: string
+              description: Spark address that received the token transfer
+              example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+            onChainTransaction:
+              $ref: '#/components/schemas/OnChainTransaction'
+              description: On-chain Spark transaction that delivered funds to this destination. Populated after the transfer settles when transaction details are available.
+          description: Direct Spark address destination details
     UmaAddressTransactionDestination:
       title: UMA Address Destination
       allOf:
@@ -19817,11 +19855,13 @@ components:
     TransactionDestinationOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountTransactionDestination'
+        - $ref: '#/components/schemas/SparkAddressTransactionDestination'
         - $ref: '#/components/schemas/UmaAddressTransactionDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
+          SPARK_ADDRESS: '#/components/schemas/SparkAddressTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
     Refund:
       type: object
@@ -20688,6 +20728,7 @@ components:
       type: string
       enum:
         - ACCOUNT
+        - SPARK_ADDRESS
         - UMA_ADDRESS
       description: Type of payment destination
       example: ACCOUNT
@@ -20720,6 +20761,24 @@ components:
                 - $ref: '#/components/schemas/PaymentRail'
                 - description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           description: Destination account details
+    SparkAddressDestination:
+      title: Spark Address
+      allOf:
+        - $ref: '#/components/schemas/BaseDestination'
+        - type: object
+          required:
+            - destinationType
+            - sparkAddress
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - SPARK_ADDRESS
+            sparkAddress:
+              type: string
+              description: Spark address that receives the source Embedded Wallet's token. The address must use the same Spark network as the source wallet. Supported only for same-currency transfers from an Embedded Wallet source.
+              example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+          description: Direct Spark address destination
     UmaAddressDestination:
       title: UMA Address
       allOf:
@@ -20745,11 +20804,13 @@ components:
     QuoteDestinationOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountDestination'
+        - $ref: '#/components/schemas/SparkAddressDestination'
         - $ref: '#/components/schemas/UmaAddressDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountDestination'
+          SPARK_ADDRESS: '#/components/schemas/SparkAddressDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressDestination'
     Quote:
       type: object
@@ -20913,6 +20974,7 @@ components:
           $ref: '#/components/schemas/QuoteSourceOneOf'
         destination:
           $ref: '#/components/schemas/QuoteDestinationOneOf'
+          description: Destination for the transfer. `SPARK_ADDRESS` is supported only for same-currency transfers from an `EMBEDDED_WALLET` internal account.
         lockedCurrencySide:
           $ref: '#/components/schemas/QuoteLockSide'
         lockedCurrencyAmount:

--- a/mintlify/snippets/global-accounts/walkthrough.mdx
+++ b/mintlify/snippets/global-accounts/walkthrough.mdx
@@ -360,6 +360,62 @@ curl -X POST "$GRID_BASE_URL/quotes/Quote:019542f5-b3e7-1d02-0000-000000000006/e
 
 The transaction is on its way. You'll receive standard transaction webhooks (`OUTGOING_PAYMENT`) as it settles — see [Transaction lifecycle](/platform-overview/core-concepts/transaction-lifecycle).
 
+## Send to another Global Account or Spark address
+
+Use the same quote and signature flow to send USDB without converting it. Set
+the source to the sender's Embedded Wallet account and choose one of these
+destinations:
+
+- `ACCOUNT` with another Embedded Wallet's internal account ID.
+- `SPARK_ADDRESS` with any compatible Spark address, including a wallet outside
+  your platform.
+
+The quote returns `payloadToSign` as shown above. Embedded Wallet sources do not
+support `immediatelyExecute`; stamp the payload and call
+`POST /quotes/{quoteId}/execute`.
+
+<CodeGroup>
+```bash Internal account
+curl -X POST "$GRID_BASE_URL/quotes" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: 33d31868-f45f-4f02-bda0-f57b147e1695" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
+    },
+    "destination": {
+      "destinationType": "ACCOUNT",
+      "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000003"
+    },
+    "lockedCurrencySide": "SENDING",
+    "lockedCurrencyAmount": 10000000,
+    "description": "Dinner"
+  }'
+```
+
+```bash Spark address
+curl -X POST "$GRID_BASE_URL/quotes" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: d7da1014-6130-43b4-a338-b8f705efdb43" \
+  -d '{
+    "source": {
+      "sourceType": "ACCOUNT",
+      "accountId": "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
+    },
+    "destination": {
+      "destinationType": "SPARK_ADDRESS",
+      "sparkAddress": "spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu"
+    },
+    "lockedCurrencySide": "SENDING",
+    "lockedCurrencyAmount": 10000000,
+    "description": "Wallet transfer"
+  }'
+```
+</CodeGroup>
+
 ## Where to next
 
 <CardGroup cols={2}>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3575,12 +3575,13 @@ paths:
     post:
       summary: Create a transfer quote
       description: |
-        Generate a quote for a cross-currency transfer between any combination of accounts
-        and UMA addresses. This endpoint handles currency exchange and provides the necessary
-        instructions to execute the transfer.
+        Generate a quote for a transfer between accounts, Spark addresses, and UMA
+        addresses. This endpoint handles currency exchange where needed and provides
+        the necessary instructions to execute the transfer.
 
         **Transfer Types Supported:**
         - **Account to Account**: Transfer between internal/external accounts with currency exchange.
+        - **Embedded Wallet to Spark Address**: Send the source Spark token directly to any compatible Spark address.
         - **Account to UMA**: Transfer from an internal account to an UMA address.
         - **UMA to Account or UMA to UMA**: This transfer type will only be funded by payment instructions, not from an internal account.
 
@@ -3589,8 +3590,11 @@ paths:
         - **Currency Exchange**: Handles all cross-currency transfers with real-time exchange rates
         - **Payment Instructions**: For UMA or customer ID sources, provides banking details needed for execution
 
-        **Important:** If you are transferring funds in the same currency (no exchange required),
-        use the `/transfer-in` or `/transfer-out` endpoints instead.
+        **Important:** For most same-currency account transfers, use `/transfer-in`
+        or `/transfer-out`. Embedded Wallet transfers to another Embedded Wallet or
+        Spark address use this quote flow because the wallet owner must sign the
+        `payloadToSign` returned by the quote and then call
+        `POST /quotes/{quoteId}/execute`.
       operationId: createQuote
       tags:
         - Cross-Currency Transfers
@@ -3638,6 +3642,18 @@ paths:
                   lockedCurrencySide: SENDING
                   lockedCurrencyAmount: 1000
                   description: 'Payment for invoice #1234'
+              embeddedWalletToSparkAddress:
+                summary: Send USDB from an Embedded Wallet to a Spark address
+                value:
+                  source:
+                    sourceType: ACCOUNT
+                    accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+                  destination:
+                    destinationType: SPARK_ADDRESS
+                    sparkAddress: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+                  lockedCurrencySide: SENDING
+                  lockedCurrencyAmount: 10000000
+                  description: Wallet transfer
               realTimeFundingToSparkWallet:
                 summary: Real-time funding to Spark Wallet as an on-ramp flow. Immediate execution.
                 value:
@@ -19736,6 +19752,7 @@ components:
       type: string
       enum:
         - ACCOUNT
+        - SPARK_ADDRESS
         - UMA_ADDRESS
       description: Type of transaction destination
       example: ACCOUNT
@@ -19796,6 +19813,27 @@ components:
               $ref: '#/components/schemas/OnChainTransaction'
               description: On-chain transaction that delivered funds to this destination, when the destination is an external crypto wallet. Populated once the crypto transfer has settled.
           description: Destination account details
+    SparkAddressTransactionDestination:
+      title: Spark Address Destination
+      allOf:
+        - $ref: '#/components/schemas/BaseTransactionDestination'
+        - type: object
+          required:
+            - destinationType
+            - sparkAddress
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - SPARK_ADDRESS
+            sparkAddress:
+              type: string
+              description: Spark address that received the token transfer
+              example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+            onChainTransaction:
+              $ref: '#/components/schemas/OnChainTransaction'
+              description: On-chain Spark transaction that delivered funds to this destination. Populated after the transfer settles when transaction details are available.
+          description: Direct Spark address destination details
     UmaAddressTransactionDestination:
       title: UMA Address Destination
       allOf:
@@ -19817,11 +19855,13 @@ components:
     TransactionDestinationOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountTransactionDestination'
+        - $ref: '#/components/schemas/SparkAddressTransactionDestination'
         - $ref: '#/components/schemas/UmaAddressTransactionDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountTransactionDestination'
+          SPARK_ADDRESS: '#/components/schemas/SparkAddressTransactionDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressTransactionDestination'
     Refund:
       type: object
@@ -20688,6 +20728,7 @@ components:
       type: string
       enum:
         - ACCOUNT
+        - SPARK_ADDRESS
         - UMA_ADDRESS
       description: Type of payment destination
       example: ACCOUNT
@@ -20720,6 +20761,24 @@ components:
                 - $ref: '#/components/schemas/PaymentRail'
                 - description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           description: Destination account details
+    SparkAddressDestination:
+      title: Spark Address
+      allOf:
+        - $ref: '#/components/schemas/BaseDestination'
+        - type: object
+          required:
+            - destinationType
+            - sparkAddress
+          properties:
+            destinationType:
+              type: string
+              enum:
+                - SPARK_ADDRESS
+            sparkAddress:
+              type: string
+              description: Spark address that receives the source Embedded Wallet's token. The address must use the same Spark network as the source wallet. Supported only for same-currency transfers from an Embedded Wallet source.
+              example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+          description: Direct Spark address destination
     UmaAddressDestination:
       title: UMA Address
       allOf:
@@ -20745,11 +20804,13 @@ components:
     QuoteDestinationOneOf:
       oneOf:
         - $ref: '#/components/schemas/AccountDestination'
+        - $ref: '#/components/schemas/SparkAddressDestination'
         - $ref: '#/components/schemas/UmaAddressDestination'
       discriminator:
         propertyName: destinationType
         mapping:
           ACCOUNT: '#/components/schemas/AccountDestination'
+          SPARK_ADDRESS: '#/components/schemas/SparkAddressDestination'
           UMA_ADDRESS: '#/components/schemas/UmaAddressDestination'
     Quote:
       type: object
@@ -20913,6 +20974,7 @@ components:
           $ref: '#/components/schemas/QuoteSourceOneOf'
         destination:
           $ref: '#/components/schemas/QuoteDestinationOneOf'
+          description: Destination for the transfer. `SPARK_ADDRESS` is supported only for same-currency transfers from an `EMBEDDED_WALLET` internal account.
         lockedCurrencySide:
           $ref: '#/components/schemas/QuoteLockSide'
         lockedCurrencyAmount:

--- a/openapi/components/schemas/quotes/DestinationType.yaml
+++ b/openapi/components/schemas/quotes/DestinationType.yaml
@@ -1,6 +1,7 @@
 type: string
 enum:
   - ACCOUNT
+  - SPARK_ADDRESS
   - UMA_ADDRESS
 description: Type of payment destination
 example: ACCOUNT

--- a/openapi/components/schemas/quotes/QuoteDestinationOneOf.yaml
+++ b/openapi/components/schemas/quotes/QuoteDestinationOneOf.yaml
@@ -1,8 +1,10 @@
 oneOf:
   - $ref: ./AccountDestination.yaml
+  - $ref: ./SparkAddressDestination.yaml
   - $ref: ./UmaAddressDestination.yaml
 discriminator:
   propertyName: destinationType
   mapping:
     ACCOUNT: ./AccountDestination.yaml
+    SPARK_ADDRESS: ./SparkAddressDestination.yaml
     UMA_ADDRESS: ./UmaAddressDestination.yaml

--- a/openapi/components/schemas/quotes/QuoteRequest.yaml
+++ b/openapi/components/schemas/quotes/QuoteRequest.yaml
@@ -18,6 +18,9 @@ properties:
     $ref: ./QuoteSourceOneOf.yaml
   destination:
     $ref: ./QuoteDestinationOneOf.yaml
+    description: >-
+      Destination for the transfer. `SPARK_ADDRESS` is supported only for
+      same-currency transfers from an `EMBEDDED_WALLET` internal account.
   lockedCurrencySide:
     $ref: ./QuoteLockSide.yaml
   lockedCurrencyAmount:

--- a/openapi/components/schemas/quotes/SparkAddressDestination.yaml
+++ b/openapi/components/schemas/quotes/SparkAddressDestination.yaml
@@ -1,0 +1,21 @@
+title: Spark Address
+allOf:
+  - $ref: ./BaseDestination.yaml
+  - type: object
+    required:
+      - destinationType
+      - sparkAddress
+    properties:
+      destinationType:
+        type: string
+        enum:
+          - SPARK_ADDRESS
+      sparkAddress:
+        type: string
+        description: >-
+          Spark address that receives the source Embedded Wallet's token.
+          The address must use the same Spark network as the source wallet.
+          Supported only for same-currency transfers from an Embedded Wallet
+          source.
+        example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+    description: Direct Spark address destination

--- a/openapi/components/schemas/transactions/SparkAddressTransactionDestination.yaml
+++ b/openapi/components/schemas/transactions/SparkAddressTransactionDestination.yaml
@@ -1,0 +1,22 @@
+title: Spark Address Destination
+allOf:
+  - $ref: ./BaseTransactionDestination.yaml
+  - type: object
+    required:
+      - destinationType
+      - sparkAddress
+    properties:
+      destinationType:
+        type: string
+        enum:
+          - SPARK_ADDRESS
+      sparkAddress:
+        type: string
+        description: Spark address that received the token transfer
+        example: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+      onChainTransaction:
+        $ref: ./OnChainTransaction.yaml
+        description: >-
+          On-chain Spark transaction that delivered funds to this destination.
+          Populated after the transfer settles when transaction details are available.
+    description: Direct Spark address destination details

--- a/openapi/components/schemas/transactions/TransactionDestinationOneOf.yaml
+++ b/openapi/components/schemas/transactions/TransactionDestinationOneOf.yaml
@@ -1,8 +1,10 @@
 oneOf:
   - $ref: ./AccountTransactionDestination.yaml
+  - $ref: ./SparkAddressTransactionDestination.yaml
   - $ref: ./UmaAddressTransactionDestination.yaml
 discriminator:
   propertyName: destinationType
   mapping:
     ACCOUNT: ./AccountTransactionDestination.yaml
+    SPARK_ADDRESS: ./SparkAddressTransactionDestination.yaml
     UMA_ADDRESS: ./UmaAddressTransactionDestination.yaml

--- a/openapi/components/schemas/transactions/TransactionDestinationType.yaml
+++ b/openapi/components/schemas/transactions/TransactionDestinationType.yaml
@@ -1,6 +1,7 @@
 type: string
 enum:
   - ACCOUNT
+  - SPARK_ADDRESS
   - UMA_ADDRESS
 description: Type of transaction destination
 example: ACCOUNT

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -1,12 +1,13 @@
 post:
   summary: Create a transfer quote
   description: |
-    Generate a quote for a cross-currency transfer between any combination of accounts
-    and UMA addresses. This endpoint handles currency exchange and provides the necessary
-    instructions to execute the transfer.
+    Generate a quote for a transfer between accounts, Spark addresses, and UMA
+    addresses. This endpoint handles currency exchange where needed and provides
+    the necessary instructions to execute the transfer.
 
     **Transfer Types Supported:**
     - **Account to Account**: Transfer between internal/external accounts with currency exchange.
+    - **Embedded Wallet to Spark Address**: Send the source Spark token directly to any compatible Spark address.
     - **Account to UMA**: Transfer from an internal account to an UMA address.
     - **UMA to Account or UMA to UMA**: This transfer type will only be funded by payment instructions, not from an internal account.
 
@@ -15,8 +16,11 @@ post:
     - **Currency Exchange**: Handles all cross-currency transfers with real-time exchange rates
     - **Payment Instructions**: For UMA or customer ID sources, provides banking details needed for execution
 
-    **Important:** If you are transferring funds in the same currency (no exchange required),
-    use the `/transfer-in` or `/transfer-out` endpoints instead.
+    **Important:** For most same-currency account transfers, use `/transfer-in`
+    or `/transfer-out`. Embedded Wallet transfers to another Embedded Wallet or
+    Spark address use this quote flow because the wallet owner must sign the
+    `payloadToSign` returned by the quote and then call
+    `POST /quotes/{quoteId}/execute`.
   operationId: createQuote
   tags:
     - Cross-Currency Transfers
@@ -65,6 +69,18 @@ post:
               lockedCurrencySide: SENDING
               lockedCurrencyAmount: 1000
               description: 'Payment for invoice #1234'
+          embeddedWalletToSparkAddress:
+            summary: Send USDB from an Embedded Wallet to a Spark address
+            value:
+              source:
+                sourceType: ACCOUNT
+                accountId: InternalAccount:019542f5-b3e7-1d02-0000-000000000002
+              destination:
+                destinationType: SPARK_ADDRESS
+                sparkAddress: spark1pgssyuuuhnrrdjswal5c3s3rafw9w3y5dd4cjy3duxlf7hjzkp0rqx6dj6mrhu
+              lockedCurrencySide: SENDING
+              lockedCurrencyAmount: 10000000
+              description: 'Wallet transfer'
           realTimeFundingToSparkWallet:
             summary: Real-time funding to Spark Wallet as an on-ramp flow. Immediate execution.
             value:


### PR DESCRIPTION
## Reason

Global Account Embedded Wallets need a public, signed quote flow for sending USDB directly to an arbitrary Spark address. Existing embedded-wallet-to-embedded-wallet transfers already use the receiver’s explicit internal account ID; a customer is an account owner rather than a settlement destination, so this API does not add a customer destination alias.

## Overview

- Add a `SPARK_ADDRESS` quote destination variant for raw Spark addresses.
- Retain `ACCOUNT` as the canonical destination for transfers to another managed Embedded Wallet.
- Add a `SPARK_ADDRESS` transaction destination so direct transfers retain their destination in transaction responses.
- Expose the settled Spark transaction through `onChainTransaction`. Grid models Spark as a decentralized blockchain network via `CryptoNetwork.SPARK`, so `transactionHash` is the Spark transaction hash and `network` is `SPARK`.
- Document the existing quote → stamp payload → execute flow; `immediatelyExecute` remains unsupported for Embedded Wallet sources because the wallet owner must sign the generated payload.
- Add Global Accounts examples for internal-account and raw Spark-address destinations.

The Sparkcore implementation and generated client updates land in the linked webdev stack. Existing `ACCOUNT` and `UMA_ADDRESS` behavior is unchanged.

## Test Plan

- `npm run build:openapi`
- `npm run lint`
