### PR TITLE
ci(grid-wallet-prod): deploy the pushed image via ArgoCD

### DIFF
--- a/.github/workflows/grid-wallet-prod-image.yml
+++ b/.github/workflows/grid-wallet-prod-image.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'components/grid-wallet-prod/**'
       - '.github/workflows/grid-wallet-prod-image.yml'
+  # Manual runs exist so this workflow can be exercised deliberately rather than
+  # only ever executing for the first time against main. Safe for auth: a
+  # dispatch is only offered on a branch, and from main the OIDC sub is still
+  # repo:lightsparkdev/grid-api:ref:refs/heads/main — which is what BOTH the
+  # ECR push role's trust policy and the ArgoCD RBAC entry match on. Dispatching
+  # from any other branch changes the sub and fails to authenticate, by design.
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -17,6 +24,12 @@ concurrency:
 
 jobs:
   build:
+    # Encode the branch restriction here too, rather than leaning only on the
+    # ECR trust policy and ArgoCD RBAC to reject a non-main dispatch. Both are
+    # configured in other repos and could be relaxed independently of this
+    # file; this keeps the gate visible where the trigger is. `deploy` inherits
+    # it through `needs: build` — a skipped build skips the deploy.
+    if: github.ref == 'refs/heads/main'
     # The tooling-prod cluster is Graviton (m8g), so the image must be
     # linux/arm64. A native ARM runner avoids QEMU emulation, which makes a
     # Next.js build painfully slow. NOTE: no other workflow in this repo uses
@@ -24,6 +37,13 @@ jobs:
     # runners are not enabled for the org and the fallback is
     # docker/setup-qemu-action + docker/setup-buildx-action on ubuntu-latest.
     runs-on: ubuntu-24.04-arm
+    # A Next build on native ARM takes ~2 min; anything approaching this is hung.
+    timeout-minutes: 30
+    # Emitted by its own step, NOT derived inside "Build and push": that step
+    # exits early when the tag is already present, so a tag computed there
+    # would be missing on exactly the re-run path where deploy still has work.
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
     # Actions are pinned to full commit SHAs, not major tags. This job holds
     # id-token: write and assumes a role that can push to ECR, so an upstream
     # tag move would silently change code running with cloud write access.
@@ -41,13 +61,16 @@ jobs:
       - id: ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
+      - id: meta
+        run: echo "tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         working-directory: components/grid-wallet-prod
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
+          TAG: ${{ steps.meta.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="sha-${GITHUB_SHA}"
           IMAGE="${REGISTRY}/grid-wallet-prod:${TAG}"
 
           # The ECR repo is IMMUTABLE-tagged, so re-pushing an existing tag is
@@ -85,3 +108,110 @@ jobs:
             -t "$IMAGE" .
           docker push "$IMAGE"
           echo "Pushed $IMAGE"
+
+  deploy:
+    needs: build
+    # An ARC runner in tooling-prod, whose image bakes a checksum-pinned argocd
+    # CLI (same as golinks/docket) — no install step, and no Docker daemon
+    # needed here, which is why the build job cannot share this runner. The
+    # scale set is org-scoped (githubConfigUrl is the lightsparkdev org), so
+    # grid-api can target it even though no other job in this repo does yet.
+    runs-on: arc-runner-1
+    # No other job in this repo targets an ARC label, so scheduling here is
+    # unproven. Without a bound, a scale set that never provisions leaves this
+    # job queued until the platform limit rather than failing visibly. The two
+    # argocd calls each carry their own --timeout 300, so this only has to
+    # backstop the scheduling and auth phases.
+    timeout-minutes: 20
+    steps:
+      # Fail fast, with the version on record, if the image ever ships without it.
+      - name: Check ArgoCD CLI
+        run: argocd version --client
+
+      # GitHub OIDC → Dex token exchange, so no long-lived ArgoCD token lives in
+      # repo secrets. NOTE: golinks/docket reach the ID-token endpoint through
+      # actions/github-script because they authenticate with
+      # ACTIONS_RUNTIME_TOKEN, which is not exposed to `run` steps.
+      # ACTIONS_ID_TOKEN_REQUEST_{URL,TOKEN} are, so the action is unnecessary —
+      # one less pinned third-party dependency in a job that can write to the
+      # cluster. If this step ever fails to get a token, that indirection is the
+      # documented fallback.
+      - name: Authenticate to ArgoCD via OIDC
+        id: argocd-auth
+        run: |
+          set -euo pipefail
+          GH_TOKEN=$(curl -sSf "$ACTIONS_ID_TOKEN_REQUEST_URL" \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            -H "Accept: application/json; api-version=2.0" | jq -r .value)
+          # Check BEFORE masking: `jq -r` on a response without .value yields the
+          # string "null", and masking that would register "null" as a secret and
+          # redact it everywhere in the log, making the failure harder to read.
+          if [ -z "$GH_TOKEN" ] || [ "$GH_TOKEN" = "null" ]; then
+            echo "::error::no .value in the Actions ID-token response"
+            exit 1
+          fi
+          echo "::add-mask::$GH_TOKEN"
+
+          DEX_TOKEN=$(curl -sSf "https://argocd.tooling.sparkinfra.net/api/dex/token" \
+            --user argo-cd-cli: \
+            --data-urlencode "connector_id=github-actions" \
+            --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+            --data-urlencode "scope=openid email profile federated:id" \
+            --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token" \
+            --data-urlencode "subject_token=$GH_TOKEN" \
+            --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:id_token" \
+            | jq -r .access_token)
+          if [ -z "$DEX_TOKEN" ] || [ "$DEX_TOKEN" = "null" ]; then
+            echo "::error::Dex returned no access_token"
+            exit 1
+          fi
+          echo "::add-mask::$DEX_TOKEN"
+          echo "token=$DEX_TOKEN" >> "$GITHUB_OUTPUT"
+
+      # The running tag lives in the Application's spec.source.helm.parameters,
+      # NOT in the ops repo's values.yaml — the house pattern for this cluster
+      # (golinks, docket, zeroconf, observatory). The parameter overrides
+      # values.yaml, so the chart's placeholder tag is never what runs.
+      - name: Point the app at the new image
+        env:
+          ARGOCD_SERVER: argocd.tooling.sparkinfra.net
+          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-auth.outputs.token }}
+          TAG: ${{ needs.build.outputs.tag }}
+        run: argocd app set grid-wallet-prod --parameter "image.tag=$TAG" --grpc-web
+
+      # A whole-app sync rather than golinks' --resource-scoped one: this chart
+      # also carries a Service, and a chart-only change with no new image must
+      # still roll out. Safe without --prune, and the app's Secret is
+      # Terraform-owned and not templated by the chart, so a sync cannot fight
+      # it. The workflow-level concurrency group serializes deploys.
+      #
+      # `wait` is deliberately NOT --resource-scoped either: scoping the sync
+      # wide but the wait to the Deployment would let a failing Service sync
+      # through unnoticed, which is the exact gap widening the sync was meant
+      # to close.
+      - name: Sync and wait for rollout
+        env:
+          ARGOCD_SERVER: argocd.tooling.sparkinfra.net
+          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          argocd app sync grid-wallet-prod --timeout 300 --grpc-web
+          argocd app wait grid-wallet-prod --health --timeout 300 --grpc-web
+
+      # `argocd app set --parameter` accepts an unknown key silently, so a typo
+      # in the parameter name would sync cleanly, leave the OLD image running,
+      # and still pass the health wait — a green build that deployed nothing.
+      # Assert a live image actually carries the tag this run pushed. This also
+      # catches the non-atomic case where `set` landed but the rollout did not.
+      - name: Verify the rolled-out image
+        env:
+          ARGOCD_SERVER: argocd.tooling.sparkinfra.net
+          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-auth.outputs.token }}
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          argocd app get grid-wallet-prod --grpc-web -o json \
+            | jq -e --arg tag "$TAG" \
+                '(.status.summary.images // []) | any(endswith(":" + $tag))' >/dev/null \
+            || { echo "::error::rollout finished but no live image carries tag $TAG"; exit 1; }
+          echo "Verified: a live image carries $TAG"


