### PR TITLE
feat: document SCA_SESSION_REQUIRED (409) and ACCOUNT_LOCKED (423) on quote authorize

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3891,11 +3891,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error404'
         '409':
-          description: SCA is not required for this customer, or the quote has no pending challenge to authorize.
+          description: SCA is not required for this customer, or the quote has no pending challenge to authorize. Also returned with `SCA_SESSION_REQUIRED` when the customer's SCA login session is missing or expired — re-authenticate the customer, then authorize again.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '423':
+          description: Returned with `ACCOUNT_LOCKED` when the customer's login is temporarily locked after too many failed authorization attempts. The customer must wait for the lock to expire before authorizing again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error423'
         '429':
           description: Too many requests. Returned with `RATE_LIMITED` when authorization attempts for this challenge happen too frequently (for example, repeated bad codes brute-forcing the OTP). The challenge may be invalidated after too many failed attempts. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
           content:
@@ -12580,6 +12586,7 @@ components:
             | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
+            | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -12588,6 +12595,7 @@ components:
             - EMAIL_OTP_EMAIL_ALREADY_EXISTS
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
             - PASSKEY_ALREADY_ENROLLED
+            - SCA_SESSION_REQUIRED
             - CONFLICT
         message:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3891,11 +3891,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error404'
         '409':
-          description: SCA is not required for this customer, or the quote has no pending challenge to authorize.
+          description: SCA is not required for this customer, or the quote has no pending challenge to authorize. Also returned with `SCA_SESSION_REQUIRED` when the customer's SCA login session is missing or expired — re-authenticate the customer, then authorize again.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '423':
+          description: Returned with `ACCOUNT_LOCKED` when the customer's login is temporarily locked after too many failed authorization attempts. The customer must wait for the lock to expire before authorizing again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error423'
         '429':
           description: Too many requests. Returned with `RATE_LIMITED` when authorization attempts for this challenge happen too frequently (for example, repeated bad codes brute-forcing the OTP). The challenge may be invalidated after too many failed attempts. Clients should back off and retry after the interval indicated by the `Retry-After` response header.
           content:
@@ -12580,6 +12586,7 @@ components:
             | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
+            | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -12588,6 +12595,7 @@ components:
             - EMAIL_OTP_EMAIL_ALREADY_EXISTS
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
             - PASSKEY_ALREADY_ENROLLED
+            - SCA_SESSION_REQUIRED
             - CONFLICT
         message:
           type: string

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -20,6 +20,7 @@ properties:
       | EMAIL_OTP_EMAIL_ALREADY_EXISTS | Email address is already associated with an EMAIL_OTP credential |
       | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
       | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
+      | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -28,6 +29,7 @@ properties:
       - EMAIL_OTP_EMAIL_ALREADY_EXISTS
       - EMAIL_OTP_CREDENTIAL_SET_CHANGED
       - PASSKEY_ALREADY_ENROLLED
+      - SCA_SESSION_REQUIRED
       - CONFLICT
   message:
     type: string

--- a/openapi/paths/quotes/quotes_{quoteId}_authorize.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}_authorize.yaml
@@ -64,11 +64,22 @@ post:
     '409':
       description: >-
         SCA is not required for this customer, or the quote has
-        no pending challenge to authorize.
+        no pending challenge to authorize. Also returned with
+        `SCA_SESSION_REQUIRED` when the customer's SCA login session is missing
+        or expired — re-authenticate the customer, then authorize again.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error409.yaml
+    '423':
+      description: >-
+        Returned with `ACCOUNT_LOCKED` when the customer's login is temporarily
+        locked after too many failed authorization attempts. The customer must
+        wait for the lock to expire before authorizing again.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error423.yaml
     '429':
       description: >-
         Too many requests. Returned with `RATE_LIMITED` when authorization


### PR DESCRIPTION
## Summary

Two error codes the API already returns were missing from the spec, so a generated client rejected the response instead of surfacing the code.

- **`SCA_SESSION_REQUIRED` added to the `Error409` `code` enum.** The API returns this with HTTP 409 when the customer's Strong Customer Authentication login session is missing or expired. Because it was absent from the enum, a generated client raised a validation error while deserializing the response — so an integrator got an opaque failure rather than a code they could act on. It is deliberately distinct from a `401`, which means the *platform's* API credentials were rejected: a `401` is not customer-recoverable, whereas `SCA_SESSION_REQUIRED` means "re-authenticate the customer, then retry".

- **`POST /quotes/{quoteId}/authorize` now documents `409 SCA_SESSION_REQUIRED` and `423 ACCOUNT_LOCKED`.** This is the endpoint that surfaces both. Its `409` description previously covered only the "SCA not required / no pending challenge" cases, and it declared no `423` at all — even though the endpoint returns `ACCOUNT_LOCKED` when the customer's login is temporarily locked after too many failed authorization attempts. `Error423` already existed and needed no change; this just references it.

Both changes are additive and non-breaking, so `info.version` stays `2025-10-13`.

## Known limitation this does not fix

While verifying the above against the running implementation, I found that the error **envelope** does not match what the `ErrorNNN` schemas declare. The API sends:

```json
{"code": "SCA_SESSION_REQUIRED", "reason": "..."}
```

but every `ErrorNNN` schema requires `status`, `code`, and `message`. So a generated Python client rejects a real error body on `status` (`int_type`) and `message` (`string_type`) regardless of this change:

```
('status',)  | int_type    | Input should be a valid integer
('message',) | string_type | Input should be a valid string
```

This is pre-existing and applies to **every** documented error response across the spec, not just the two codes here — it is not introduced by this PR, and this PR is still a strict improvement (the enum is the published contract, and integrators reading the raw JSON body now have the code documented). But it does mean the typed-model path is not yet usable for error handling, so reconciling the envelope is worth its own change. Two options, both spec-wide decisions I did not want to make unilaterally: make the server emit `status`/`message`, or change the schemas to match reality (`reason`, and `status` not required).

Relatedly, `Error423`'s own description points readers at `details.lockedUntil` / `details.failedAttempts`, but no error path populates them — those fields appear only on the `200` body of `POST /sca/record-event`. I left that description alone rather than expand this PR's scope, and worded the new `423` on the authorize endpoint to promise only what is actually sent.

## Test plan

- `make lint` exits 0 (Redocly + Spectral, `--fail-severity=error`); the 630 remaining findings are pre-existing warnings/infos, 0 errors.
- `make build` rebundled `openapi.yaml` and `mintlify/openapi.yaml`; re-running it is a no-op, so the committed bundles byte-match the build output.
- Confirmed against the running implementation that both codes are genuinely emitted on this endpoint, each covered by a test asserting the status/code pair at the HTTP boundary — the `423` case is newly covered by a test added alongside this change. The `423` body was captured directly to confirm the wording matches what is sent.
- Diff is 4 files: 2 spec sources + the 2 generated bundles.

## Public

Documents two error codes the Grid API already returns: `SCA_SESSION_REQUIRED` (409) is added to the shared `Error409` enum, and `POST /quotes/{quoteId}/authorize` now documents both it and `423 ACCOUNT_LOCKED`.


Original PR: https://github.com/lightsparkdev/grid-api/pull/759