### PR TITLE
Add USD account bank, account type and wire routing fields

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -13600,13 +13600,13 @@ components:
           pattern: ^[0-9]{9}$
         bankName:
           type: string
-          description: The name of the financial institution holding the account
+          description: The name of the financial institution holding the account. Optional on every rail, and recommended for wires, where it identifies the beneficiary's institution on the payment message.
           example: Chase Bank
           minLength: 1
           maxLength: 140
         bankAccountType:
           type: string
-          description: Whether the account is a checking or a savings account
+          description: Whether the account is a checking or a savings account. Optional on every rail; when omitted, the account is treated as a checking account.
           enum:
             - CHECKING
             - SAVINGS

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -13598,10 +13598,43 @@ components:
           minLength: 9
           maxLength: 9
           pattern: ^[0-9]{9}$
+        bankName:
+          type: string
+          description: The name of the financial institution holding the account
+          example: Chase Bank
+          minLength: 1
+          maxLength: 140
+        bankAccountType:
+          type: string
+          description: Whether the account is a checking or a savings account
+          enum:
+            - CHECKING
+            - SAVINGS
+          example: CHECKING
+        intermediaryBankName:
+          type: string
+          description: The name of the intermediary financial institution, for accounts reachable only through a correspondent bank. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: JPMorgan Chase Bank
+          minLength: 1
+          maxLength: 140
+        intermediaryRoutingNumber:
+          type: string
+          description: The ABA routing number of the intermediary financial institution. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: '021000021'
+          minLength: 9
+          maxLength: 9
+          pattern: ^[0-9]{9}$
+        fiToFiInformation:
+          type: string
+          description: Bank-to-bank instructions carried alongside the payment. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: /BNF/Invoice 4471
+          maxLength: 210
       example:
         accountType: USD_ACCOUNT
         accountNumber: '1234567890'
         routingNumber: '021000021'
+        bankName: Chase Bank
+        bankAccountType: CHECKING
     UsdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
@@ -20774,6 +20807,24 @@ components:
           description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           allOf:
             - $ref: '#/components/schemas/PaymentRail'
+    PurposeOfPayment:
+      type: string
+      description: The purpose of the payment. This may be required when sending to certain geographies (e.g. India).
+      enum:
+        - GIFT
+        - SELF
+        - GOODS_OR_SERVICES
+        - EDUCATION
+        - HEALTH_OR_MEDICAL
+        - REAL_ESTATE_PURCHASE
+        - TAX_PAYMENT
+        - LOAN_PAYMENT
+        - UTILITY_BILL
+        - DONATION
+        - TRAVEL
+        - FAMILY_SUPPORT
+        - SALARY_PAYMENT
+        - OTHER
     TransferOutRequest:
       type: object
       required:
@@ -20796,6 +20847,8 @@ components:
           maxLength: 80
           description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
           example: '12345'
+        purposeOfPayment:
+          $ref: '#/components/schemas/PurposeOfPayment'
     CurrencyPreference:
       type: object
       required:
@@ -21151,24 +21204,6 @@ components:
         - SENDING
         - RECEIVING
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
-    PurposeOfPayment:
-      type: string
-      description: The purpose of the payment. This may be required when sending to certain geographies (e.g. India).
-      enum:
-        - GIFT
-        - SELF
-        - GOODS_OR_SERVICES
-        - EDUCATION
-        - HEALTH_OR_MEDICAL
-        - REAL_ESTATE_PURCHASE
-        - TAX_PAYMENT
-        - LOAN_PAYMENT
-        - UTILITY_BILL
-        - DONATION
-        - TRAVEL
-        - FAMILY_SUPPORT
-        - SALARY_PAYMENT
-        - OTHER
     QuoteRequest:
       type: object
       required:

--- a/mintlify/payouts-and-b2b/payment-flow/send-payment.mdx
+++ b/mintlify/payouts-and-b2b/payment-flow/send-payment.mdx
@@ -90,6 +90,11 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/transfer-out' \
   `remittanceInformation` is optional. Use it to send a reference that travels with the payment to the recipient (max 80 characters). This populates the ACH Addenda record, FedNow/RTP remittance information, or wire OBI field depending on the payment rail.
 </Info>
 
