### PR TITLE
Update example addresses across API docs and samples

### DIFF
--- a/mintlify/global-p2p/onboarding/configuring-customers.mdx
+++ b/mintlify/global-p2p/onboarding/configuring-customers.mdx
@@ -135,9 +135,9 @@ curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
     "address": {
       "line1": "456 Oak Avenue",
       "line2": "Floor 12",
-      "city": "New York",
-      "state": "NY",
-      "postalCode": "10001",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
       "country": "US"
     }
   }'

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -426,9 +426,9 @@ paths:
                   address:
                     line1: 123 Market Street
                     line2: Suite 400
-                    city: San Francisco
-                    state: CA
-                    postalCode: '94105'
+                    city: Seattle
+                    state: WA
+                    postalCode: '98101'
                     country: US
       responses:
         '201':
@@ -688,9 +688,9 @@ paths:
                     - USDC
                   address:
                     line1: 456 Market St
-                    city: San Francisco
-                    state: CA
-                    postalCode: '94103'
+                    city: Seattle
+                    state: WA
+                    postalCode: '98101'
                     country: US
               businessUpdate:
                 summary: Update business customer example
@@ -705,9 +705,9 @@ paths:
                     taxId: EIN-123456789
                   address:
                     line1: 100 Technology Parkway
-                    city: Palo Alto
-                    state: CA
-                    postalCode: '94304'
+                    city: Bellevue
+                    state: WA
+                    postalCode: '98004'
                     country: US
               embeddedWalletEmailUpdate:
                 summary: Embedded Wallet email update request (both steps)
@@ -10056,9 +10056,9 @@ webhooks:
                     address:
                       line1: 123 Main Street
                       line2: Apt 4B
-                      city: San Francisco
-                      state: CA
-                      postalCode: '94105'
+                      city: Seattle
+                      state: WA
+                      postalCode: '98101'
                       country: US
                     createdAt: '2025-07-21T17:32:28Z'
                     updatedAt: '2025-07-21T17:32:28Z'
@@ -10103,9 +10103,9 @@ webhooks:
                     kybStatus: APPROVED
                     address:
                       line1: 456 Business Ave
-                      city: New York
-                      state: NY
-                      postalCode: '10001'
+                      city: Seattle
+                      state: WA
+                      postalCode: '98101'
                       country: US
                     businessInfo:
                       legalName: Acme Corporation

--- a/mintlify/payouts-and-b2b/onboarding/configuring-customers.mdx
+++ b/mintlify/payouts-and-b2b/onboarding/configuring-customers.mdx
@@ -65,9 +65,9 @@ curl -X PATCH "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}
     "customerType": "INDIVIDUAL",
     "address": {
       "line1": "456 Market St",
-      "city": "San Francisco",
-      "state": "CA",
-      "postalCode": "94103",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
       "country": "US"
     }
   }'

--- a/mintlify/ramps/platform-tools/sandbox-testing.mdx
+++ b/mintlify/ramps/platform-tools/sandbox-testing.mdx
@@ -77,9 +77,9 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
     "birthDate": "1990-01-15",
     "address": {
       "line1": "123 Test Street",
-      "city": "San Francisco",
-      "state": "CA",
-      "postalCode": "94105",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
       "country": "US"
     }
   }'

--- a/mintlify/snippets/creating-customers/customers.mdx
+++ b/mintlify/snippets/creating-customers/customers.mdx
@@ -123,9 +123,9 @@ curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
     "address": {
       "line1": "456 Oak Avenue",
       "line2": "Floor 12",
-      "city": "New York",
-      "state": "NY",
-      "postalCode": "10001",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
       "country": "US"
     }
   }}'

--- a/mintlify/snippets/kyc/kyc-regulated.mdx
+++ b/mintlify/snippets/kyc/kyc-regulated.mdx
@@ -73,9 +73,9 @@ The examples below show a more comprehensive set of data. Not all fields are str
       "address": {
         "line1": "456 Oak Avenue",
         "line2": "Floor 12",
-        "city": "New York",
-        "state": "NY",
-        "postalCode": "10001",
+        "city": "Seattle",
+        "state": "WA",
+        "postalCode": "98101",
         "country": "US"
       }
     }

