### PR TITLE
Document external-account GET/DELETE, and fix all 85 broken curl auth examples

### DIFF
--- a/mintlify/global-p2p/getting-started/platform-configuration.mdx
+++ b/mintlify/global-p2p/getting-started/platform-configuration.mdx
@@ -197,7 +197,7 @@ After updating your configuration, it's recommended to verify that the changes w
 
 ```bash
 curl -X GET "https://api.lightspark.com/grid/2025-10-13/config" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 The response should reflect your updated **settings**.

--- a/mintlify/global-p2p/onboarding/invitations.mdx
+++ b/mintlify/global-p2p/onboarding/invitations.mdx
@@ -34,7 +34,7 @@ To create an invitation, make a POST request to `/invitations` with the inviter'
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/invitations" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "inviterUma": "$inviter@uma.domain",
@@ -67,7 +67,7 @@ To create a pay-by-link invitation, include the `amountToSend` field when creati
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/invitations" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "inviterUma": "$inviter@uma.domain",
@@ -121,7 +121,7 @@ POST request to `/invitations/{invitationCode}/claim` including the invitee's ne
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/invitations/019542f5/claim" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "inviteeUma": "$invitee@uma.domain"
@@ -140,7 +140,7 @@ To cancel a pending invitation, make a POST request to `/invitations/{invitation
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/invitations/019542f5/cancel" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 A successful cancellation will:

--- a/mintlify/global-p2p/sending-receiving-payments/receiving-payments.mdx
+++ b/mintlify/global-p2p/sending-receiving-payments/receiving-payments.mdx
@@ -110,7 +110,7 @@ Example of approving asynchronously:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/transactions/Transaction:019542f5-b3e7-1d02-0000-000000000005/approve" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "receiverCustomerInfo": {
@@ -124,7 +124,7 @@ Example of rejecting asynchronously:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/transactions/Transaction:019542f5-b3e7-1d02-0000-000000000005/reject" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "reason": "RESTRICTED_JURISDICTION"
@@ -187,7 +187,7 @@ To set an external account as the default UMA deposit account for a customer, yo
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",

--- a/mintlify/payouts-and-b2b/payment-flow/list-transactions.mdx
+++ b/mintlify/payouts-and-b2b/payment-flow/list-transactions.mdx
@@ -12,7 +12,7 @@ Retrieve transaction history with flexible filtering options. Transactions are r
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 {
   "data": [
@@ -69,14 +69,14 @@ Get all transactions for a specific customer:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Or use your platform's customer ID:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?platformCustomerId=customer_12345' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### Filter by transaction type
@@ -87,14 +87,14 @@ Get only incoming or outgoing transactions:
 <Tab title="Outgoing Only">
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?type=OUTGOING' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 </Tab>
 
 <Tab title="Incoming Only">
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?type=INCOMING' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 </Tab>
 </Tabs>
@@ -106,11 +106,11 @@ Get transactions in a specific status:
 ```bash
 # Get all pending transactions
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?status=PENDING' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 # Get all completed transactions
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?status=COMPLETED' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Available statuses:**
@@ -127,7 +127,7 @@ Get transactions within a specific date range:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?startDate=2025-10-01T00:00:00Z&endDate=2025-10-31T23:59:59Z' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Tip>Dates must be in ISO 8601 format (e.g., `2025-10-03T15:00:00Z`).</Tip>
@@ -139,15 +139,15 @@ Get transactions for a specific account:
 ```bash
 # Any transactions involving this account (sent or received)
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?accountIdentifier=InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 # Only transactions sent FROM this account
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?senderAccountIdentifier=InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 
 # Only transactions sent TO this account
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?receiverAccountIdentifier=ExternalAccount:a12dcbd6-dced-4ec4-b756-3c3a9ea3d123' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Combining filters
@@ -157,7 +157,7 @@ You can combine multiple filters to narrow down results:
 ```bash
 # Get completed outgoing transactions for a customer in October 2025
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001&type=OUTGOING&status=COMPLETED&startDate=2025-10-01T00:00:00Z&endDate=2025-10-31T23:59:59Z' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Pagination
@@ -168,7 +168,7 @@ Handle large result sets with cursor-based pagination:
 <Step title="Get first page">
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?limit=20' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Response:
@@ -191,7 +191,7 @@ Use the `nextCursor` from the previous response:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?limit=20&cursor=eyJpZCI6IlRyYW5z...' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 </Step>
@@ -236,7 +236,7 @@ Retrieve details for a specific transaction by ID:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions/Transaction:019542f5-b3e7-1d02-0000-000000000030' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Best practices

--- a/mintlify/payouts-and-b2b/payment-flow/send-payment.mdx
+++ b/mintlify/payouts-and-b2b/payment-flow/send-payment.mdx
@@ -55,7 +55,7 @@ Use the `/transfer-out` endpoint when sending funds in the same currency (no exc
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/internal-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Note the `id` fields from both the internal and external accounts you want to use.
@@ -67,7 +67,7 @@ Note the `id` fields from both the internal and external accounts you want to us
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/transfer-out' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -201,7 +201,7 @@ Use the quotes flow when sending funds with currency conversion. This locks in a
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -280,7 +280,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes/Quote:019542f5-b3e7-1d02-0000-000000000025/execute' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ```json Success (200 OK)

--- a/mintlify/ramps/accounts/external-accounts.mdx
+++ b/mintlify/ramps/accounts/external-accounts.mdx
@@ -47,7 +47,7 @@ The primary destination type for on-ramps:
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -123,7 +123,7 @@ For off-ramp flows, create external bank accounts with full beneficiary informat
 
 ```bash
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -158,14 +158,14 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### Filter by currency
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001&currency=BTC' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Account status and verification

--- a/mintlify/ramps/accounts/internal-accounts.mdx
+++ b/mintlify/ramps/accounts/internal-accounts.mdx
@@ -221,7 +221,7 @@ Use platform-level internal accounts for pooled liquidity:
 ```bash
 # Get platform internal accounts
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/platform/internal-accounts?currency=BTC' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Info>

--- a/mintlify/ramps/conversion-flows/fiat-crypto-conversion.mdx
+++ b/mintlify/ramps/conversion-flows/fiat-crypto-conversion.mdx
@@ -29,7 +29,7 @@ First, create an external account for the crypto destination:
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -45,7 +45,7 @@ Then create a quote using the external account ID:
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {
@@ -213,7 +213,7 @@ For instant on-ramps (e.g., reward payouts), use `immediatelyExecute: true` with
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/quotes' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "source": {

--- a/mintlify/ramps/conversion-flows/self-custody-wallets.mdx
+++ b/mintlify/ramps/conversion-flows/self-custody-wallets.mdx
@@ -67,7 +67,7 @@ Register the Spark wallet as an external account:
 <CodeGroup>
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",

--- a/mintlify/ramps/quickstart.mdx
+++ b/mintlify/ramps/quickstart.mdx
@@ -63,7 +63,7 @@ Register the customer's Spark wallet as an external account so it can be used as
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",

--- a/mintlify/rewards/developer-guides/distributing-rewards.mdx
+++ b/mintlify/rewards/developer-guides/distributing-rewards.mdx
@@ -24,7 +24,7 @@ You can find your platform's internal account by listing all internal accounts f
 
 ```bash
 curl -X GET "https://api.lightspark.com/grid/2025-10-13/platform/internal-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Response:
@@ -68,7 +68,7 @@ First, create an external account for the destination wallet:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -84,7 +84,7 @@ Then create the quote using the external account ID:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {
@@ -200,7 +200,7 @@ After reviewing the quote's exchange rate and fees, execute it:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes/{quoteId}/execute" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Note>
@@ -218,7 +218,7 @@ First, create the external account:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -317,7 +317,7 @@ Then review the exchange rate and fees, and execute:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes/{quoteId}/execute" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Best Practices

--- a/mintlify/rewards/developer-guides/listing-transactions.mdx
+++ b/mintlify/rewards/developer-guides/listing-transactions.mdx
@@ -13,7 +13,7 @@ Retrieve transaction history for Bitcoin rewards distributed through your platfo
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ```json response
@@ -70,14 +70,14 @@ Get all Bitcoin rewards sent to a customer:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Or use your platform's customer ID:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?platformCustomerId=user_789' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### Rewards by date range
@@ -87,7 +87,7 @@ Get all rewards distributed in a specific period:
 ```bash
 # October 2025 rewards
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?startDate=2025-10-01T00:00:00Z&endDate=2025-10-31T23:59:59Z' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Tip>Dates must be in ISO 8601 format (e.g., `2025-10-03T15:00:00Z`).</Tip>
@@ -98,7 +98,7 @@ Track rewards that failed to complete:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?status=FAILED&type=OUTGOING' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Transaction statuses:**
@@ -114,7 +114,7 @@ Get all rewards paid from your platform's USD internal account:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?senderAccountIdentifier=InternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965&type=OUTGOING' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Combining filters
@@ -124,7 +124,7 @@ Narrow down results by combining multiple filters:
 ```bash
 # All completed rewards for a customer in October
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?platformCustomerId=user_789&status=COMPLETED&startDate=2025-10-01T00:00:00Z&endDate=2025-10-31T23:59:59Z' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Pagination
@@ -165,7 +165,7 @@ Retrieve details for a specific reward transaction:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions/Transaction:019542f5-b3e7-1d02-0000-000000000025' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Common use cases

--- a/mintlify/rewards/onboarding/configuring-customers.mdx
+++ b/mintlify/rewards/onboarding/configuring-customers.mdx
@@ -50,7 +50,7 @@ Retrieve a paginated list of customers with optional filtering:
 
 ```bash
 curl -X GET "https://api.lightspark.com/grid/2025-10-13/customers?limit=20&customerType=INDIVIDUAL" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### Query Parameters
@@ -144,7 +144,7 @@ Get detailed information about a specific customer:
 
 ```bash
 curl -X GET "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ## Deleting Customers
@@ -153,7 +153,7 @@ Delete a customer by their system-generated ID:
 
 ```bash
 curl -X DELETE "https://api.lightspark.com/grid/2025-10-13/customers/{customerId}" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Warning>

--- a/mintlify/rewards/quickstart.mdx
+++ b/mintlify/rewards/quickstart.mdx
@@ -62,7 +62,7 @@ List your platform's internal accounts to see the available balances and funding
 
 ```bash
 curl -X GET "https://api.lightspark.com/grid/2025-10-13/platform/internal-accounts?currency=USD" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### Response
@@ -198,7 +198,7 @@ Register the customer's Spark wallet as an external account.
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers/external-accounts" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -233,7 +233,7 @@ Create and execute a trade from USD to BTC using the external account as the des
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/quotes" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "source": {

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -1004,7 +1004,7 @@ Fetch one external account by its system-generated ID:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 **Response:**
@@ -1044,7 +1044,7 @@ Delete an external account by its system-generated ID:
 
 ```bash
 curl -X DELETE 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Returns `204 No Content` on success.

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -998,6 +998,65 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/platform/external-accoun
   depositing funds from external sources.
 </Info>
 
+## Retrieving a single external account
+
+Fetch one external account by its system-generated ID:
+
+```bash
+curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
+  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+```
+
+**Response:**
+
+```json
+{
+  "id": "ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965",
+  "customerId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
+  "status": "ACTIVE",
+  "currency": "USD",
+  "platformAccountId": "acc_123456789",
+  "accountInfo": {
+    "accountType": "USD_ACCOUNT",
+    "accountNumber": "1234567890",
+    "routingNumber": "021000021",
+    "bankName": "Chase Bank",
+    "bankAccountType": "CHECKING",
+    "paymentRails": ["ACH", "WIRE", "RTP", "FEDNOW"],
+    "beneficiary": {
+      "beneficiaryType": "INDIVIDUAL",
+      "fullName": "Jane Doe"
+    }
+  }
+}
+```
+
+<Info>
+  `paymentRails` reports the rails Grid selected for the account. It is
+  returned on the account and is not something you send when creating one.
+</Info>
+
+Returns `404` if no external account matches the ID.
+
+## Deleting an external account
+
+Delete an external account by its system-generated ID:
+
+```bash
+curl -X DELETE 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:e85dcbd6-dced-4ec4-b756-3c3a9ea3d965' \
+  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+```
+
+Returns `204 No Content` on success.
+
+<Warning>
+  An account that is currently a **trusted beneficiary** for Strong Customer
+  Authentication cannot be deleted — the request fails with `409` and code
+  `BENEFICIARY_TRUSTED`. Untrust it first via `POST
+  /customers/external-accounts/{externalAccountId}/untrust` and its
+  `/confirm`, then delete.
+</Warning>
+
 ## Best practices
 
 <AccordionGroup>

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -16,7 +16,7 @@ Use the [Discoveries API](/api-reference/discoveries/list-available-receiving-in
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/discoveries?country=PH&currency=PHP' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ```json Response
@@ -48,7 +48,7 @@ Use `bankName` from the response as the `bankName` value when creating an extern
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "USD",
@@ -92,7 +92,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "MXN",
@@ -125,7 +125,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "BRL",
@@ -165,7 +165,7 @@ Colombia supports two payment rails: bank transfer and mobile money.
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "COP",
@@ -197,7 +197,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "COP",
@@ -241,7 +241,7 @@ El Salvador supports two payment rails: bank transfer and mobile money.
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "USD",
@@ -271,7 +271,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "USD",
@@ -306,7 +306,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "EUR",
@@ -340,7 +340,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "PHP",
@@ -376,7 +376,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "GBP",
@@ -411,7 +411,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "INR",
@@ -443,7 +443,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "NGN",
@@ -479,7 +479,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "ZAR",
@@ -515,7 +515,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "KES",
@@ -550,7 +550,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "TZS",
@@ -585,7 +585,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "ZMW",
@@ -620,7 +620,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "RWF",
@@ -655,7 +655,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "MWK",
@@ -690,7 +690,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "UGX",
@@ -725,7 +725,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "XOF",
@@ -763,7 +763,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "CAD",
@@ -802,7 +802,7 @@ Use a SWIFT account to send payouts to bank accounts in countries or currencies 
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "USD",
@@ -842,7 +842,7 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 
 ```bash cURL
 curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET' \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H 'Content-Type: application/json' \
   -d '{
     "currency": "BTC",
@@ -981,7 +981,7 @@ Beneficiary data may be reviewed for risk and compliance. Only `ACTIVE` accounts
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accounts?customerId=Customer:019542f5-b3e7-1d02-0000-000000000001' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 ### List platform accounts
@@ -990,7 +990,7 @@ For platform-wide operations, list all platform-level external accounts:
 
 ```bash
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/platform/external-accounts' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 <Info>

--- a/mintlify/snippets/kyc/kyc-regulated.mdx
+++ b/mintlify/snippets/kyc/kyc-regulated.mdx
@@ -19,7 +19,7 @@ To register a new customer in the system, use the `POST /customers` endpoint:
 
 ```bash
 curl -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
-  -H "Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "platformCustomerId": "customer_12345",

--- a/mintlify/snippets/reconciliation/reconciliation.mdx
+++ b/mintlify/snippets/reconciliation/reconciliation.mdx
@@ -89,7 +89,7 @@ We recommend querying days from `00:00:00.000` to `23:59:59.999` in your preferr
 
 ```bash cURL
 curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?startDate=2025-10-01T00:00:00.000Z&endDate=2025-10-01T23:59:59.999Z&limit=100' \
-  -H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"
 ```
 
 Response 


### PR DESCRIPTION
## Summary

Two things, both docs-only. Generated bundles untouched.

1. **Documents `GET` and `DELETE` for a single external account** — `external-accounts.mdx` covered create and list but neither by-id operation.
2. **Fixes all 85 remaining broken curl auth examples** across 17 files.

**Replaces #359**, which should be closed.

## Part 1 — the new sections

| Section | Covers |
|---|---|
| Retrieving a single external account | `GET /customers/external-accounts/{externalAccountId}`, full response example, `404` |
| Deleting an external account | `DELETE /customers/external-accounts/{externalAccountId}`, `204`, and the `409 BENEFICIARY_TRUSTED` path |

**Why a rewrite rather than a rebase of #359.** That PR has been open since April and the spec moved under it in four ways:

1. **It documents a `PATCH` endpoint that does not exist.** The path exposes only `get:` and `delete:` — verified in both the source path file and the bundled `openapi.yaml`. About a third of that PR describes an operation the API doesn't have.
2. **`"accountType": "US_ACCOUNT"`** is not a member of `ExternalAccountType`. The value is `USD_ACCOUNT`.
3. **`"accountCategory": "CHECKING"`** is not a field on `UsdAccountInfoBase`. The real field is `bankAccountType`.
4. **Delete's contract changed.** #770 added a `409`, which #359 predates.

**The `409` is why the delete section earns its place.** `BENEFICIARY_TRUSTED` fires when the account is a trusted SCA beneficiary, and the caller must untrust *and* confirm before delete succeeds. Nothing at the call site hints at that.

**The GET example includes `paymentRails`** because the response genuinely carries it — `UsdExternalAccountInfo` composes `UsdAccountInfo`, which requires it. A short `<Info>` notes it's returned rather than sent; that distinction has already caused one real bug.

Every field traces to a schema: `ExternalAccount` for the envelope, `UsdAccountInfoBase` for account fields, `UsdAccountInfo` for `paymentRails` (`ACH`/`WIRE`/`RTP`/`FEDNOW`), `UsdBeneficiary` for the minimum beneficiary shape.

## Part 2 — the curl auth sweep

Greptile flagged the auth header on the new examples. It was right, and the problem turned out to be repo-wide: **85 curl examples across 17 files** used

```bash
-H 'Authorization: Basic $GRID_CLIENT_ID:$GRID_CLIENT_SECRET'
```

which fails **two** independent ways. The single quotes stop the shell expanding the variables; and Basic auth requires `base64(user:pass)`, not the raw pair, so the header is rejected even once expanded. Every one of these failed on copy-paste — which is the entire point of a curl example.

All 85 now use `-u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET"`.

**This converges on the existing majority rather than introducing a style.** `api-reference/authentication.mdx` documents `curl -u "{client_id}:{client_secret}"`, and 178 examples across 40 other files already use `-u`. The `-H` form was the minority pattern.

Biggest concentrations: `snippets/external-accounts.mdx` (26), `payouts-and-b2b/payment-flow/list-transactions.mdx` (15), `rewards/developer-guides/listing-transactions.mdx` (8).

## Verification

- **85 replacements, 85 lines added, 85 deleted** — strictly 1:1, no line lost or merged
- Zero occurrences of the broken form remain
- **Only auth lines changed** — diff contains no other removals, so no `-H 'Content-Type'` was clobbered
- **The 11 JS/Python `Basic ${credentials}` usages are untouched.** Those build the header from a pre-encoded value and are correct; the sweep matched only `-H` lines carrying the raw credential pair
- No curl block ended up with a duplicate `-u`
- MDX component tags and code fences balance across every `.mdx` in `mintlify/`
- The new JSON example parses
- Generated bundles byte-identical to `main`

**Not verified:** no visual render check, and `make lint` was not run — it fails on `main` regardless, because `npx spectral lint` resolves to a stub `spectral@0.0.0` rather than `@stoplight/spectral-cli`. This change touches no OpenAPI source, so the Mintlify preview is the meaningful check.

## Still open in this file

`external-accounts.mdx` documents 21 of ~37 account types in `account-types.ts`. Missing: `XAF`, `BWP`, `AED`, `BDT`, `EGP`, `GHS`, `GTQ`, `HTG`, `JMD`, `PKR`, `CNY`, plus wallet types `BASE_WALLET`, `POLYGON_WALLET`, `PLASMA_WALLET`, `SOLANA_WALLET`, `TRON_WALLET`, `ETHEREUM_WALLET`. Out of scope here, but it's the largest remaining documentation gap in this area.