### PR TITLE
docs(skill): drop remaining paymentRails from create examples

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -220,7 +220,6 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     "currency": "MXN",
     "accountInfo": {
       "accountType": "MXN_ACCOUNT",
-      "paymentRails": ["SPEI"],
       "clabeNumber": "<18-digit-number>",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -578,7 +577,7 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
 7. **Destination currency is only for UMA**: Specify `currency` in the destination object ONLY for `UMA_ADDRESS` destinations. For `ACCOUNT` destinations the currency is intrinsic to the account and must be omitted — the only optional field there is `paymentRail`
 8. **Individual beneficiary requires fullName**: For `beneficiaryType: "INDIVIDUAL"`, `fullName` is required. `birthDate` (YYYY-MM-DD) and `nationality` (2-letter code) are optional but recommended
 9. **Use correct Nigerian field names**: Use `bankName` (NOT `bankCode`) and include `purposeOfPayment`
-10. **Don't forget country-specific required fields**: Brazil (BRL_ACCOUNT) requires `pixKey`, `pixKeyType`, and `taxId`; Europe (EUR_ACCOUNT) requires `iban`; all fiat accounts require `paymentRails`
+10. **Don't forget country-specific required fields**: Brazil (BRL_ACCOUNT) requires `pixKey`, `pixKeyType`, and `taxId`; Europe (EUR_ACCOUNT) requires `iban`; all fiat accounts require a `beneficiary`. Do not send `paymentRails` — Grid selects the rail and returns it on the created account.
 
 ## Error Handling
 

--- a/.claude/skills/grid-api/references/workflows.md
+++ b/.claude/skills/grid-api/references/workflows.md
@@ -165,7 +165,6 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     "currency": "MXN",
     "accountInfo": {
       "accountType": "MXN_ACCOUNT",
-      "paymentRails": ["SPEI"],
       "clabeNumber": "012345678901234567",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -296,7 +295,6 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     "currency": "USD",
     "accountInfo": {
       "accountType": "USD_ACCOUNT",
-      "paymentRails": ["ACH"],
       "routingNumber": "123456789",
       "accountNumber": "12345678901",
       "beneficiary": {


### PR DESCRIPTION
## Summary

Follow-up to the skill spec-refresh (#708). That PR removed the response-only `paymentRails` field from the create examples in `account-types.md`, but three references survived elsewhere and contradicted the fix:

- `SKILL.md` — `"paymentRails": ["SPEI"]` in the external-account create example
- `SKILL.md` — Best Practices tip #10 still asserted *"all fiat accounts require `paymentRails`"*
- `references/workflows.md` — `"paymentRails": ["SPEI"]` and `"paymentRails": ["ACH"]` in two create bodies

`paymentRails` is not an input on any `*ExternalAccountCreateInfo` schema — Grid selects the rail and returns it on the created account (`common/*AccountInfo.yaml`). Left as-is, the skill instructs callers to send an invalid field on every fiat account create, and tip #10 is high-weight guidance.

Tip #10 now points at the field that *is* required (`beneficiary`) and states the rail is server-selected.

## Test plan

Docs-only. Verified no `paymentRails` remains in any request body across the skill (the 3 surviving mentions all describe it as response-only), and all 25 curl JSON bodies still parse.

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/752