### PR TITLE
feat(sca): return the session expiry and require an end-user IP on SCA login complete

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -13142,9 +13142,10 @@ components:
           example: app.example.com
     ScaLoginCompleteRequest:
       type: object
-      description: Completes an SCA login by submitting the proof for the started factor. Carries the same proof fields as an `ScaAuthorization` (`code` for `SMS_OTP` / `TOTP`, or `passkeyAssertion` + `origin` for `PASSKEY`), plus the `factor` being completed and, for `SMS_OTP`, the `challengeId` returned by the login start.
+      description: Completes an SCA login by submitting the proof for the started factor. Carries the same proof fields as an `ScaAuthorization` (`code` for `SMS_OTP` / `TOTP`, or `passkeyAssertion` + `origin` for `PASSKEY`), plus the `factor` being completed, the `endUserIpAddress` the login is being performed from, and, for `SMS_OTP`, the `challengeId` returned by the login start.
       required:
         - factor
+        - endUserIpAddress
       anyOf:
         - required:
             - code
@@ -13155,6 +13156,10 @@ components:
         factor:
           $ref: '#/components/schemas/ScaFactor'
           description: The factor being completed; must match the started login.
+        endUserIpAddress:
+          type: string
+          description: The IP address of the end user's device completing this login, recorded against the login event by the SCA provider. Supply the customer's address, not your server's — it feeds the provider's risk assessment and any transaction-risk exemption.
+          example: 203.0.113.42
         challengeId:
           type:
             - string
@@ -13186,8 +13191,15 @@ components:
       properties:
         status:
           type: string
-          description: The status of the login session, passed through verbatim (Grid does not normalize it). A successful login reports `SUCCESS`; other values indicate the login did not complete and should be surfaced to the caller.
+          description: The status of the login session. A successful login reports `SUCCESS`; other values indicate the login did not complete and should be surfaced to the caller.
           example: SUCCESS
+        sessionExpiresAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: Absolute UTC timestamp after which the customer's SCA session is no longer valid and they must complete another SCA login. Money movement in SCA-regulated currencies is refused once it passes, so prompt a re-login ahead of it rather than waiting for a `SCA_SESSION_REQUIRED` failure. Present when the login established a session.
+          example: '2026-01-29T12:00:00Z'
     Error423:
       type: object
       required:
@@ -21255,6 +21267,12 @@ components:
             - 'null'
           description: The WebAuthn origin the `passkeyAssertion` was produced against. **Required** alongside `passkeyAssertion`; omit it for the `code` path. When the challenge lists `passkeyAllowedOrigins` (enrollment / login challenges), it must be one of those. A per-transaction passkey challenge carries `passkeyAssertionOptions` but may omit `passkeyAllowedOrigins`; in that case supply the origin your app invoked the WebAuthn API from, which must match the relying party in `passkeyAssertionOptions`.
           example: https://app.example.com
+        endUserIpAddress:
+          type:
+            - string
+            - 'null'
+          description: 'The IP address of the end user''s device authorizing this operation, forwarded to the SCA provider where it feeds risk assessment and any transaction-risk exemption. Supply the customer''s address, not your server''s. Optional: the provider records it for money-movement authorizations, and ignores it for beneficiary trust changes.'
+          example: 203.0.113.42
     TransactionListResponse:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13142,9 +13142,10 @@ components:
           example: app.example.com
     ScaLoginCompleteRequest:
       type: object
-      description: Completes an SCA login by submitting the proof for the started factor. Carries the same proof fields as an `ScaAuthorization` (`code` for `SMS_OTP` / `TOTP`, or `passkeyAssertion` + `origin` for `PASSKEY`), plus the `factor` being completed and, for `SMS_OTP`, the `challengeId` returned by the login start.
+      description: Completes an SCA login by submitting the proof for the started factor. Carries the same proof fields as an `ScaAuthorization` (`code` for `SMS_OTP` / `TOTP`, or `passkeyAssertion` + `origin` for `PASSKEY`), plus the `factor` being completed, the `endUserIpAddress` the login is being performed from, and, for `SMS_OTP`, the `challengeId` returned by the login start.
       required:
         - factor
