### PR TITLE
docs: mark customer email/phoneNumber conditionally required

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12232,12 +12232,12 @@ components:
         email:
           type: string
           format: email
-          description: Email address for the customer.
+          description: Email address for the customer. **Required in regions that verify the email address before identity verification** (e.g. the EU); optional otherwise.
           example: john.doe@example.com
         phoneNumber:
           type: string
           pattern: ^\+[1-9]\d{1,14}$
-          description: Phone number for the customer in strict E.164 format.
+          description: Phone number for the customer in strict E.164 format. **Required in regions that verify the phone number before identity verification** (e.g. the EU); optional otherwise.
           example: '+14155551234'
         umaAddress:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12232,12 +12232,12 @@ components:
         email:
           type: string
           format: email
-          description: Email address for the customer.
+          description: Email address for the customer. **Required in regions that verify the email address before identity verification** (e.g. the EU); optional otherwise.
           example: john.doe@example.com
         phoneNumber:
           type: string
           pattern: ^\+[1-9]\d{1,14}$
-          description: Phone number for the customer in strict E.164 format.
+          description: Phone number for the customer in strict E.164 format. **Required in regions that verify the phone number before identity verification** (e.g. the EU); optional otherwise.
           example: '+14155551234'
         umaAddress:
           type: string

--- a/openapi/components/schemas/customers/CustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/CustomerCreateRequest.yaml
@@ -34,13 +34,18 @@ properties:
   email:
     type: string
     format: email
-    description: Email address for the customer.
+    description: >-
+      Email address for the customer. **Required in regions that verify the
+      email address before identity verification** (e.g. the EU); optional
+      otherwise.
     example: john.doe@example.com
   phoneNumber:
     type: string
     pattern: '^\+[1-9]\d{1,14}$'
     description: >-
-      Phone number for the customer in strict E.164 format.
+      Phone number for the customer in strict E.164 format. **Required in
+      regions that verify the phone number before identity verification**
+      (e.g. the EU); optional otherwise.
     example: '+14155551234'
   umaAddress:
     type: string


### PR DESCRIPTION
## Summary

`CustomerCreateRequest` lists `email` and `phoneNumber` as flatly optional, but a customer in a region that verifies a contact channel before identity verification cannot be created without that channel's value — `POST /customers` rejects the request with `INVALID_INPUT`. The spec gave integrators no way to know that, so an EU onboarding that omits `phoneNumber` fails against a contract that says it's optional.

Documents the conditional requirement on both fields, as a region requirement.

## Changes

- `openapi/components/schemas/customers/CustomerCreateRequest.yaml` — expanded `email` and `phoneNumber` descriptions
- `openapi.yaml`, `mintlify/openapi.yaml` — rebundled via `make build`

Description-only: no schema shape, type, or requirement-list change, so generated clients are unaffected and no version bump is needed. `make lint-openapi` passes (0 errors).

Requested by @jklein24


Original PR: https://github.com/lightsparkdev/grid-api/pull/748