### PR TITLE
feat(grid-visualizer): add SWIFT_ACCOUNT to accountTypeSpecs

### DIFF
--- a/components/grid-visualizer/src/data/account-types.ts
+++ b/components/grid-visualizer/src/data/account-types.ts
@@ -386,4 +386,15 @@ export const accountTypeSpecs: Record<string, AccountTypeSpec> = {
     ],
     beneficiaryRequired: true,
   },
+  SWIFT_ACCOUNT: {
+    accountType: 'SWIFT_ACCOUNT',
+    fields: [
+      { name: 'country', example: 'NG', description: 'Bank country code (ISO 3166-1 alpha-2)' },
+      { name: 'swiftCode', example: 'GTBINGLA' },
+      { name: 'bankName', example: 'Guaranty Trust Bank' },
+      { name: 'accountNumber', example: '1234567890', description: 'For most corridors' },
+      { name: 'iban', example: 'GB29NWBK60161331926819', description: 'For IBAN-only corridors (e.g. BR, GB)' },
+    ],
+    beneficiaryRequired: true,
+  },
 };


### PR DESCRIPTION
## Summary

`SWIFT_ACCOUNT` exists everywhere else in this repo — the OpenAPI schemas (`SwiftAccountInfoBase.yaml`, `ExternalAccountType.yaml`, `ExternalAccountInfoOneOf.yaml`, `PaymentInstructions.yaml`), the Mintlify docs (`mintlify/snippets/external-accounts.mdx` has a SWIFT tab), the grid-api skill reference (`.claude/skills/grid-api/references/account-types.md`), and the generated `bankAccountFields.generated.ts` in both `components/grid-wallet-demo` and `components/grid-wallet-prod`.

It was missing from exactly one place: `components/grid-visualizer/src/data/account-types.ts`. This PR adds it.

This supersedes the SWIFT portion of #478 and #531, both of which are being closed as largely superseded — the rest of their content already landed on `main` via later syncs. This one entry is the genuine remainder.

## Fields

Derived from `openapi/components/schemas/common/SwiftAccountInfoBase.yaml` rather than from the old PR descriptions:

| Field | Schema status |
|---|---|
| `country` | required (ISO 3166-1 alpha-2) |
| `swiftCode` | required |
| `bankName` | required |
| `accountNumber` | optional — "Required for most corridors" |
| `iban` | optional — "Required for IBAN-only corridors (e.g. BR, GB)" |

`accountNumber` and `iban` are conditionally exclusive. Both are listed with disambiguating `description`s, matching how the file already handles the same situation for `PKR_ACCOUNT`, `EGP_ACCOUNT`, `SLV_ACCOUNT` and `COP_ACCOUNT`.

`beneficiaryRequired: true` — every fiat bank account type in the file sets this, and the SWIFT example in `mintlify/snippets/external-accounts.mdx` includes a `beneficiary` block.

Example values match the Nigerian GTBank example already in the Mintlify SWIFT tab (`NG` / `GTBINGLA` / `Guaranty Trust Bank` / `1234567890`) rather than inventing new ones. The `iban` example is the schema's own example.

## ⚠️ This entry is currently unreachable in the UI — follow-up required

I investigated how `accountTypeSpecs` is consumed. It is read in exactly one file, `components/grid-visualizer/src/lib/code-generator.ts`, always as a lookup keyed by `CurrencySelection.accountType`:

- `buildAccountInfoBody()` → `accountTypeSpecs[sel.accountType]`
- `generateSteps()` → `accountTypeSpecs[destination.accountType]` / `accountTypeSpecs[source.accountType]`

Every `CurrencySelection` is constructed from one of only two data sources:

- `data/currencies.ts` — `FiatCurrency.accountType`, a **single string** per currency (built in `CurrencyPicker.lookupSelection()` and `hooks/useFlowBuilder.ts`)
- `data/crypto.ts` — `CryptoAsset.accountTypes[].type`

`SWIFT_ACCOUNT` is not a currency; it's a cross-currency correspondent-banking account type, so it appears in neither. **Nothing in the visualizer can currently produce `accountType === 'SWIFT_ACCOUNT'`, so this spec is dead data until a follow-up lands.**

I am deliberately *not* fixing that here: two other PRs are in flight against `components/grid-visualizer/src/data/currencies.ts` and touching it would create conflicts. The `account-types.ts` entry is correct and needed either way, so it ships now.

**What the follow-up needs to do:** allow a fiat currency to offer more than one account type, and let the user choose. Concretely:

1. In `data/currencies.ts`, widen `FiatCurrency` beyond the single `accountType: string` — e.g. add an optional `alternateAccountTypes?: { type: string; label: string }[]` — and add `SWIFT_ACCOUNT` as an alternate on the currencies where an international wire is a real option.
2. In `components/InputCard/InputCard.tsx`, add a fiat equivalent of the existing `getNetworkOptions()` / `NetworkDropdown` pattern (which already does exactly this for crypto assets with more than one `accountTypes` entry), so the selected account type flows into `CurrencySelection.accountType`.
3. Thread the choice through `CurrencyPicker.lookupSelection()` and `hooks/useFlowBuilder.ts`, both of which currently hard-assign `accountType: fiat.accountType`.

Once that lands, the spec added here is picked up by `code-generator.ts` with no further change.

## Testing / what I could not verify

- ✅ Typechecked the changed file standalone: `npx tsc --noEmit --strict --ignoreConfig --ignoreDeprecations 6.0 --target es2020 --moduleResolution bundler --module esnext src/data/account-types.ts` — clean. The file is pure TypeScript with no imports, so this is a complete check of it.
- ❌ **No full build or dev-server run.** `npm ci` in `components/grid-visualizer` fails because `@central-icons-react` requires a `CENTRAL_LICENSE_KEY` env var that is not available in this environment. I have not run the app, the project-wide `tsc`, ESLint, or any visual check.
- ❌ Consequently the rendered output was not verified — though as described above, there is currently no UI path that would render it.

There are no tests covering `account-types.ts` in this component.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnjJ8yWJsui7jLqqrDrL4)_