### PR TITLE
docs(openapi): region and currencies resolve independently on customer create

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -394,6 +394,17 @@ paths:
                   birthDate: '1988-05-22'
                   nationality: MX
                   phoneNumber: '+525512345678'
+              individualCustomerCurrenciesOnly:
+                summary: Create an individual customer with currencies and no region
+                value:
+                  customerType: INDIVIDUAL
+                  platformCustomerId: ind-4c2e8b15
+                  currencies:
+                    - BRL
+                  fullName: Ana Oliveira
+                  birthDate: '1992-11-03'
+                  nationality: BR
+                  phoneNumber: '+5511987654321'
               businessCustomer:
                 summary: Create a business customer
                 value:
@@ -12843,13 +12854,13 @@ components:
           $ref: '#/components/schemas/CustomerType'
         region:
           type: string
-          description: Country code (ISO 3166-1 alpha-2) representing the customer's regional identity. This determines the regulatory jurisdiction and KYC requirements for the customer. Required if the customer will use currencies with different KYC requirements across regions. A customer with accounts in multiple regions should be registered as separate customers. This field is immutable after creation.
+          description: Country code (ISO 3166-1 alpha-2) for the customer's region. Optional — send it only when the same currency is offered in more than one of your regions, to pick the one that applies to this customer.
           example: US
         currencies:
           type: array
           items:
             type: string
-          description: List of currency codes the customer will use (ISO 4217 for fiat, e.g. "USD", "EUR"; tickers for crypto, e.g. "BTC", "USDC"). Required if the customer will use more than one sending currency, since the correct currencies cannot always be inferred. If not provided, currencies will be inferred from the customer's region. Some currency combinations may require separate customers — if so, the request will be rejected with details.
+          description: Currency codes the customer will use — ISO 4217 for fiat, tickers for crypto (e.g. "USDC"). Optional — send them if your platform supports more than one currency, so we know which ones this customer needs. Some combinations require separate customers.
           example:
             - USD
             - USDC

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -394,6 +394,17 @@ paths:
                   birthDate: '1988-05-22'
                   nationality: MX
                   phoneNumber: '+525512345678'
+              individualCustomerCurrenciesOnly:
+                summary: Create an individual customer with currencies and no region
+                value:
+                  customerType: INDIVIDUAL
+                  platformCustomerId: ind-4c2e8b15
+                  currencies:
+                    - BRL
+                  fullName: Ana Oliveira
+                  birthDate: '1992-11-03'
+                  nationality: BR
+                  phoneNumber: '+5511987654321'
               businessCustomer:
                 summary: Create a business customer
                 value:
@@ -12843,13 +12854,13 @@ components:
           $ref: '#/components/schemas/CustomerType'
         region:
           type: string
-          description: Country code (ISO 3166-1 alpha-2) representing the customer's regional identity. This determines the regulatory jurisdiction and KYC requirements for the customer. Required if the customer will use currencies with different KYC requirements across regions. A customer with accounts in multiple regions should be registered as separate customers. This field is immutable after creation.
+          description: Country code (ISO 3166-1 alpha-2) for the customer's region. Optional — send it only when the same currency is offered in more than one of your regions, to pick the one that applies to this customer.
           example: US
         currencies:
           type: array
           items:
             type: string
-          description: List of currency codes the customer will use (ISO 4217 for fiat, e.g. "USD", "EUR"; tickers for crypto, e.g. "BTC", "USDC"). Required if the customer will use more than one sending currency, since the correct currencies cannot always be inferred. If not provided, currencies will be inferred from the customer's region. Some currency combinations may require separate customers — if so, the request will be rejected with details.
+          description: Currency codes the customer will use — ISO 4217 for fiat, tickers for crypto (e.g. "USDC"). Optional — send them if your platform supports more than one currency, so we know which ones this customer needs. Some combinations require separate customers.
           example:
             - USD
             - USDC

--- a/openapi/components/schemas/customers/CustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/CustomerCreateRequest.yaml
@@ -11,23 +11,19 @@ properties:
   region:
     type: string
     description: >-
