### PR TITLE
feat: add optional ownershipType to external account schema

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -16768,6 +16768,13 @@ components:
         - CNY_ACCOUNT
       description: Type of external account or wallet
       example: AED_ACCOUNT
+    OwnershipType:
+      type: string
+      enum:
+        - FIRST_PARTY
+        - THIRD_PARTY
+      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
+      example: FIRST_PARTY
     BaseExternalAccountInfo:
       type: object
       required:
@@ -16775,6 +16782,8 @@ components:
       properties:
         accountType:
           $ref: '#/components/schemas/ExternalAccountType'
+        ownershipType:
+          $ref: '#/components/schemas/OwnershipType'
     AedBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -20003,6 +20003,8 @@ components:
           type: string
           description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
           example: ext_acc_123456
+        ownershipType:
+          $ref: '#/components/schemas/OwnershipType'
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountCreateInfoOneOf'
     BeneficialOwnerListResponse:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -16690,6 +16690,13 @@ components:
         - UNDER_REVIEW
         - INACTIVE
       description: Status of an external account
+    OwnershipType:
+      type: string
+      enum:
+        - FIRST_PARTY
+        - THIRD_PARTY
+      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
+      example: FIRST_PARTY
     BeneficiaryVerificationStatus:
       type: string
       enum:
@@ -16768,13 +16775,6 @@ components:
         - CNY_ACCOUNT
       description: Type of external account or wallet
       example: AED_ACCOUNT
-    OwnershipType:
-      type: string
-      enum:
-        - FIRST_PARTY
-        - THIRD_PARTY
-      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
-      example: FIRST_PARTY
     BaseExternalAccountInfo:
       type: object
       required:
@@ -16782,8 +16782,6 @@ components:
       properties:
         accountType:
           $ref: '#/components/schemas/ExternalAccountType'
-        ownershipType:
-          $ref: '#/components/schemas/OwnershipType'
     AedBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -19069,6 +19067,8 @@ components:
               type: string
               description: Optional platform-specific identifier for this account
               example: acc_123456789
+            ownershipType:
+              $ref: '#/components/schemas/OwnershipType'
             currency:
               type: string
               description: The ISO 4217 currency code
@@ -19981,6 +19981,8 @@ components:
               type: string
               description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
               example: ext_acc_123456
+            ownershipType:
+              $ref: '#/components/schemas/OwnershipType'
             defaultUmaDepositAccount:
               type: boolean
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16768,6 +16768,13 @@ components:
         - CNY_ACCOUNT
       description: Type of external account or wallet
       example: AED_ACCOUNT
+    OwnershipType:
+      type: string
+      enum:
+        - FIRST_PARTY
+        - THIRD_PARTY
+      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
+      example: FIRST_PARTY
     BaseExternalAccountInfo:
       type: object
       required:
@@ -16775,6 +16782,8 @@ components:
       properties:
         accountType:
           $ref: '#/components/schemas/ExternalAccountType'
+        ownershipType:
+          $ref: '#/components/schemas/OwnershipType'
     AedBeneficiary:
       title: Individual Beneficiary
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20003,6 +20003,8 @@ components:
           type: string
           description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
           example: ext_acc_123456
+        ownershipType:
+          $ref: '#/components/schemas/OwnershipType'
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountCreateInfoOneOf'
     BeneficialOwnerListResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16690,6 +16690,13 @@ components:
         - UNDER_REVIEW
         - INACTIVE
       description: Status of an external account
+    OwnershipType:
+      type: string
+      enum:
+        - FIRST_PARTY
+        - THIRD_PARTY
+      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
+      example: FIRST_PARTY
     BeneficiaryVerificationStatus:
       type: string
       enum:
@@ -16768,13 +16775,6 @@ components:
         - CNY_ACCOUNT
       description: Type of external account or wallet
       example: AED_ACCOUNT
-    OwnershipType:
-      type: string
-      enum:
-        - FIRST_PARTY
-        - THIRD_PARTY
-      description: Whether the external account belongs to the customer themselves (first party) or to someone else (third party)
-      example: FIRST_PARTY
     BaseExternalAccountInfo:
       type: object
       required:
@@ -16782,8 +16782,6 @@ components:
       properties:
         accountType:
           $ref: '#/components/schemas/ExternalAccountType'
