### PR TITLE
Offer Ethereum as a USDC network, per the schema

### DIFF
--- a/components/grid-visualizer/src/data/crypto.ts
+++ b/components/grid-visualizer/src/data/crypto.ts
@@ -33,6 +33,7 @@ export const cryptoAssets: CryptoAsset[] = [
       { type: 'SOLANA_WALLET', label: 'Wallet', network: 'Solana' },
       { type: 'POLYGON_WALLET', label: 'Wallet', network: 'Polygon' },
       { type: 'BASE_WALLET', label: 'Wallet', network: 'Base' },
+      { type: 'ETHEREUM_WALLET', label: 'Wallet', network: 'Ethereum' },
     ],
     examplePerson: { fullName: 'Alex Rivera', nationality: 'US' },
   },


### PR DESCRIPTION
## Summary

`PaymentEthereumWalletInfo.yaml` declares `enum: [USDC, USDT]`, but `crypto.ts` listed `ETHEREUM_WALLET` only under USDT. USDC-on-Ethereum is supported by the API and simply could not be selected in the visualizer, so that flow could not be built or code-generated.

One line. Ethereum is the only chain carrying both assets — Base and Polygon are USDC-only per their own `Payment<Chain>WalletInfo.yaml` enums — so this is the single missing entry, not the first of a batch.

| Chain | Schema enum | In `crypto.ts` before |
|---|---|---|
| Ethereum | `USDC`, `USDT` | USDT only ❌ |
| Base | `USDC` | USDC ✅ |
| Polygon | `USDC` | USDC ✅ |

## ⚠️ Missing network icon — please read

`NetworkDropdown` renders `/networks/${network.toLowerCase()}.svg` with no error handling, and **`public/networks/ethereum.svg` does not exist**. The new row will render without an icon.

This gap is pre-existing, not introduced here — `tron.svg` and `plasma.svg` are missing too, so USDT's dropdown already shows three iconless rows. But USDC's dropdown currently has all three of its icons (`solana`, `polygon`, `base`), so this change does put the first broken one there.

I did not add the asset: an Ethereum mark is brand artwork, and inventing one that doesn't match the existing set is worse than leaving the gap visible. Someone should drop in `ethereum.svg` — and `tron.svg` / `plasma.svg` while they're at it, since those are already broken today.

If the missing icon is a blocker, holding this until the asset lands is reasonable. The data being wrong is the more serious problem, so I'd merge and follow up.

## Verification

- Strict typecheck of `crypto.ts` — clean
- Cross-checked all three EVM chains against their `Payment<Chain>WalletInfo.yaml` enums, not just Ethereum
- **Not verified:** no build or render check — `npm ci` fails here because `@central-icons-react` requires `CENTRAL_LICENSE_KEY`. The Vercel preview is the real check; worth confirming the USDC dropdown now offers Ethereum and seeing how the iconless row actually looks.

## Context

Found while triaging the stale docs-sync PRs. This is the one genuinely-unlanded, non-documentation item from #288, whose other changes are already on `main` (`ETHEREUM_WALLET` in `account-types.ts`, the `businessType: FINTECH` → `FINANCE_AND_INSURANCE` fix) or superseded (currency entries via #791, the supported-chain table via #777).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnjJ8yWJsui7jLqqrDrL4)_