### PR TITLE
docs(cards): document the optional 3DS password on card create

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -12,7 +12,8 @@ rules:
   # Naming Conventions (README: Naming Conventions)
   # ============================================================
 
-  # Fields must be camelCase (excludes TestWebhookResponse which mirrors external format)
+  # Fields must be camelCase (excludes TestWebhookResponse which mirrors
+  # external format; see the overrides block for per-property exemptions)
   field-names-camelCase:
     description: Schema property names must be camelCase
     message: "Property '{{property}}' must be camelCase. See openapi/README.md#field-naming"
@@ -179,3 +180,13 @@ rules:
       function: pattern
       functionOptions:
         match: "^((\\/([a-z0-9]+(-[a-z0-9]+)*|\\{[a-zA-Z0-9]+\\}))+|\\/sandbox\\/cards\\/\\{id\\}\\/simulate\\/(balance_inquiry|credit_authorization|financial_authorization|financial_credit_authorization|authorization_advice|credit_authorization_advice|return_reversal))$"
+
+# Per-property exemptions from the naming rules above.
+overrides:
+  # "3DS" is the industry spelling of the 3-D Secure factor, and this field
+  # mirrors the issuer's own request field name. Renaming it to satisfy the
+  # camelCase rule would break the wire contract Grid already accepts.
+  - files:
+      - "openapi.yaml#/components/schemas/CardCreateRequest/properties/threeDSecurePassword"
+    rules:
+      field-names-camelCase: "off"

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -23585,6 +23585,10 @@ components:
           type: string
           description: Optional platform-specific card identifier. System-generated when omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
+        threeDSecurePassword:
+          type: string
+          description: 'Optional static password used as the card''s 3-D Secure factor. Only accepted for card programs whose issuer supports a static-password factor (EU cards today); supplying it for a program that does not is rejected with `INVALID_INPUT`. When omitted, one is generated on the cardholder''s behalf. Grid does not retain the value: it is forwarded to the issuer and discarded, so it cannot be read back afterwards.'
+          example: AbCd1234EfGh5678
         form:
           $ref: '#/components/schemas/CardForm'
         fundingSources:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23585,6 +23585,10 @@ components:
           type: string
           description: Optional platform-specific card identifier. System-generated when omitted, mirroring `platformCustomerId` semantics.
           example: card-emp-aary-001
+        threeDSecurePassword:
+          type: string
+          description: 'Optional static password used as the card''s 3-D Secure factor. Only accepted for card programs whose issuer supports a static-password factor (EU cards today); supplying it for a program that does not is rejected with `INVALID_INPUT`. When omitted, one is generated on the cardholder''s behalf. Grid does not retain the value: it is forwarded to the issuer and discarded, so it cannot be read back afterwards.'
+          example: AbCd1234EfGh5678
         form:
           $ref: '#/components/schemas/CardForm'
         fundingSources:

--- a/openapi/components/schemas/cards/CardCreateRequest.yaml
+++ b/openapi/components/schemas/cards/CardCreateRequest.yaml
@@ -17,6 +17,16 @@ properties:
       Optional platform-specific card identifier. System-generated when
       omitted, mirroring `platformCustomerId` semantics.
     example: card-emp-aary-001
+  threeDSecurePassword:
+    type: string
+    description: >-
+      Optional static password used as the card's 3-D Secure factor. Only
+      accepted for card programs whose issuer supports a static-password
+      factor (EU cards today); supplying it for a program that does not is
+      rejected with `INVALID_INPUT`. When omitted, one is generated on the
+      cardholder's behalf. Grid does not retain the value: it is forwarded to
+      the issuer and discarded, so it cannot be read back afterwards.
+    example: AbCd1234EfGh5678
   form:
     $ref: ./CardForm.yaml
   fundingSources:


### PR DESCRIPTION
Grid already accepts `threeDSecurePassword` on `POST /cards` and forwards it to the issuer, but the field was absent from the spec — so it reached no SDK and no documentation, and was discoverable only by being told about it. That is a poor property for a security-relevant field, so this documents it.

## What it does

- Adds the optional `threeDSecurePassword` to `CardCreateRequest`.
- Regenerates `openapi.yaml` and `mintlify/openapi.yaml`.

Documented semantics, matching the current implementation:

- Only accepted for card programs whose issuer supports a static-password 3-D Secure factor (EU cards today). Supplying it for a program that does not is rejected with `INVALID_INPUT` — the US/Lithic program has no such factor, and silently dropping a caller-supplied secret would be worse than refusing it.
- When omitted, one is generated on the cardholder's behalf.
- **Grid does not retain the value.** It is forwarded to the issuer and discarded, so it cannot be read back.

## The lint exemption

The name trips `field-names-camelCase` because of the consecutive capitals in "3DS". That spelling is the industry one and matches the issuer's own request field, and Grid already honors it on the wire, so renaming would break a live contract to satisfy a naming rule.

Rather than exclude the whole schema, this adds a spectral `overrides` block scoped to the single property, alongside the existing `TestWebhookResponse` carve-out. `field-names-camelCase` still applies to every other field on `CardCreateRequest`.

## Verification

`npm run lint:openapi` exits 0. Confirmed the exemption is doing real work rather than masking: spectral reports 0 errors on main, 1 error (`field-names-camelCase` on this property) with the field added and no override, and 0 errors with the override. The field is present in both generated bundles.

## Follow-up

Worth deciding separately whether the handler should keep accepting a caller-supplied password at all, or always generate one. There is no strength validation on the Grid side today — the issuer's validator is the only gate.