-        ownershipType:
-          $ref: '#/components/schemas/OwnershipType'
     AedBeneficiary:
       title: Individual Beneficiary
       type: object
@@ -19069,6 +19067,8 @@ components:
               type: string
               description: Optional platform-specific identifier for this account
               example: acc_123456789
+            ownershipType:
+              $ref: '#/components/schemas/OwnershipType'
             currency:
               type: string
               description: The ISO 4217 currency code
@@ -19981,6 +19981,8 @@ components:
               type: string
               description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
               example: ext_acc_123456
+            ownershipType:
+              $ref: '#/components/schemas/OwnershipType'
             defaultUmaDepositAccount:
               type: boolean
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.

--- a/openapi/components/schemas/external_accounts/BaseExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/BaseExternalAccountInfo.yaml
@@ -4,3 +4,5 @@ required:
 properties:
   accountType:
     $ref: ./ExternalAccountType.yaml
+  ownershipType:
+    $ref: ./OwnershipType.yaml

--- a/openapi/components/schemas/external_accounts/BaseExternalAccountInfo.yaml
+++ b/openapi/components/schemas/external_accounts/BaseExternalAccountInfo.yaml
@@ -4,5 +4,3 @@ required:
 properties:
   accountType:
     $ref: ./ExternalAccountType.yaml
-  ownershipType:
-    $ref: ./OwnershipType.yaml

--- a/openapi/components/schemas/external_accounts/ExternalAccount.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccount.yaml
@@ -22,6 +22,8 @@ allOf:
         type: string
         description: Optional platform-specific identifier for this account
         example: acc_123456789
+      ownershipType:
+        $ref: ./OwnershipType.yaml
       currency:
         type: string
         description: The ISO 4217 currency code

--- a/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
@@ -18,6 +18,8 @@ allOf:
         type: string
         description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
         example: ext_acc_123456
+      ownershipType:
+        $ref: ./OwnershipType.yaml
       defaultUmaDepositAccount:
         type: boolean
         description: >-

--- a/openapi/components/schemas/external_accounts/OwnershipType.yaml
+++ b/openapi/components/schemas/external_accounts/OwnershipType.yaml
@@ -1,0 +1,8 @@
+type: string
+enum:
+  - FIRST_PARTY
+  - THIRD_PARTY
+description: >-
+  Whether the external account belongs to the customer themselves (first party)
+  or to someone else (third party)
+example: FIRST_PARTY

--- a/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
@@ -11,5 +11,7 @@ properties:
     type: string
     description: Your platform's identifier for the account in your system. This can be used to reference the account by your own identifier.
     example: ext_acc_123456
+  ownershipType:
+    $ref: ./OwnershipType.yaml
   accountInfo:
     $ref: ./ExternalAccountCreateInfoOneOf.yaml


### PR DESCRIPTION
Adds an optional `ownershipType` field to the external account resource, so external accounts can indicate whether they belong to the customer themselves (`FIRST_PARTY`) or to a third party (`THIRD_PARTY`).

## Changes

- **New enum** `openapi/components/schemas/external_accounts/OwnershipType.yaml` with values `FIRST_PARTY` and `THIRD_PARTY`.
- **`ExternalAccount.yaml`**: adds an optional top-level `ownershipType` property, alongside the other resource-level fields (`customerId`, `currency`, `platformAccountId`, ...).
- **`ExternalAccountCreateRequest.yaml`** and **`PlatformExternalAccountCreateRequest.yaml`**: add the same optional `ownershipType` property so it can be set at creation time for both customer and platform-owned accounts.
- Rebundled `openapi.yaml` and `mintlify/openapi.yaml` via `make build`.

The field lives on the resource envelope rather than inside the per-rail `accountInfo` payloads, matching where the other account-level metadata sits. It is optional, so this is backwards compatible and `info.version` is unchanged.

## Testing

- `make build` — bundles cleanly.
- `npx @redocly/cli lint openapi.yaml` — valid (warnings only, all pre-existing).

Note: the `npx spectral lint` step of `make lint` fails in this environment because the `spectral` binary isn't resolvable, and `make lint-markdown` fails because `package.json` has no `lint:markdown` script. Both are pre-existing and unrelated to this change.