+        - endUserIpAddress
       anyOf:
         - required:
             - code
@@ -13155,6 +13156,10 @@ components:
         factor:
           $ref: '#/components/schemas/ScaFactor'
           description: The factor being completed; must match the started login.
+        endUserIpAddress:
+          type: string
+          description: The IP address of the end user's device completing this login, recorded against the login event by the SCA provider. Supply the customer's address, not your server's — it feeds the provider's risk assessment and any transaction-risk exemption.
+          example: 203.0.113.42
         challengeId:
           type:
             - string
@@ -13186,8 +13191,15 @@ components:
       properties:
         status:
           type: string
-          description: The status of the login session, passed through verbatim (Grid does not normalize it). A successful login reports `SUCCESS`; other values indicate the login did not complete and should be surfaced to the caller.
+          description: The status of the login session. A successful login reports `SUCCESS`; other values indicate the login did not complete and should be surfaced to the caller.
           example: SUCCESS
+        sessionExpiresAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: Absolute UTC timestamp after which the customer's SCA session is no longer valid and they must complete another SCA login. Money movement in SCA-regulated currencies is refused once it passes, so prompt a re-login ahead of it rather than waiting for a `SCA_SESSION_REQUIRED` failure. Present when the login established a session.
+          example: '2026-01-29T12:00:00Z'
     Error423:
       type: object
       required:
@@ -21255,6 +21267,12 @@ components:
             - 'null'
           description: The WebAuthn origin the `passkeyAssertion` was produced against. **Required** alongside `passkeyAssertion`; omit it for the `code` path. When the challenge lists `passkeyAllowedOrigins` (enrollment / login challenges), it must be one of those. A per-transaction passkey challenge carries `passkeyAssertionOptions` but may omit `passkeyAllowedOrigins`; in that case supply the origin your app invoked the WebAuthn API from, which must match the relying party in `passkeyAssertionOptions`.
           example: https://app.example.com
+        endUserIpAddress:
+          type:
+            - string
+            - 'null'
+          description: 'The IP address of the end user''s device authorizing this operation, forwarded to the SCA provider where it feeds risk assessment and any transaction-risk exemption. Supply the customer''s address, not your server''s. Optional: the provider records it for money-movement authorizations, and ignores it for beneficiary trust changes.'
+          example: 203.0.113.42
     TransactionListResponse:
       type: object
       required:

--- a/openapi/components/schemas/sca/ScaAuthorization.yaml
+++ b/openapi/components/schemas/sca/ScaAuthorization.yaml
@@ -35,3 +35,14 @@ properties:
       that case supply the origin your app invoked the WebAuthn API from, which
       must match the relying party in `passkeyAssertionOptions`.
     example: https://app.example.com
+  endUserIpAddress:
+    type:
+      - string
+      - 'null'
+    description: >-
+      The IP address of the end user's device authorizing this operation,
+      forwarded to the SCA provider where it feeds risk assessment and any
+      transaction-risk exemption. Supply the customer's address, not your
+      server's. Optional: the provider records it for money-movement
+      authorizations, and ignores it for beneficiary trust changes.
+    example: 203.0.113.42

--- a/openapi/components/schemas/sca/ScaLoginComplete.yaml
+++ b/openapi/components/schemas/sca/ScaLoginComplete.yaml
@@ -6,8 +6,19 @@ properties:
   status:
     type: string
     description: >-
-      The status of the login session, passed through
-      verbatim (Grid does not normalize it). A successful login reports
-      `SUCCESS`; other values indicate the login did not
-      complete and should be surfaced to the caller.
+      The status of the login session. A successful login reports `SUCCESS`;
+      other values indicate the login did not complete and should be surfaced
+      to the caller.
     example: SUCCESS
