### PR TITLE
feat(openapi): require businessInfo.country on business customer create

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12886,6 +12886,7 @@ components:
       description: Additional information required for business entities
       required:
         - legalName
+        - country
         - taxId
         - incorporatedOn
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12886,6 +12886,7 @@ components:
       description: Additional information required for business entities
       required:
         - legalName
+        - country
         - taxId
         - incorporatedOn
       properties:

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -2,6 +2,7 @@ type: object
 description: Additional information required for business entities
 required:
   - legalName
+  - country
   - taxId
   - incorporatedOn
 properties:


### PR DESCRIPTION
## Reason

`businessInfo.country` — the country of incorporation — is what decides which other KYB fields a business has to supply