### PR TITLE
feat(config): fee config fixedFee takes an amount and a currency code

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11497,11 +11497,22 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
           example: 30
         fixedFee:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Fixed fee charged per transaction, denominated in the smallest unit of the fee config's `sourceCurrency` (e.g., cents for USD).
-          example: 100
+          type: object
+          description: Fixed fee charged per transaction.
+          properties:
+            amount:
+              type: integer
+              format: int64
+              minimum: 0
+              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+              example: 100
+            currency:
+              type: string
+              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+              example: USD
+          required:
+            - amount
+            - currency
       required:
         - feeType
         - sourceCurrency

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11497,11 +11497,22 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
           example: 30
         fixedFee:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Fixed fee charged per transaction, denominated in the smallest unit of the fee config's `sourceCurrency` (e.g., cents for USD).
-          example: 100
+          type: object
+          description: Fixed fee charged per transaction.
+          properties:
+            amount:
+              type: integer
+              format: int64
+              minimum: 0
+              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+              example: 100
+            currency:
+              type: string
+              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+              example: USD
+          required:
+            - amount
+            - currency
       required:
         - feeType
         - sourceCurrency

--- a/openapi/components/schemas/config/FeeConfig.yaml
+++ b/openapi/components/schemas/config/FeeConfig.yaml
@@ -18,13 +18,27 @@ properties:
       Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
     example: 30
   fixedFee:
-    type: integer
-    format: int64
-    minimum: 0
-    description: >-
-      Fixed fee charged per transaction, denominated in the smallest unit of
-      the fee config's `sourceCurrency` (e.g., cents for USD).
-    example: 100
+    type: object
+    description: Fixed fee charged per transaction.
+    properties:
+      amount:
+        type: integer
+        format: int64
+        minimum: 0
+        description: >-
+          Fee amount in the smallest unit of the fixed fee's `currency`
+          (e.g., cents for USD).
+        example: 100
+      currency:
+        type: string
+        description: >-
+          Three-letter currency code (ISO 4217) the fixed fee is denominated
+          in. Some cryptocurrencies may use their own ticker symbols (e.g.
+          "BTC" for Bitcoin, "USDC" for USDC, etc.)
+        example: USD
+    required:
+      - amount
+      - currency
 required:
   - feeType
   - sourceCurrency


### PR DESCRIPTION
fixedFee is now an object of amount plus a plain ISO 4217 currency code,
so the fee currency is explicit without nesting the full Currency object.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>