### PR TITLE
feat(errors): Error400.details.errors[] array for multi-field validation

### DIFF
--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -9,14 +9,14 @@ describe("error handling", () => {
         status: 400,
         code: "INVALID_REQUEST",
         message: "Bad request",
-        details: { field: "email" },
+        details: { errors: [{ field: "email" }] },
       },
     });
 
     const parsed = JSON.parse(stdout);
     expect(parsed.success).toBe(false);
     expect(parsed.error.code).toBe("INVALID_REQUEST");
-    expect(parsed.error.details).toEqual({ field: "email" });
+    expect(parsed.error.details).toEqual({ errors: [{ field: "email" }] });
     // The whole error envelope must not be nested under details.
     expect(parsed.error.details.code).toBeUndefined();
   });

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11303,6 +11303,22 @@ components:
           type: integer
           description: Maximum length in characters.
           example: 500
+    FieldError:
+      type: object
+      required:
+        - field
+      description: One field-level validation failure. Field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`) emit an array of these under `details.errors` so platforms can render form-field-level UX for every failure in a single round-trip.
+      properties:
+        field:
+          type: string
+          description: Dot-notation path to the offending field.
+          example: taxIdentifier
+        constraint:
+          $ref: '#/components/schemas/FieldConstraint'
+        message:
+          type: string
+          description: Human-readable explanation of what's wrong with this field.
+          example: Value is not one of the allowed enum members.
     Error400:
       type: object
       required:
@@ -11404,14 +11420,13 @@ components:
           description: Error message
         details:
           type: object
-          description: Additional error details. Shape varies by `code`. For field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`), `details.field` and `details.constraint` are populated so platforms can pre-validate their onboarding form before re-submitting.
+          description: Additional error details. Shape varies by `code`. For field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`), `details.errors[]` enumerates every invalid field so platforms can render form-field-level UX for the entire request in a single round-trip.
           properties:
-            field:
-              type: string
-              description: Dot-notation path to the offending field. Present on field-validation errors from submit endpoints.
-              example: taxIdentifier
-            constraint:
-              $ref: '#/components/schemas/FieldConstraint'
+            errors:
+              type: array
+              description: One entry per invalid field. Present on field-validation errors from submit endpoints.
+              items:
+                $ref: '#/components/schemas/FieldError'
           additionalProperties: true
     Error501:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11303,6 +11303,22 @@ components:
           type: integer
           description: Maximum length in characters.
           example: 500
+    FieldError:
+      type: object
+      required:
+        - field
+      description: One field-level validation failure. Field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`) emit an array of these under `details.errors` so platforms can render form-field-level UX for every failure in a single round-trip.
+      properties:
+        field:
+          type: string
+          description: Dot-notation path to the offending field.
+          example: taxIdentifier
+        constraint:
+          $ref: '#/components/schemas/FieldConstraint'
+        message:
+          type: string
+          description: Human-readable explanation of what's wrong with this field.
+          example: Value is not one of the allowed enum members.
     Error400:
       type: object
       required:
@@ -11404,14 +11420,13 @@ components:
           description: Error message
         details:
           type: object
-          description: Additional error details. Shape varies by `code`. For field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`), `details.field` and `details.constraint` are populated so platforms can pre-validate their onboarding form before re-submitting.
+          description: Additional error details. Shape varies by `code`. For field-validation errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`), `details.errors[]` enumerates every invalid field so platforms can render form-field-level UX for the entire request in a single round-trip.
           properties:
-            field:
-              type: string
-              description: Dot-notation path to the offending field. Present on field-validation errors from submit endpoints.
-              example: taxIdentifier
-            constraint:
-              $ref: '#/components/schemas/FieldConstraint'
+            errors:
+              type: array
+              description: One entry per invalid field. Present on field-validation errors from submit endpoints.
+              items:
+                $ref: '#/components/schemas/FieldError'
           additionalProperties: true
     Error501:
       type: object

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -101,15 +101,14 @@ properties:
     description: >-
       Additional error details. Shape varies by `code`. For field-validation
       errors on submit endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`),
-      `details.field` and `details.constraint` are populated so platforms can
-      pre-validate their onboarding form before re-submitting.
+      `details.errors[]` enumerates every invalid field so platforms can render
+      form-field-level UX for the entire request in a single round-trip.
     properties:
-      field:
-        type: string
+      errors:
+        type: array
         description: >-
-          Dot-notation path to the offending field. Present on field-validation
-          errors from submit endpoints.
-        example: taxIdentifier
-      constraint:
-        $ref: ./FieldConstraint.yaml
+          One entry per invalid field. Present on field-validation errors from
+          submit endpoints.
+        items:
+          $ref: ./FieldError.yaml
     additionalProperties: true

--- a/openapi/components/schemas/errors/FieldError.yaml
+++ b/openapi/components/schemas/errors/FieldError.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - field
+description: >-
+  One field-level validation failure. Field-validation errors on submit
+  endpoints (e.g. `POST /customers`, `PATCH /customers/{id}`) emit an array of
+  these under `details.errors` so platforms can render form-field-level UX
+  for every failure in a single round-trip.
+properties:
+  field:
+    type: string
+    description: Dot-notation path to the offending field.
+    example: taxIdentifier
+  constraint:
+    $ref: ./FieldConstraint.yaml
+  message:
+    type: string
+    description: Human-readable explanation of what's wrong with this field.
+    example: Value is not one of the allowed enum members.


### PR DESCRIPTION
## Summary

Replaces singular `details.field` + `details.constraint` on `Error400` with a typed `details.errors[]` array so submit endpoints (`POST /customers`, `PATCH /customers/{id}`) can report every invalid field in one round-trip.

## Motivation

The consumer implementation on the sparkcore side (webdev#31110) iterates all pydantic errors and emits one entry per invalid field. The spec previously only surfaced the first as machine-readable — platform integrators would have to re-submit and see the next one on each round-trip. The array shape lets them render form-field-level UX for the whole request in one shot.

## Changes: 4 files

- `openapi/components/schemas/errors/FieldError.yaml` — new schema: `{field: required string, constraint?: FieldConstraint, message?: string}`. One entry per invalid field.
- `openapi/components/schemas/errors/Error400.yaml` — `details` now has `errors: array` of `FieldError`; drops the singular `field` and `constraint` properties.
- `openapi.yaml` + `mintlify/openapi.yaml` — regenerated bundles (`make build`).

## Breaking change

`details.field` and `details.constraint` are removed at the top level of `details`. Approved per [lightsparkdev/webdev#31110](https://github.com/lightsparkdev/webdev/pull/31110) review — no external consumers had wired the previous shape into production yet, so this is safe to change in place.

Skipping the `info.version` bump on that basis; happy to add one if reviewers prefer.

## Downstream consumer

The sparkcore side lives in [lightsparkdev/webdev#31110](https://github.com/lightsparkdev/webdev/pull/31110). After this lands, that PR will regenerate the grid-api Python client and drop its backwards-compat singular field/constraint carriage on `GridException`.

Requested by @akanter

Original PR: https://github.com/lightsparkdev/grid-api/pull/763