### PR DESCRIPTION
The workflow built and pushed an image, but nothing deployed it. The app has no `syncPolicy.automated` (and the `public-http-app` module doesn't expose one), so every deploy was a manual `argocd sync`. This closes that.

**Depends on lightsparkdev/tooling-infra#138 — land that first.** It grants this repo's main-branch CI the ArgoCD permission used here; without it the deploy job fails with `PermissionDenied`.

## Approach

Follows the pattern golinks / docket / zeroconf / observatory already use against this cluster: GitHub OIDC → Dex token exchange (no long-lived ArgoCD token in repo secrets), set the `image.tag` helm parameter on the Application, sync, wait, verify.

## Details worth a look

- **The `tag` output comes from its own `meta` step.** "Build and push" `exit 0`s early when the immutable tag already exists, so a tag computed *inside* that step would be empty on exactly the re-run path where the deploy still has work to do.
- **`sync` and `wait` are both whole-app.** golinks scopes both to the Deployment; widening the sync (so a chart-only change with no new image still rolls out) while leaving the wait Deployment-scoped would let a failing Service sync through unnoticed.
- **A verify step asserts a live image carries the pushed tag.** `argocd app set --parameter` accepts an unknown key *silently*, so a typo'd parameter name would sync cleanly, leave the old image running, and still pass the health wait — a green build that deployed nothing. This also catches the non-atomic case where `set` landed but the rollout didn't.
- **`if: github.ref == 'refs/heads/main'` on `build`.** The ECR trust policy and ArgoCD RBAC already reject a non-main dispatch, but both live in other repos and could be relaxed independently; this keeps the gate visible next to the trigger. `deploy` inherits it via `needs: build`.
- **No `actions/github-script`.** golinks needs it only to reach `ACTIONS_RUNTIME_TOKEN`, which isn't exposed to `run` steps; `ACTIONS_ID_TOKEN_REQUEST_{URL,TOKEN}` are. One less pinned third-party action in a job that can write to the cluster.
- **No GitHub `environment`, deliberately.** Declaring one rewrites the OIDC `sub` away from `ref:refs/heads/main` and breaks both the ECR role trust policy and the ArgoCD RBAC entry.
- **`timeout-minutes` on both jobs.** No other job in this repo targets an ARC label, so scheduling on `arc-runner-1` is unproven; without a bound, a scale set that never provisions leaves the job queued instead of failing.

## Known tradeoff

Deploys are now automatic on every qualifying merge, which weakens the design spec's accepted-risk mitigation for `Recreate`-induced webhook loss ("don't deploy while someone is demoing") — no human picks the moment now. Accepted knowingly; a GitHub `environment` approval gate was rejected because of the OIDC `sub` constraint above. The escape hatch, if it bites, is gating `deploy` on the commit message.

## Review

Greptile 5/5, no comments. Also went through a 7-review Codex + Gemini panel (correctness / security / tests / spec-compliance / pattern-fit); the fixes above are what came out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
