### PR TITLE
feat(flow-builder): add stablecoin bridge rails to cross-currency flows

### DIFF
--- a/components/grid-visualizer/src/app/page.tsx
+++ b/components/grid-visualizer/src/app/page.tsx
@@ -6,6 +6,8 @@ import { usePanelCollapse } from '@/hooks/usePanelCollapse';
 import { Header } from '@/components/Header/Header';
 import { InputCard, CardChevron } from '@/components/InputCard/InputCard';
 import { FundingModelSection } from '@/components/FundingModelSection/FundingModelSection';
+import { SettlementSection } from '@/components/SettlementSection/SettlementSection';
+import { needsTwoSwitches } from '@/lib/flow-path';
 import { RegionPicker } from '@/components/RegionPicker/RegionPicker';
 import { PopularFlows } from '@/components/PopularFlows/PopularFlows';
 import { CurrencyPicker } from '@/components/CurrencyPicker/CurrencyPicker';
@@ -32,6 +34,7 @@ export default function Home() {
     setReceiveNetwork,
     setSourceFundingMode,
     setSourceRail,
+    setSettlementRail,
     swap,
     setSourceRegion,
     setDestRegion,
@@ -135,8 +138,7 @@ export default function Home() {
     });
   }, [mobileView, theme]);
 
-  const { flowExpanded, codeExpanded, toggleFlow, toggleCode } =
-    usePanelCollapse();
+  const { flowExpanded, codeExpanded, toggleFlow } = usePanelCollapse();
 
   return (
     <main className={styles.layout} data-mobile-view={mobileView}>
@@ -198,6 +200,14 @@ export default function Home() {
                   onModeChange={setSourceFundingMode}
                 />
               )}
