### PR TITLE
Add SCA_NOT_COMPLETED outgoing transaction failure reason

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -20373,7 +20373,11 @@ components:
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
         - COUNTERPARTY_POST_TX_FAILED
-      description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+        - SCA_NOT_COMPLETED
+      description: |-
+        Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+
+        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer Authentication challenge before it expired, so the transaction was never authorized and no funds were moved. Only occurs for customers in a region where SCA is required (e.g. the EU). Create a new quote to try again, and have the customer authorize it while the challenge is live.
     RailSelectionMode:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20373,7 +20373,11 @@ components:
         - LIGHTNING_PAYMENT_FAILED
         - FUNDING_AMOUNT_MISMATCH
         - COUNTERPARTY_POST_TX_FAILED
-      description: Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+        - SCA_NOT_COMPLETED
+      description: |-
+        Reason for failure of an outgoing transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+
+        `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer Authentication challenge before it expired, so the transaction was never authorized and no funds were moved. Only occurs for customers in a region where SCA is required (e.g. the EU). Create a new quote to try again, and have the customer authorize it while the challenge is live.
     RailSelectionMode:
       type: string
       enum:

--- a/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransactionFailureReason.yaml
@@ -5,7 +5,15 @@ enum:
   - LIGHTNING_PAYMENT_FAILED
   - FUNDING_AMOUNT_MISMATCH
   - COUNTERPARTY_POST_TX_FAILED
+  - SCA_NOT_COMPLETED
 description: >-
   Reason for failure of an outgoing transaction. This is used to provide more
   context on why a transaction failed. If the transaction is not in a failed
   state, this field is omitted.
+
+
+  `SCA_NOT_COMPLETED` means the customer did not satisfy the Strong Customer
+  Authentication challenge before it expired, so the transaction was never
+  authorized and no funds were moved. Only occurs for customers in a region
+  where SCA is required (e.g. the EU). Create a new quote to try again, and have
+  the customer authorize it while the challenge is live.


### PR DESCRIPTION
## Summary

Adds `SCA_NOT_COMPLETED` to `OutgoingTransactionFailureReason`.

When a customer in an SCA-regulated region (e.g. the EU) is issued a Strong Customer Authentication challenge for a money movement and never satisfies it, the challenge expires and the transaction fails. Today that surfaces with no `failureReason` at all, so integrators can't tell an abandoned authorization apart from a genuine payment failure — the two need completely different follow-up.

The new value is scoped narrowly to the case where nothing moved, so the guidance in the description ("no funds were moved; create a new quote and have the customer authorize it while the challenge is live") is always true when a client sees it. Failures where an intermediate leg already executed and needs operator reconciliation continue to surface as `QUOTE_EXECUTION_FAILED`, matching how other operational failures are reported.

## Compatibility

Non-breaking. `oasdiff breaking` against `main` reports **0 errors, 17 warnings** — all the same `response-property-enum-value-added` informational warning, one per operation that returns an outgoing transaction. The repo's breaking-changes gate runs with `--fail-on ERR`, so this passes, and `info.version` is unchanged per the repo convention of bumping only for breaking changes.

## Test plan

- `make build` — rebundled `openapi.yaml` + `mintlify/openapi.yaml`; the diff is limited to this enum and its description
- `make lint-openapi` — "Woohoo! Your API description is valid. 🎉", 0 errors (remaining warnings are pre-existing repo-wide `schema-properties-have-examples` noise, untouched by this change)
- `oasdiff breaking main HEAD --fail-on ERR` — exit 0

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/760