--- a/mintlify/snippets/kyc/kyc-unregulated.mdx
+++ b/mintlify/snippets/kyc/kyc-unregulated.mdx
@@ -241,9 +241,9 @@ The shape of the flow depends on the customer type:
       },
       "address": {
         "line1": "456 Oak Avenue",
-        "city": "New York",
-        "state": "NY",
-        "postalCode": "10001",
+        "city": "Seattle",
+        "state": "WA",
+        "postalCode": "98101",
         "country": "US"
       }
     }'

--- a/mintlify/snippets/kyc/kyc-webhooks.mdx
+++ b/mintlify/snippets/kyc/kyc-webhooks.mdx
@@ -23,9 +23,9 @@ For regulated platforms, customers are created with `APPROVED` KYC status by def
     "address": {
       "line1": "123 Main Street",
       "line2": "Apt 4B",
-      "city": "San Francisco",
-      "state": "CA",
-      "postalCode": "94105",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
       "country": "US"
     },
     "createdAt": "2025-07-21T17:32:28Z",

--- a/mintlify/snippets/sandbox-verification.mdx
+++ b/mintlify/snippets/sandbox-verification.mdx
@@ -23,7 +23,7 @@ curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
     "fullName": "Jane Doe 003",
     "birthDate": "1990-01-15",
     "nationality": "US",
-    "address": { "line1": "123 Main St", "city": "SF", "state": "CA", "postalCode": "94105", "country": "US" }
+    "address": { "line1": "123 Main St", "city": "Seattle", "state": "WA", "postalCode": "98101", "country": "US" }
   }'
 
 # First verification attempt: returns MISSING_FIELD errors on edd.* fields

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -426,9 +426,9 @@ paths:
                   address:
                     line1: 123 Market Street
                     line2: Suite 400
-                    city: San Francisco
-                    state: CA
-                    postalCode: '94105'
+                    city: Seattle
+                    state: WA
+                    postalCode: '98101'
                     country: US
       responses:
         '201':
@@ -688,9 +688,9 @@ paths:
                     - USDC
                   address:
                     line1: 456 Market St
-                    city: San Francisco
-                    state: CA
-                    postalCode: '94103'
+                    city: Seattle
+                    state: WA
+                    postalCode: '98101'
                     country: US
               businessUpdate:
                 summary: Update business customer example
@@ -705,9 +705,9 @@ paths:
                     taxId: EIN-123456789
                   address:
                     line1: 100 Technology Parkway
-                    city: Palo Alto
-                    state: CA
-                    postalCode: '94304'
+                    city: Bellevue
+                    state: WA
+                    postalCode: '98004'
                     country: US
               embeddedWalletEmailUpdate:
                 summary: Embedded Wallet email update request (both steps)
@@ -10056,9 +10056,9 @@ webhooks:
                     address:
                       line1: 123 Main Street
                       line2: Apt 4B
-                      city: San Francisco
-                      state: CA
-                      postalCode: '94105'
+                      city: Seattle
+                      state: WA
+                      postalCode: '98101'
                       country: US
                     createdAt: '2025-07-21T17:32:28Z'
                     updatedAt: '2025-07-21T17:32:28Z'
@@ -10103,9 +10103,9 @@ webhooks:
                     kybStatus: APPROVED
                     address:
                       line1: 456 Business Ave
-                      city: New York
-                      state: NY
-                      postalCode: '10001'
+                      city: Seattle
+                      state: WA
+                      postalCode: '98101'
                       country: US
                     businessInfo:
                       legalName: Acme Corporation

--- a/openapi/paths/customers/customers.yaml
+++ b/openapi/paths/customers/customers.yaml
@@ -71,9 +71,9 @@ post:
               address:
                 line1: 123 Market Street
                 line2: Suite 400