+<Info>
+  `purposeOfPayment` is optional and accepts the same values as on a quote. Some destinations
+  require it, and some rails carry it on the payment itself.
+</Info>
+
 
 ```json Success (201 Created)
 {

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -79,6 +79,12 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 <Note>
   Category must be `CHECKING` or `SAVINGS`. Routing number must be 9 digits.
 </Note>
+
+<Note>
+  Three further fields apply to the `WIRE` rail and are ignored on ACH, RTP and FedNow:
+  `intermediaryBankName` and `intermediaryRoutingNumber`, for a beneficiary bank reachable only
+  through a correspondent, and `fiToFiInformation` for bank-to-bank instructions.
+</Note>
 </Tab>
 
 <Tab title="Mexico">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13600,13 +13600,13 @@ components:
           pattern: ^[0-9]{9}$
         bankName:
           type: string
-          description: The name of the financial institution holding the account
+          description: The name of the financial institution holding the account. Optional on every rail, and recommended for wires, where it identifies the beneficiary's institution on the payment message.
           example: Chase Bank
           minLength: 1
           maxLength: 140
         bankAccountType:
           type: string
-          description: Whether the account is a checking or a savings account
+          description: Whether the account is a checking or a savings account. Optional on every rail; when omitted, the account is treated as a checking account.
           enum:
             - CHECKING
             - SAVINGS

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13598,10 +13598,43 @@ components:
           minLength: 9
           maxLength: 9
           pattern: ^[0-9]{9}$
+        bankName:
+          type: string
+          description: The name of the financial institution holding the account
+          example: Chase Bank
+          minLength: 1
+          maxLength: 140
+        bankAccountType:
+          type: string
+          description: Whether the account is a checking or a savings account
+          enum:
+            - CHECKING
+            - SAVINGS
+          example: CHECKING
+        intermediaryBankName:
+          type: string
+          description: The name of the intermediary financial institution, for accounts reachable only through a correspondent bank. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: JPMorgan Chase Bank
+          minLength: 1
+          maxLength: 140
+        intermediaryRoutingNumber:
+          type: string
+          description: The ABA routing number of the intermediary financial institution. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: '021000021'
+          minLength: 9
+          maxLength: 9
+          pattern: ^[0-9]{9}$
+        fiToFiInformation:
+          type: string
+          description: Bank-to-bank instructions carried alongside the payment. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.
+          example: /BNF/Invoice 4471
+          maxLength: 210
       example:
         accountType: USD_ACCOUNT
         accountNumber: '1234567890'
         routingNumber: '021000021'
+        bankName: Chase Bank
+        bankAccountType: CHECKING
     UsdAccountInfo:
       allOf:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
@@ -20774,6 +20807,24 @@ components:
           description: The payment rail to use for the transfer. Must be one of the rails supported by the destination account. If not specified, the system will select a default rail.
           allOf:
             - $ref: '#/components/schemas/PaymentRail'
+    PurposeOfPayment:
+      type: string
+      description: The purpose of the payment. This may be required when sending to certain geographies (e.g. India).
+      enum:
+        - GIFT
+        - SELF
+        - GOODS_OR_SERVICES
+        - EDUCATION
+        - HEALTH_OR_MEDICAL
+        - REAL_ESTATE_PURCHASE
+        - TAX_PAYMENT
+        - LOAN_PAYMENT
+        - UTILITY_BILL
+        - DONATION
+        - TRAVEL
+        - FAMILY_SUPPORT
+        - SALARY_PAYMENT
+        - OTHER
     TransferOutRequest:
       type: object
       required:
@@ -20796,6 +20847,8 @@ components:
           maxLength: 80
           description: 'Free-form information about the payment that travels with it to the recipient. The field this populates depends on the payment rail: for ACH it populates the Addenda record, for FedNow and RTP it populates the remittanceInformation field, and for wires it populates the OBI (Originator to Beneficiary Information) / beneficiary information.'
           example: '12345'
+        purposeOfPayment:
+          $ref: '#/components/schemas/PurposeOfPayment'
     CurrencyPreference:
       type: object
       required:
@@ -21151,24 +21204,6 @@ components:
         - SENDING
         - RECEIVING
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
-    PurposeOfPayment:
-      type: string
-      description: The purpose of the payment. This may be required when sending to certain geographies (e.g. India).
-      enum:
-        - GIFT
-        - SELF
-        - GOODS_OR_SERVICES
-        - EDUCATION
-        - HEALTH_OR_MEDICAL
-        - REAL_ESTATE_PURCHASE
-        - TAX_PAYMENT
-        - LOAN_PAYMENT
-        - UTILITY_BILL
-        - DONATION
-        - TRAVEL
-        - FAMILY_SUPPORT
-        - SALARY_PAYMENT
-        - OTHER
     QuoteRequest:
       type: object
       required:

--- a/openapi/components/schemas/common/UsdAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/UsdAccountInfoBase.yaml
@@ -20,7 +20,47 @@ properties:
     minLength: 9
     maxLength: 9
     pattern: ^[0-9]{9}$
+  bankName:
+    type: string
+    description: The name of the financial institution holding the account
+    example: Chase Bank
+    minLength: 1
+    maxLength: 140
+  bankAccountType:
+    type: string
+    description: Whether the account is a checking or a savings account
+    enum:
+    - CHECKING
+    - SAVINGS
+    example: CHECKING
+  intermediaryBankName:
+    type: string
+    description: >-
+      The name of the intermediary financial institution, for accounts reachable
+      only through a correspondent bank. Used on the WIRE rail; ignored on ACH,
+      RTP and FEDNOW.
+    example: JPMorgan Chase Bank
+    minLength: 1
+    maxLength: 140
+  intermediaryRoutingNumber:
+    type: string
+    description: >-
+      The ABA routing number of the intermediary financial institution. Used on
+      the WIRE rail; ignored on ACH, RTP and FEDNOW.
+    example: '021000021'
+    minLength: 9
+    maxLength: 9
+    pattern: ^[0-9]{9}$
+  fiToFiInformation:
+    type: string
+    description: >-
+      Bank-to-bank instructions carried alongside the payment. Used on the WIRE
+      rail; ignored on ACH, RTP and FEDNOW.
+    example: /BNF/Invoice 4471
+    maxLength: 210
 example:
   accountType: USD_ACCOUNT
   accountNumber: '1234567890'
   routingNumber: '021000021'
+  bankName: Chase Bank
+  bankAccountType: CHECKING

--- a/openapi/components/schemas/common/UsdAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/UsdAccountInfoBase.yaml
@@ -22,13 +22,18 @@ properties:
     pattern: ^[0-9]{9}$
   bankName:
     type: string
-    description: The name of the financial institution holding the account
+    description: >-
+      The name of the financial institution holding the account. Optional on
+      every rail, and recommended for wires, where it identifies the
+      beneficiary's institution on the payment message.
     example: Chase Bank
     minLength: 1
     maxLength: 140
   bankAccountType:
     type: string
-    description: Whether the account is a checking or a savings account
+    description: >-
+      Whether the account is a checking or a savings account. Optional on every
+      rail; when omitted, the account is treated as a checking account.
     enum:
     - CHECKING
     - SAVINGS

--- a/openapi/components/schemas/transfers/TransferOutRequest.yaml
+++ b/openapi/components/schemas/transfers/TransferOutRequest.yaml
@@ -26,3 +26,5 @@ properties:
       remittanceInformation field, and for wires it populates the OBI
       (Originator to Beneficiary Information) / beneficiary information.
     example: '12345'
+  purposeOfPayment:
+    $ref: ../quotes/PurposeOfPayment.yaml


### PR DESCRIPTION
## Summary

Adds the USD account fields needed to describe a domestic wire beneficiary, and `purposeOfPayment` on `TransferOutRequest`.

`UsdAccountInfoBase` carried only `accountNumber` and `routingNumber`, so a USD account could not express which bank holds it, whether it is checking or savings, or how to reach it through a correspondent. Every other bank-account shape in the spec already has at least `bankName` — `SwiftAccountInfoBase` requires it, and `SlvAccountInfoBase` has both `bankName` and `bankAccountType` with the same `CHECKING`/`SAVINGS` enum reused here.

Two of these fields were **already documented** but never existed in the spec: the "United States" example in `snippets/external-accounts.mdx` shows `bankAccountType` and `bankName` on a `USD_ACCOUNT`, and the note below it says "Category must be `CHECKING` or `SAVINGS`". This change makes those docs true.

## Changes

`openapi/components/schemas/common/UsdAccountInfoBase.yaml` — five optional properties, no change to `required`:

| Property | Type | Notes |
|---|---|---|
| `bankName` | string, 1–140 | Institution holding the account; optional on every rail, recommended for wires |
| `bankAccountType` | `CHECKING` \| `SAVINGS` | Same enum as `SlvAccountInfoBase`; optional on every rail, defaults to checking |
| `intermediaryBankName` | string, 1–140 | `WIRE` rail only |
| `intermediaryRoutingNumber` | string, 9 digits, `^[0-9]{9}$` | `WIRE` rail only |
| `fiToFiInformation` | string, ≤210 | Bank-to-bank instructions, `WIRE` rail only |

Lengths follow the wire-message field sizes: 140 for party name lines, and 210 for the bank-to-bank field (six 35-character lines). `intermediaryRoutingNumber` mirrors the existing `routingNumber` constraints exactly.

`openapi/components/schemas/transfers/TransferOutRequest.yaml` — adds `purposeOfPayment`, `$ref`-ing the existing `quotes/PurposeOfPayment.yaml`. `QuoteRequest` already accepts it; transfer-out was the only send shape that could not record a payment purpose, even though it accepts the neighbouring `remittanceInformation`.

Also rebundled `openapi.yaml` / `mintlify/openapi.yaml` via `make build`, and documented the three wire-only fields plus `purposeOfPayment` in the two affected MDX pages.

## Compatibility

Additive and non-breaking — every new property is optional and nothing existing changed, so `info.version` is unchanged.

Verified against the same gate CI runs:

```
$ oasdiff breaking base/openapi.yaml head/openapi.yaml --format singleline --fail-on ERR
No breaking changes to report, but the specs are different
$ echo $?
0
```

`make lint` exits 0 ("Woohoo! Your API description is valid. 🎉"). The remaining `schema-properties-have-examples` / `-descriptions` findings are pre-existing repo-wide noise; none of them are on the schemas touched here — every property added carries both a description and an example.

## Test plan

- [x] `make build` — bundle regenerated, diff is additive only
- [x] `make lint` — exit 0, no findings on `UsdAccountInfoBase` or `TransferOutRequest`
- [x] `oasdiff breaking --fail-on ERR` — 0 breaking changes

Original PR: https://github.com/lightsparkdev/grid-api/pull/765
