### PR TITLE
feat: add EU legal forms to business entity type

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11959,6 +11959,10 @@ components:
         - CORPORATION
         - S_CORPORATION
         - NON_PROFIT
+        - PUBLICLY_LISTED_COMPANY
+        - TRUST
+        - PRIVATE_FOUNDATION
+        - CHARITY
         - OTHER
       description: Legal entity type of the business
       example: LLC

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11959,6 +11959,10 @@ components:
         - CORPORATION
         - S_CORPORATION
         - NON_PROFIT
+        - PUBLICLY_LISTED_COMPANY
+        - TRUST
+        - PRIVATE_FOUNDATION
+        - CHARITY
         - OTHER
       description: Legal entity type of the business
       example: LLC

--- a/openapi/components/schemas/customers/EntityType.yaml
+++ b/openapi/components/schemas/customers/EntityType.yaml
@@ -6,6 +6,10 @@ enum:
   - CORPORATION
   - S_CORPORATION
   - NON_PROFIT
+  - PUBLICLY_LISTED_COMPANY
+  - TRUST
+  - PRIVATE_FOUNDATION
+  - CHARITY
   - OTHER
 description: Legal entity type of the business
 example: LLC


### PR DESCRIPTION
## Summary

Adds four legal entity types to `EntityType` so businesses incorporated outside the US can be described faithfully:

- `PUBLICLY_LISTED_COMPANY`
- `TRUST`
- `PRIVATE_FOUNDATION`
- `CHARITY`

The existing members are US-shaped (`LLC`, `S_CORPORATION`, `SOLE_PROPRIETORSHIP`), so a publicly listed company, trust, foundation or charity could previously only be recorded as `OTHER`. Downstream verification providers distinguish these forms, and `OTHER` is not always accepted in their place — so the imprecision could block business verification rather than merely lose detail.

`OTHER` is retained for genuinely unlisted forms.

## Compatibility

Additive only — no existing value changes meaning, and no field becomes required.

`oasdiff breaking` reports **0 errors, 40 warnings** (all `response-property-enum-value-added`), so `info.version` is unchanged per the repo's convention of bumping only for breaking changes.

Clients that exhaustively switch on `entityType` should handle unknown values, as with any enum in this spec.

## Test plan

- `make build` — spec rebundled (`openapi.yaml` + `mintlify/openapi.yaml`)
- `make lint-openapi` — passes, 0 errors
- `oasdiff breaking <base> <head> --fail-on ERR` — exit 0

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/781