### PR TITLE
Remove remittanceInformation from the Quote response schema

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21028,11 +21028,6 @@ components:
           type: string
           description: The ID of the transaction created from this quote.
           example: Transaction:019542f5-b3e7-1d02-0000-000000000005
-        remittanceInformation:
-          type: string
-          maxLength: 80
-          description: 'Free-form information about the payment that travels with it to the recipient, as provided on the quote request. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
-          example: '12345'
         counterpartyInformation:
           $ref: '#/components/schemas/CounterpartyInformation'
           description: Additional information about the counterparty, if available and required by the platform in their configuration.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21028,11 +21028,6 @@ components:
           type: string
           description: The ID of the transaction created from this quote.
           example: Transaction:019542f5-b3e7-1d02-0000-000000000005
-        remittanceInformation:
-          type: string
-          maxLength: 80
-          description: 'Free-form information about the payment that travels with it to the recipient, as provided on the quote request. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
-          example: '12345'
         counterpartyInformation:
           $ref: '#/components/schemas/CounterpartyInformation'
           description: Additional information about the counterparty, if available and required by the platform in their configuration.

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -129,17 +129,6 @@ properties:
     type: string
     description: The ID of the transaction created from this quote.
     example: Transaction:019542f5-b3e7-1d02-0000-000000000005
-  remittanceInformation:
-    type: string
-    maxLength: 80
-    description: >-
-      Free-form information about the payment that travels with it to the
-      recipient, as provided on the quote request. The field this populates
-      depends on the payment rail: for ACH it populates the Addenda record, for
-      FedNow and RTP it populates the remittanceInformation field, and for wires
-      it populates the OBI (Originator to Beneficiary Information) / beneficiary
-      information.
-    example: '12345'
   counterpartyInformation:
     $ref: ../transactions/CounterpartyInformation.yaml
     description: >-


### PR DESCRIPTION
## Summary

`remittanceInformation` is an input field only — callers set it on `POST /quotes` and it travels with the payment on the rail. The `Quote` response schema was also echoing it back, which documented a field the API does not return.

This removes it from `Quote` (the response) and leaves it in place on `QuoteRequest`.

## Changes: 3 files

- `openapi/components/schemas/quotes/Quote.yaml` — drop the `remittanceInformation` property
- `openapi.yaml`, `mintlify/openapi.yaml` — regenerated bundles (`make build`)

No version bump: the field was never a documented, relied-upon part of the response, and no `servers.url` path change is involved.

## Test plan

- `make build` — bundles regenerate cleanly
- `make lint` — 0 errors (630 pre-existing warnings/infos, unchanged by this diff)
- Confirmed no other reference to the field on the response side: request-side usages in the CLI (`cli/src/commands/quotes.ts`, `cli/src/commands/transfers.ts`), the visualizer code generator, the docs snippets, `TransferOutRequest`, and `RealtimeFundingTransactionSource` are all untouched

Requested by @shreyav

Original PR: https://github.com/lightsparkdev/grid-api/pull/757