### PR TITLE
feat: document BENEFICIARY_TRUSTED (409) on customer external-account delete

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2363,7 +2363,7 @@ paths:
       summary: Delete customer external account by ID
       description: |-
         Delete a customer external account by its system-generated ID.
-        An account that is currently a trusted beneficiary cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
+        An account that is currently a trusted beneficiary for SCA cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
       operationId: deleteCustomerExternalAccountById
       tags:
         - External Accounts

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2361,7 +2361,9 @@ paths:
                 $ref: '#/components/schemas/Error500'
     delete:
       summary: Delete customer external account by ID
-      description: Delete a customer external account by its system-generated ID
+      description: |-
+        Delete a customer external account by its system-generated ID.
+        An account that is currently a trusted beneficiary cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
       operationId: deleteCustomerExternalAccountById
       tags:
         - External Accounts
@@ -2382,6 +2384,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Returned with `BENEFICIARY_TRUSTED` when the external account is currently a trusted beneficiary. Untrust it first, then delete.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -12602,6 +12610,7 @@ components:
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
             | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
+            | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -12611,6 +12620,7 @@ components:
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
             - PASSKEY_ALREADY_ENROLLED
             - SCA_SESSION_REQUIRED
+            - BENEFICIARY_TRUSTED
             - CONFLICT
         message:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2363,7 +2363,7 @@ paths:
       summary: Delete customer external account by ID
       description: |-
         Delete a customer external account by its system-generated ID.
-        An account that is currently a trusted beneficiary cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
+        An account that is currently a trusted beneficiary for SCA cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
       operationId: deleteCustomerExternalAccountById
       tags:
         - External Accounts

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2361,7 +2361,9 @@ paths:
                 $ref: '#/components/schemas/Error500'
     delete:
       summary: Delete customer external account by ID
-      description: Delete a customer external account by its system-generated ID
+      description: |-
+        Delete a customer external account by its system-generated ID.
+        An account that is currently a trusted beneficiary cannot be deleted — untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete.
       operationId: deleteCustomerExternalAccountById
       tags:
         - External Accounts
@@ -2382,6 +2384,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Returned with `BENEFICIARY_TRUSTED` when the external account is currently a trusted beneficiary. Untrust it first, then delete.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -12602,6 +12610,7 @@ components:
             | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
             | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
+            | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -12611,6 +12620,7 @@ components:
             - EMAIL_OTP_CREDENTIAL_SET_CHANGED
             - PASSKEY_ALREADY_ENROLLED
             - SCA_SESSION_REQUIRED
+            - BENEFICIARY_TRUSTED
             - CONFLICT
         message:
           type: string

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -21,6 +21,7 @@ properties:
       | EMAIL_OTP_CREDENTIAL_SET_CHANGED | Tied EMAIL_OTP credential set changed after the signed-retry challenge was issued |
       | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
       | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
+      | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -30,6 +31,7 @@ properties:
       - EMAIL_OTP_CREDENTIAL_SET_CHANGED
       - PASSKEY_ALREADY_ENROLLED
       - SCA_SESSION_REQUIRED
+      - BENEFICIARY_TRUSTED
       - CONFLICT
   message:
     type: string

--- a/openapi/paths/customers/customers_external_accounts_{externalAccountId}.yaml
+++ b/openapi/paths/customers/customers_external_accounts_{externalAccountId}.yaml
@@ -43,7 +43,7 @@ delete:
   description: >-
     Delete a customer external account by its system-generated ID.
 
-    An account that is currently a trusted beneficiary cannot be deleted —
+    An account that is currently a trusted beneficiary for SCA cannot be deleted —
     untrust it first via
     `POST /customers/external-accounts/{externalAccountId}/untrust` (and its
     `/confirm`), then delete.

--- a/openapi/paths/customers/customers_external_accounts_{externalAccountId}.yaml
+++ b/openapi/paths/customers/customers_external_accounts_{externalAccountId}.yaml
@@ -40,7 +40,13 @@ get:
             $ref: ../../components/schemas/errors/Error500.yaml
 delete:
   summary: Delete customer external account by ID
-  description: Delete a customer external account by its system-generated ID
+  description: >-
+    Delete a customer external account by its system-generated ID.
+
+    An account that is currently a trusted beneficiary cannot be deleted —
+    untrust it first via
+    `POST /customers/external-accounts/{externalAccountId}/untrust` (and its
+    `/confirm`), then delete.
   operationId: deleteCustomerExternalAccountById
   tags:
     - External Accounts
@@ -61,6 +67,14 @@ delete:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Returned with `BENEFICIARY_TRUSTED` when the external account is
+        currently a trusted beneficiary. Untrust it first, then delete.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:


### PR DESCRIPTION
## Summary

`DELETE /customers/external-accounts/{externalAccountId}` can return `409` when the account is currently a trusted beneficiary, but the spec declared only `204`/`401`/`404`/`500`. This documents the missing status and its error code.

- **`BENEFICIARY_TRUSTED` added to the shared `Error409` `code` enum.** Because it was absent, a generated client would raise a validation error while deserializing the response instead of surfacing a code the integrator can branch on.
- **The `delete` operation now declares `409`** and its `description` states the ordering requirement: an account that is currently a trusted beneficiary must be untrusted first, via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), before it can be deleted.

Trust cannot be revoked as a side effect of a delete — untrusting a beneficiary requires the customer to complete a Strong Customer Authentication challenge, which a `DELETE` has no way to carry. So the delete is refused while trust is in place rather than leaving the account deleted but still trusted.

Both changes are additive and non-breaking, so `info.version` stays `2025-10-13`.

## Test plan

- `make lint` exits 0 (Redocly + Spectral, `--fail-severity=error`): 632 findings, **0 errors**, all pre-existing warnings/infos.
- `make build` rebundled `openapi.yaml` and `mintlify/openapi.yaml`; re-running it is a no-op, so the committed bundles byte-match the build output.
- The `409`/`BENEFICIARY_TRUSTED` pair is covered by tests asserting the status and code at the HTTP boundary, alongside the trust → refused-delete → untrust → successful-delete lifecycle.
- Diff is 4 files: 2 spec sources + the 2 generated bundles.

## Public

Documents a `409 BENEFICIARY_TRUSTED` response on `DELETE /customers/external-accounts/{externalAccountId}`: an external account that is currently a trusted beneficiary must be untrusted before it can be deleted.

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/769