-      Country code (ISO 3166-1 alpha-2) representing the customer's regional identity.
-      This determines the regulatory jurisdiction and KYC requirements for the customer.
-      Required if the customer will use currencies with different KYC requirements across
-      regions. A customer with accounts in multiple regions should be registered as separate
-      customers. This field is immutable after creation.
+      Country code (ISO 3166-1 alpha-2) for the customer's region. Optional — send
+      it only when the same currency is offered in more than one of your regions,
+      to pick the one that applies to this customer.
     example: US
   currencies:
     type: array
     items:
       type: string
     description: >-
-      List of currency codes the customer will use (ISO 4217 for fiat, e.g. "USD", "EUR";
-      tickers for crypto, e.g. "BTC", "USDC"). Required if the customer will use more than
-      one sending currency, since the correct currencies cannot always be inferred. If not
-      provided, currencies will be inferred from the customer's region. Some currency
-      combinations may require separate customers — if so, the request will be rejected
-      with details.
+      Currency codes the customer will use — ISO 4217 for fiat, tickers for crypto
+      (e.g. "USDC"). Optional — send them if your platform supports more than one
+      currency, so we know which ones this customer needs. Some combinations
+      require separate customers.
     example:
       - USD
       - USDC

--- a/openapi/paths/customers/customers.yaml
+++ b/openapi/paths/customers/customers.yaml
@@ -39,6 +39,17 @@ post:
               birthDate: '1988-05-22'
               nationality: MX
               phoneNumber: '+525512345678'
+          individualCustomerCurrenciesOnly:
+            summary: Create an individual customer with currencies and no region
+            value:
+              customerType: INDIVIDUAL
+              platformCustomerId: ind-4c2e8b15
+              currencies:
+                - BRL
+              fullName: Ana Oliveira
+              birthDate: '1992-11-03'
+              nationality: BR
+              phoneNumber: '+5511987654321'
           businessCustomer:
             summary: Create a business customer
             value:


### PR DESCRIPTION
## Reason

Create-customer required `region` and `currencies` to be sent together or not at all, but the spec never said so — it documented the two as independently conditional and promised currencies could be inferred from region. lightsparkdev/webdev#31313 removes the both-or-neither rule from the handler: currencies pin the payment configuration on their own, and region is only a tiebreaker. This brings the API surface in line.

## Overview

`CustomerCreateRequest.yaml`:

- **`region`** — drops the both-or-neither requirement, the "determines the regulatory jurisdiction and KYC requirements" claim, and "immutable after creation". Nothing persists the field. Now described by what it is actually for: optional, and only needed to say which region applies when the same currency is offered in more than one of yours.
- **`currencies`** — drops "currencies will be inferred from the customer's region" as the only fallback. Now: optional, send them if your platform supports more than one currency; some combinations require separate customers.

Both are two plain sentences aimed at an integrator, rather than describing the resolution mechanism.

`paths/customers/customers.yaml` gains a create example with currencies and no region. Worth noting the existing `individualCustomerInferred` example (region, no currencies) was *rejected* by the old rule — the examples already assumed the behavior #31313 implements.

Two related things deliberately not here:

- The `region` text describes the intended end state. Today `unique(platform_id, currency_code)` means one currency cannot be served by two switches on a platform, so region currently narrows across different currencies' jurisdictions instead. #31313's docstring TODO is the re-key to `(platform, currency, jurisdiction)` that makes the described behavior literal.
- `Customer.yaml` documents `region` and `currencies` on the customer **response**, but neither is ever populated. Removing them is an oasdiff `response-property-removed` ERR, so it wants its own change.

## Test Plan

- `npm run lint:openapi` — redocly lint clean, spectral clean at `--fail-severity=error`, bundles regenerated into `openapi.yaml` and `mintlify/openapi.yaml`.
- Description- and example-only, so there is nothing for the breaking-changes workflow to flag; the **Detect breaking changes** run on this PR confirms it. oasdiff could not be run locally (pinned v1.16.0 needs go >= 1.26; the docker image is OOM-killed on the bundle), so CI is the check.
- Behavior itself is covered by the tests in lightsparkdev/webdev#31313; **this should land with or after that merge**, since until then it describes behavior the API does not have yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)