+
+              {state.send && state.receive &&
+                needsTwoSwitches(state.send, state.receive, state.sourceRegion, state.destRegion) && (
+                <SettlementSection
+                  selectedAsset={state.settlementRail}
+                  onAssetChange={setSettlementRail}
+                />
+              )}
             </div>
 
             {isComplete && (
@@ -249,6 +259,7 @@ export default function Home() {
               sourceRegion={state.sourceRegion}
               destRegion={state.destRegion}
               sourceRail={state.sourceRail}
+              settlementRail={state.settlementRail}
               expanded={flowExpanded}
               onToggle={toggleFlow}
             />

--- a/components/grid-visualizer/src/components/FlowPanel/FlowPanel.tsx
+++ b/components/grid-visualizer/src/components/FlowPanel/FlowPanel.tsx
@@ -22,6 +22,7 @@ interface FlowPanelProps {
   sourceRegion?: string | null;
   destRegion?: string | null;
   sourceRail?: string | null;
+  settlementRail?: string | null;
   expanded: boolean;
   onToggle: () => void;
 }
@@ -193,7 +194,7 @@ function FlowNodeActionCard({
   );
 }
 
-const SWITCH_TOOLTIP = 'Grid Switch converts currencies and routes payments in real time using Bitcoin and local payment rails';
+const SWITCH_TOOLTIP = 'Grid Switch converts currencies and routes payments in real time using Bitcoin, stablecoins, and local payment rails';
 const EXTERNAL_TOOLTIP = 'External account — a bank account or crypto wallet outside of Grid';
 const INTERNAL_TOOLTIP = 'Grid internal account — holds a balance within Grid, enabling instant transfers';
 
@@ -266,10 +267,11 @@ export function FlowPanel({
   sourceRegion,
   destRegion,
   sourceRail,
+  settlementRail,
   expanded,
   onToggle,
 }: FlowPanelProps) {
-  const path = useMemo(() => buildFlowPath(send, receive, sourceRegion, destRegion, sourceRail), [send, receive, sourceRegion, destRegion, sourceRail]);
+  const path = useMemo(() => buildFlowPath(send, receive, sourceRegion, destRegion, sourceRail, settlementRail), [send, receive, sourceRegion, destRegion, sourceRail, settlementRail]);
   const pathKey = path.nodes.map((n) => n.id + n.label + n.isInternal + n.actionCards.map((a) => a.text).join(',')).join('|');
   const contentRef = useRef<HTMLDivElement>(null);
   const flowRef = useRef<HTMLDivElement>(null);
@@ -439,9 +441,12 @@ export function FlowPanel({
                   <svg className={styles.connectorOverlay}>
                     {connectors.map((c, i) => {
                       const connLabel = path.connectorLabels[i]?.text ?? 'Transfer';
+                      const isBridge = path.nodes[i]?.type === 'switch' && path.nodes[i + 1]?.type === 'switch';
                       const tipText = c.dashed
                         ? `${connLabel} — dashed line indicates external leg`
-                        : connLabel;
+                        : isBridge
+                          ? `${connLabel} — Grid picks the bridge rail automatically`
+                          : connLabel;
                       return (
                       <g
                         key={i}

--- a/components/grid-visualizer/src/components/SettlementSection/SettlementSection.module.scss
+++ b/components/grid-visualizer/src/components/SettlementSection/SettlementSection.module.scss
@@ -1,0 +1,128 @@
+@use '@lightsparkdev/origin/src/tokens/text-styles' as *;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  overflow: hidden;
+}
+
+// Divider — "Settlement rail" text + horizontal line
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px var(--spacing-xs) 0;
+}
+
+.dividerLabel {
+  font-family: var(--font-family-sans);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  font-feature-settings: 'salt' 1;
+}
+
+.dividerLine {
+  flex: 1;
+  height: 0;
+  border-top: var(--stroke-xs) solid var(--border-tertiary);
+}
+
+// Selector group — stacked options with shared border
+.selectorGroup {
+  corner-shape: squircle;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-base);
+  border: var(--stroke-xs) solid var(--border-tertiary);
+  border-radius: var(--corner-radius-md);
+  overflow: clip;
+
+  :global([data-theme='dark']) & {
+    background: var(--surface-primary);
+  }
+}
+
+// Individual option
+.option {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: var(--spacing-md);
+  min-width: 200px;
+  background: var(--surface-base);
+  cursor: pointer;
+  transition: background 100ms ease;
+
+  :global([data-theme='dark']) & {
+    background: var(--surface-primary);
+  }
+
+  &:not(:last-child) {
+    border-bottom: var(--stroke-xs) solid var(--border-tertiary);
+  }
+
+  &:hover {
+    background: var(--color-alpha-black-04);
+
+    :global([data-theme='dark']) & {
+      background: var(--color-alpha-white-04);
+    }
+  }
+}
+
+.optionSelected {
+  // No extra background — selected state shown by checkmark
+}
+
+.optionIcon {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.optionIconImg {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.optionContent {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.optionTitle {
+  @include label-sm;
+  color: var(--text-primary);
+  font-feature-settings: 'salt' 1;
+}
+
+.optionDesc {
+  @include body-sm;
+  color: var(--text-secondary);
+  font-feature-settings: 'salt' 1;
+}
+
+.optionCheck {
+  display: flex;
+  flex-shrink: 0;
+  color: var(--status-success);
+
+  svg path {
+    vector-effect: non-scaling-stroke;
+  }
+}
+
+.footnote {
+  @include body-sm;
+  color: var(--text-tertiary);
+  padding: 0 var(--spacing-xs);
+  font-feature-settings: 'salt' 1;
+}

--- a/components/grid-visualizer/src/components/SettlementSection/SettlementSection.tsx
+++ b/components/grid-visualizer/src/components/SettlementSection/SettlementSection.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { settlementRails } from '@/data/settlement-rails';
+import { IconCheckmark2Small } from '@central-icons-react/round-outlined-radius-3-stroke-1.5/IconCheckmark2Small';
+import { motion, AnimatePresence } from 'motion/react';
+import clsx from 'clsx';
+import styles from './SettlementSection.module.scss';
+
+interface SettlementSectionProps {
+  selectedAsset: string;
+  onAssetChange: (asset: string) => void;
+}
+
+export function SettlementSection({
+  selectedAsset,
+  onAssetChange,
+}: SettlementSectionProps) {
+  return (
+    <AnimatePresence>
+      <motion.div
+        className={styles.section}
+        initial={{ opacity: 0, height: 0 }}
+        animate={{ opacity: 1, height: 'auto' }}
+        exit={{ opacity: 0, height: 0 }}
+        transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+      >
+        {/* Divider */}
+        <div className={styles.divider}>
+          <span className={styles.dividerLabel}>Bridge via</span>
+          <div className={styles.dividerLine} />
+        </div>
+
+        {/* Selector group */}
+        <div className={styles.selectorGroup}>
+          {settlementRails.map((rail) => {
+            const isSelected = rail.asset === selectedAsset;
+            return (
+              <button
+                key={rail.asset}
+                className={clsx(styles.option, isSelected && styles.optionSelected)}
+                onClick={() => onAssetChange(rail.asset)}
+                type="button"
+              >
+                <span className={styles.optionIcon}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={rail.icon} alt="" className={styles.optionIconImg} />
+                </span>
+                <span className={styles.optionContent}>
+                  <span className={styles.optionTitle}>{rail.assetName}</span>
+                  <span className={styles.optionDesc}>
+                    {rail.asset === rail.assetName
+                      ? `via ${rail.networkLabel}`
+                      : `${rail.asset} via ${rail.networkLabel}`}
+                  </span>
+                </span>
+                {isSelected && (
+                  <motion.span
+                    className={styles.optionCheck}
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                  >
+                    <IconCheckmark2Small size={24} />
+                  </motion.span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <span className={styles.footnote}>
+          Grid picks the optimal bridge rail automatically. The API calls
+          stay the same.
+        </span>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/components/grid-visualizer/src/data/settlement-rails.ts
+++ b/components/grid-visualizer/src/data/settlement-rails.ts
@@ -1,0 +1,45 @@
+export interface SettlementRail {
+  /** Asset code used in flow action cards, e.g. 'BTC' */
+  asset: string;
+  /** Display name for the picker, e.g. 'Bitcoin' */
+  assetName: string;
+  /** Network the asset settles over, e.g. 'Lightning' */
+  network: string;
+  /** Connector-label copy, e.g. 'Lightning Network' */
+  networkLabel: string;
+  icon: string;
+}
+
+// Rails Grid orchestrates over between switches. Backed by the API spec:
+// USDC on Solana is the documented inter-VASP settlement-leg example
+// (ReconciliationInstructions), and Spark legs carry USDB
+// (PaymentSparkWalletInfo.assetType).
+export const settlementRails: SettlementRail[] = [
+  {
+    asset: 'BTC',
+    assetName: 'Bitcoin',
+    network: 'Lightning',
+    networkLabel: 'Lightning Network',
+    icon: '/crypto/btc.svg',
+  },
+  {
+    asset: 'USDC',
+    assetName: 'USDC',
+    network: 'Solana',
+    networkLabel: 'Solana',
+    icon: '/crypto/usdc.svg',
+  },
+  {
+    asset: 'USDB',
+    assetName: 'Bitcoin USD',
+    network: 'Spark',
+    networkLabel: 'Spark',
+    icon: '/crypto/usdb.svg',
+  },
+];
+
+export const DEFAULT_SETTLEMENT_RAIL = 'BTC';
+
+export function getSettlementRail(asset?: string | null): SettlementRail {
+  return settlementRails.find((r) => r.asset === asset) ?? settlementRails[0];
+}

--- a/components/grid-visualizer/src/hooks/useFlowBuilder.ts
+++ b/components/grid-visualizer/src/hooks/useFlowBuilder.ts
@@ -1,6 +1,7 @@
 import { useReducer, useCallback, useMemo } from 'react';
 import { currencies } from '@/data/currencies';
 import { cryptoAssets, type CryptoAccountType } from '@/data/crypto';
+import { DEFAULT_SETTLEMENT_RAIL } from '@/data/settlement-rails';
 import type { CurrencySelection } from '@/lib/code-generator';
 
 export type { CurrencySelection };
@@ -14,6 +15,7 @@ export interface FlowBuilderState {
   destRegion: string | null;   // fiat code — only used when destination is crypto
   sourceFundingMode: SourceFundingMode;
   sourceRail: string | null;   // selected fiat rail e.g. 'RTP' — null for crypto
+  settlementRail: string;      // asset Grid settles over between switches, e.g. 'BTC' | 'USDC' | 'USDB'
   audience: 'human' | 'agent';
   pickerTarget: 'send' | 'receive' | null;
 }
@@ -25,6 +27,7 @@ type Action =
   | { type: 'SET_RECEIVE_NETWORK'; payload: CryptoAccountType }
   | { type: 'SET_SOURCE_FUNDING_MODE'; payload: SourceFundingMode }
   | { type: 'SET_SOURCE_RAIL'; payload: string }
+  | { type: 'SET_SETTLEMENT_RAIL'; payload: string }
   | { type: 'SET_SOURCE_REGION'; payload: string }
   | { type: 'SET_DEST_REGION'; payload: string }
   | { type: 'SET_AUDIENCE'; payload: 'human' | 'agent' }
@@ -40,6 +43,7 @@ const initialState: FlowBuilderState = {
   destRegion: null,
   sourceFundingMode: 'external',
   sourceRail: null,
+  settlementRail: DEFAULT_SETTLEMENT_RAIL,
   audience: 'human',
   pickerTarget: null,
 };
@@ -115,6 +119,8 @@ function reducer(state: FlowBuilderState, action: Action): FlowBuilderState {
     }
     case 'SET_SOURCE_RAIL':
       return { ...state, sourceRail: action.payload };
+    case 'SET_SETTLEMENT_RAIL':
+      return { ...state, settlementRail: action.payload };
     case 'SET_SOURCE_REGION':
       return { ...state, sourceRegion: action.payload };
     case 'SET_DEST_REGION':
@@ -222,6 +228,11 @@ export function useFlowBuilder() {
     [],
   );
 
+  const setSettlementRail = useCallback(
+    (asset: string) => dispatch({ type: 'SET_SETTLEMENT_RAIL', payload: asset }),
+    [],
+  );
+
   const setSourceRegion = useCallback(
     (code: string) => dispatch({ type: 'SET_SOURCE_REGION', payload: code }),
     [],
@@ -260,6 +271,7 @@ export function useFlowBuilder() {
     setReceiveNetwork,
     setSourceFundingMode,
     setSourceRail,
+    setSettlementRail,
     setSourceRegion,
     setDestRegion,
     setAudience,

--- a/components/grid-visualizer/src/lib/flow-path.ts
+++ b/components/grid-visualizer/src/lib/flow-path.ts
@@ -136,14 +136,24 @@ export function buildFlowPath(
   const twoSwitches = needsTwoSwitches(source, destination, sourceRegion, destRegion);
 
   if (twoSwitches) {
-    // Source-side switch
-    const sourceConvertAction: ActionCard = source.code === settle.asset
-      ? { text: `Accept ${settle.asset} deposit`, color: settleColor }
+    // Source-side switch. When the source already holds the bridge asset there
+    // is no conversion: external wallets deposit into the switch, while internal
+    // balances need no receiving card at all (the endpoint card and connector
+    // already describe the debit from the Grid balance).
+    const sourceConvertAction: ActionCard | null = source.code === settle.asset
+      ? (source.isInternal
+          ? null
+          : { text: `Accept ${settle.asset} deposit`, color: settleColor })
       : {
           text: `Convert ${source.code} to ${settle.asset}`,
           color: settleColor,
           gradientFrom: sendColor,
         };
+
+    const sendAction: ActionCard = {
+      text: `Send ${settle.asset} via ${settle.network}`,
+      color: settleColor,
+    };
 
     nodes.push({
       id: 'switch1',
@@ -151,18 +161,21 @@ export function buildFlowPath(
       label: `${srcFiat} Grid Switch`,
       flag: srcFiatCC,
       isInternal: true,
-      actionCards: [
-        sourceConvertAction,
-        {
-          text: `Send ${settle.asset} via ${settle.network}`,
-          color: settleColor,
-        },
-      ],
+      actionCards: sourceConvertAction
+        ? [sourceConvertAction, sendAction]
+        : [sendAction],
     });
 
-    // Destination-side switch
+    // Destination-side switch. When the destination already holds the bridge
+    // asset, use internal-balance wording for internal accounts (matching how
+    // internal destinations render elsewhere) and wallet wording for external.
     const destConvertAction: ActionCard = destination.code === settle.asset
-      ? { text: `Deliver ${settle.asset} to wallet`, color: settleColor }
+      ? {
+          text: destination.isInternal
+            ? `Credit ${settle.asset} balance`
+            : `Deliver ${settle.asset} to wallet`,
+          color: settleColor,
+        }
       : {
           text: `Convert ${settle.asset} to ${destination.code}`,
           color: receiveColor,

--- a/components/grid-visualizer/src/lib/flow-path.ts
+++ b/components/grid-visualizer/src/lib/flow-path.ts
@@ -1,5 +1,6 @@
 import type { CurrencySelection } from './code-generator';
 import { currencies } from '@/data/currencies';
+import { getSettlementRail } from '@/data/settlement-rails';
 
 export type ActionColor = 'fiat' | 'btc' | 'stable';
 
@@ -62,17 +63,40 @@ function getEndpointSublabel(sel: CurrencySelection): string {
   return sel.isInternal ? 'Internal account' : 'External account';
 }
 
+/**
+ * Whether the flow bridges two Grid Switches (cross-currency across fiat
+ * regions) — the only case where the settlement rail is visible.
+ */
+export function needsTwoSwitches(
+  source: CurrencySelection,
+  destination: CurrencySelection,
+  sourceRegion?: string | null,
+  destRegion?: string | null,
+): boolean {
+  const srcFiat = source.type === 'fiat' ? source.code : (sourceRegion ?? null);
+  const dstFiat = destination.type === 'fiat' ? destination.code : (destRegion ?? null);
+  return (
+    source.code !== destination.code &&
+    srcFiat != null &&
+    dstFiat != null &&
+    srcFiat !== dstFiat
+  );
+}
+
 export function buildFlowPath(
   source: CurrencySelection,
   destination: CurrencySelection,
   sourceRegion?: string | null,
   destRegion?: string | null,
   sourceRail?: string | null,
+  settlementRail?: string | null,
 ): FlowPath {
   const nodes: FlowNode[] = [];
 
   const sendColor = colorForCurrency(source.code, source.type);
   const receiveColor = colorForCurrency(destination.code, destination.type);
+  const settle = getSettlementRail(settlementRail);
+  const settleColor = colorForCurrency(settle.asset, 'crypto');
 
   // Source endpoint
   nodes.push({
@@ -107,20 +131,17 @@ export function buildFlowPath(
   const dstFiat = destination.type === 'fiat' ? destination.code : dstRegionCode;
   const dstFiatCC = destination.type === 'fiat' ? destination.countryCode : dstRegionCC;
 
-  // Two switches needed when the fiat sides differ (cross-currency bridge via BTC/Lightning)
-  const needsTwoSwitches =
-    source.code !== destination.code &&
-    srcFiat != null &&
-    dstFiat != null &&
-    srcFiat !== dstFiat;
+  // Two switches needed when the fiat sides differ (cross-currency bridge
+  // over the selected settlement rail — BTC/Lightning by default)
+  const twoSwitches = needsTwoSwitches(source, destination, sourceRegion, destRegion);
 
-  if (needsTwoSwitches) {
+  if (twoSwitches) {
     // Source-side switch
-    const sourceConvertAction: ActionCard = source.code === 'BTC'
-      ? { text: 'Accept BTC deposit', color: 'btc' }
+    const sourceConvertAction: ActionCard = source.code === settle.asset
+      ? { text: `Accept ${settle.asset} deposit`, color: settleColor }
       : {
-          text: `Convert ${source.code} to BTC`,
-          color: 'btc',
+          text: `Convert ${source.code} to ${settle.asset}`,
+          color: settleColor,
           gradientFrom: sendColor,
         };
 
@@ -133,24 +154,24 @@ export function buildFlowPath(
       actionCards: [
         sourceConvertAction,
         {
-          text: 'Send BTC via Lightning',
-          color: 'btc',
+          text: `Send ${settle.asset} via ${settle.network}`,
+          color: settleColor,
         },
       ],
     });
 
     // Destination-side switch
-    const destConvertAction: ActionCard = destination.code === 'BTC'
-      ? { text: 'Deliver BTC to wallet', color: 'btc' }
+    const destConvertAction: ActionCard = destination.code === settle.asset
+      ? { text: `Deliver ${settle.asset} to wallet`, color: settleColor }
       : {
-          text: `Convert BTC to ${destination.code}`,
+          text: `Convert ${settle.asset} to ${destination.code}`,
           color: receiveColor,
-          gradientFrom: 'btc',
+          gradientFrom: settleColor,
         };
 
     const destDeliverAction: ActionCard | null =
-      destination.code === 'BTC'
-        ? null // BTC delivery is already covered above
+      destination.code === settle.asset
+        ? null // settlement-asset delivery is already covered above
         : {
             text: destination.isInternal
               ? `Credit ${destination.code} balance`
@@ -244,8 +265,8 @@ export function buildFlowPath(
         : (destination.network ?? destination.accountLabel);
       text = `Funds out via ${dstRail}`;
     } else if (curr.type === 'switch' && next.type === 'switch') {
-      // Switch → switch: Lightning bridge (always real-time)
-      text = 'Real-time via Lightning Network';
+      // Switch → switch: settlement bridge (always real-time)
+      text = `Real-time via ${settle.networkLabel}`;
     } else if (curr.type === 'endpoint' && curr.isInternal && next.type === 'switch') {
       text = `From Grid ${source.code} balance`;
     } else if (curr.type === 'switch' && next.type === 'endpoint' && next.isInternal) {


### PR DESCRIPTION
## Summary

- Cross-currency flows in the flow builder hardcoded the inter-switch leg to BTC over Lightning ("Convert USD to BTC → Send BTC via Lightning → Real-time via Lightning Network"), underselling the orchestration-across-BTC-and-stables pitch (raised by Davi).
- Adds a **"Bridge via"** selector in the sidebar — BTC via Lightning (default), USDC via Solana, USDB via Spark — shown only for two-switch (cross-fiat-region) flows. Picking a rail re-renders the bridge leg: convert/send action cards, the switch-to-switch connector label, and the stablecoin (purple) color treatment.
- **Visualization only.** The quote API has no settlement-rail field (the only rail an integrator can pin is the delivery `paymentRail` on a quote destination), so the generated curl/JSON steps are unchanged — which is itself the pitch: same API calls, Grid handles the routing. A footnote and the bridge-connector tooltip state this explicitly.

## Spec grounding

- USDC on Solana is the spec's documented inter-VASP settlement-leg example (`ReconciliationInstructions.transactionHash`).
- Spark settlement legs carry USDB (`PaymentSparkWalletInfo.assetType`).
- **USDT is deliberately excluded** — it only appears in the API as an external Tron delivery network, with no evidence it's used for inter-switch settlement. Easy to add if confirmed.

Also updates the Grid Switch hover tooltip to mention stablecoins alongside Bitcoin and local rails.

## Test plan

- [x] USD → BRL renders all three bridge rails correctly (cards, connector, colors)
- [x] Single-switch flows (e.g. USD → USDC) unchanged, selector hidden
- [x] Edge cases: BTC source with USDC bridge ("Convert BTC to USDC"), stable source matching the bridge asset ("Accept USDC deposit")
- [x] Generated API steps identical across rail selections
- [x] Visual check on grid-flow-builder.vercel.app preview deploy (light + dark)

Made with [Cursor](https://cursor.com)