### PR TITLE
feat(payment-instructions): allow USDT as an Ethereum wallet assetType

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14632,6 +14632,7 @@ components:
               description: Type of asset
               enum:
                 - USDC
+                - USDT
     AedAccountInfoBase:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14632,6 +14632,7 @@ components:
               description: Type of asset
               enum:
                 - USDC
+                - USDT
     AedAccountInfoBase:
       type: object
       required:

--- a/openapi/components/schemas/common/PaymentEthereumWalletInfo.yaml
+++ b/openapi/components/schemas/common/PaymentEthereumWalletInfo.yaml
@@ -7,5 +7,6 @@ allOf:
       assetType:
         type: string
         description: Type of asset
-        enum: 
+        enum:
           - USDC
+          - USDT


### PR DESCRIPTION
## Summary

Allows `USDT` as an `assetType` on the Ethereum wallet payment-instruction schema, so an internal account denominated in USDT can return Ethereum L1 funding instructions. Previously `PaymentEthereumWalletInfo.assetType` accepted only `USDC`, which meant a USDT balance had no way to express an Ethereum L1 deposit address.

USDT is already a valid `assetType` on the Tron wallet schema; this brings Ethereum in line.

## Changes

- `openapi/components/schemas/common/PaymentEthereumWalletInfo.yaml` — add `USDT` to the `assetType` enum
- `openapi.yaml`, `mintlify/openapi.yaml` — rebundled via `make build`

No change to `EthereumWalletExternalAccountInfo`: external accounts carry no `assetType`, and their currency comes from the request body, which already accepts USDT.

## Test plan

- `make lint-openapi` — 0 errors (the 136 warnings / 494 infos are pre-existing repo-wide `schema-properties-have-{examples,descriptions}` noise; none reference this schema)
- `oasdiff breaking <main> <head> --format singleline --fail-on ERR` — **0 errors, 37 warnings**, all `response-property-enum-value-added` for the operations that return payment instructions. Adding a value to a response enum is non-breaking, so `info.version` is intentionally unchanged.

Reply with a comment (e.g. LGTM) to approve — emoji reactions don't notify me here.

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/766