+  sessionExpiresAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+    description: >-
+      Absolute UTC timestamp after which the customer's SCA session is no longer
+      valid and they must complete another SCA login. Money movement in
+      SCA-regulated currencies is refused once it passes, so prompt a re-login
+      ahead of it rather than waiting for a `SCA_SESSION_REQUIRED` failure.
+      Present when the login established a session.
+    example: '2026-01-29T12:00:00Z'

--- a/openapi/components/schemas/sca/ScaLoginCompleteRequest.yaml
+++ b/openapi/components/schemas/sca/ScaLoginCompleteRequest.yaml
@@ -3,9 +3,11 @@ description: >-
   Completes an SCA login by submitting the proof for the started factor. Carries
   the same proof fields as an `ScaAuthorization` (`code` for `SMS_OTP` / `TOTP`,
   or `passkeyAssertion` + `origin` for `PASSKEY`), plus the `factor` being
-  completed and, for `SMS_OTP`, the `challengeId` returned by the login start.
+  completed, the `endUserIpAddress` the login is being performed from, and, for
+  `SMS_OTP`, the `challengeId` returned by the login start.
 required:
   - factor
+  - endUserIpAddress
 anyOf:
   - required:
       - code
@@ -16,6 +18,14 @@ properties:
   factor:
     $ref: ./ScaFactor.yaml
     description: The factor being completed; must match the started login.
+  endUserIpAddress:
+    type: string
+    description: >-
+      The IP address of the end user's device completing this login, recorded
+      against the login event by the SCA provider. Supply the customer's
+      address, not your server's — it feeds the provider's risk assessment and
+      any transaction-risk exemption.
+    example: 203.0.113.42
   challengeId:
     type:
       - string


### PR DESCRIPTION
## Summary

Two additive-now, breaking-later gaps on the SCA login surface.

**`sessionExpiresAt` on `ScaLoginComplete`.** Completing an SCA login establishes a 180-day session, and money movement in SCA-regulated currencies (EUR / USDC) is refused once it lapses. That expiry wasn't reported anywhere, so an integrator could only discover a lapsed session as a failed payment. Returning it lets a platform prompt a re-login ahead of time.

**`endUserIpAddress`, required on `ScaLoginCompleteRequest`.** The end user's IP is recorded against the login event by the SCA provider, where it feeds risk assessment and any transaction-risk exemption. A platform relaying the login on its customer's behalf is the only party that knows that address — so it has to travel in the request rather than being inferred from the connection, which sees the platform's server.

`ScaAuthorization` gains the same field as **optional**: that schema is shared by quote authorization and beneficiary trust changes, and only the former records an IP, so requiring it would demand a value from callers of operations that ignore it.

## Breaking change

Adding a required request property is breaking (`oasdiff`: `new-required-request-property` on `POST /sca/login/complete`) and the PR is labelled accordingly.

**No `info.version` bump.** The versioning rule exists to protect integrators against a silently-changed contract, and this endpoint has no callers yet — so minting a new dated API version and the `servers.url` path that must accompany it would fragment the version namespace with no one to protect.

## Also

Drops the `status` description's claim that the value is "passed through verbatim (Grid does not normalize it)". That contradicted the same schema documenting a successful login as reporting `SUCCESS`; the value is normalized, and the description now says only what's true.

## Test plan

- `make build` — bundled `openapi.yaml` and `mintlify/openapi.yaml` regenerated in lockstep; `info.version` unchanged at `2025-10-13`.
- `make lint-openapi` — exits 0. The remaining `schema-properties-have-*` findings are pre-existing repo-wide noise; the one naming `ScaLoginCompleteRequest` is on the untouched `factor` property (confirmed identical on `main`).
- `oasdiff breaking` against `main` with the CI-pinned v1.16.0 — **exactly one** error, the expected `new-required-request-property`, and no others.
- Verified in the bundled output: the new top-level `required` composes with the existing `anyOf` proof constraint rather than replacing it; `sessionExpiresAt` is a nullable `date-time`; `ScaAuthorization.endUserIpAddress` is nullable and absent from any `required` list.

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/779