-                city: San Francisco
-                state: CA
-                postalCode: '94105'
+                city: Seattle
+                state: WA
+                postalCode: '98101'
                 country: US
   responses:
     '201':

--- a/openapi/paths/customers/customers_{customerId}.yaml
+++ b/openapi/paths/customers/customers_{customerId}.yaml
@@ -125,9 +125,9 @@ patch:
                 - USDC
               address:
                 line1: 456 Market St
-                city: San Francisco
-                state: CA
-                postalCode: '94103'
+                city: Seattle
+                state: WA
+                postalCode: '98101'
                 country: US
           businessUpdate:
             summary: Update business customer example
@@ -142,9 +142,9 @@ patch:
                 taxId: EIN-123456789
               address:
                 line1: 100 Technology Parkway
-                city: Palo Alto
-                state: CA
-                postalCode: '94304'
+                city: Bellevue
+                state: WA
+                postalCode: '98004'
                 country: US
           embeddedWalletEmailUpdate:
             summary: Embedded Wallet email update request (both steps)

--- a/openapi/webhooks/customer-update.yaml
+++ b/openapi/webhooks/customer-update.yaml
@@ -59,9 +59,9 @@ post:
                 address:
                   line1: 123 Main Street
                   line2: Apt 4B
-                  city: San Francisco
-                  state: CA
-                  postalCode: '94105'
+                  city: Seattle
+                  state: WA
+                  postalCode: '98101'
                   country: US
                 createdAt: '2025-07-21T17:32:28Z'
                 updatedAt: '2025-07-21T17:32:28Z'
@@ -106,9 +106,9 @@ post:
                 kybStatus: APPROVED
                 address:
                   line1: 456 Business Ave
-                  city: New York
-                  state: NY
-                  postalCode: '10001'
+                  city: Seattle
+                  state: WA
+                  postalCode: '98101'
                   country: US
                 businessInfo:
                   legalName: Acme Corporation

--- a/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
+++ b/samples/kotlin/src/test/kotlin/com/grid/sample/EndToEndTest.kt
@@ -34,9 +34,9 @@ class EndToEndTest {
                     "address": {
                         "country": "US",
                         "line1": "123 Test St",
-                        "postalCode": "10001",
-                        "city": "New York",
-                        "state": "NY"
+                        "postalCode": "98101",
+                        "city": "Seattle",
+                        "state": "WA"
                     }
                 }
             """)
@@ -344,9 +344,9 @@ class EndToEndTest {
                     "address": {
                         "country": "US",
                         "line1": "123 Test St",
-                        "postalCode": "10001",
-                        "city": "New York",
-                        "state": "NY"
+                        "postalCode": "98101",
+                        "city": "Seattle",
+                        "state": "WA"
                     }
                 }
             """)


### PR DESCRIPTION
## Summary
Updated example addresses throughout the OpenAPI specification, documentation, and test samples to use Seattle, WA addresses instead of San Francisco, CA; Palo Alto, CA; and New York, NY addresses.

## Changes
- **OpenAPI specs** (`openapi/` and root `openapi.yaml`): Updated address examples in customer creation, update, and webhook examples to use Seattle, WA (98101) as the standard example location
- **Documentation** (`mintlify/`): Updated curl examples and code snippets across multiple guides (onboarding, KYC, sandbox testing, webhooks) to reference Seattle addresses
- **Test samples** (`samples/kotlin/`): Updated Kotlin end-to-end test fixtures to use Seattle address data
- **Webhook examples** (`openapi/webhooks/`): Standardized webhook payload examples to use Seattle addresses

## Implementation Details
- Replaced San Francisco, CA 94105 with Seattle, WA 98101
- Replaced Palo Alto, CA 94304 with Bellevue, WA 98004
- Replaced New York, NY 10001 with Seattle, WA 98101
- Changes are consistent across all OpenAPI files, documentation snippets, and test code

Note: After merging, run `make build` to rebundle the OpenAPI spec and `make lint` to verify all changes.

https://claude.ai/code/session_01Vz9VX19sqfTKC481TTfuxw