### PR TITLE
Hide network icons that have no asset

### DIFF
--- a/components/grid-visualizer/src/components/InputCard/InputCard.tsx
+++ b/components/grid-visualizer/src/components/InputCard/InputCard.tsx
@@ -180,11 +180,14 @@ function NetworkDropdown({
                     }}
                     type="button"
                   >
+                    {/* Not every network has an icon in public/networks yet; hide the
+                        broken image rather than showing a torn-page glyph next to the name. */}
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={`/networks/${acct.network.toLowerCase()}.svg`}
                       alt=""
                       className={styles.networkMenuIcon}
+                      onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
                     />
                     <span>{acct.network}</span>
                   </button>


### PR DESCRIPTION
## Summary

`RailDropdown` renders `/networks/${network.toLowerCase()}.svg` for every entry with no error handling, and **three of the eight networks in `crypto.ts` have no asset**: `ethereum`, `plasma`, `tron`. Those rows show a broken image next to the network name.

Three lines: an `onError` that hides the image.

```
networks referenced:  base ethereum lightning plasma polygon solana spark tron
icons present:        base bitcoin lightning polygon solana spark
missing:              ethereum plasma tron
```

USDT has carried three broken rows for a while. #792 added Ethereum to USDC, which put the first one on a dropdown that had been clean — that's what surfaced it.

**Why hide rather than supply the artwork.** An Ethereum or Tron mark is brand material, and inventing one that doesn't match the existing set is worse than a gap. The three assets are still worth adding; this just stops the UI looking broken until they are.

**Why `visibility` rather than `display`.** `.networkMenuIcon` is a fixed 20×20 flex item, so hiding it preserves the slot and the network names stay left-aligned down the list. `display: none` would make rows ragged depending on which icons happen to exist.

## What I did not include, and why

This branch was going to carry the **duplicate `code: 'USD'`** fix as well — `currencies.ts` has two entries with that code (United States Dollar, and US Dollar (El Salvador)), so `currencies.find(c => c.code === 'USD')` never reaches the El Salvador entry and the picker builds two items with the same `id`, making it effectively unselectable.

Mapping it out, that is **not a small fix**. It needs selections re-keyed from `code` to `accountType` across roughly ten lookup sites in five files — `CurrencyPicker.lookupSelection`, `getRailsText`, three lookups in `InputCard`, three in `useFlowBuilder` including `getDefaultRail`'s signature, `code-generator`, `flow-path` — plus `POPULAR_CODES`, which matches item ids. `isSameCurrency` also needs a decision, since two USD entries are the same currency on different rails.

All of that lands in `.tsx` files I **cannot typecheck in this environment** — `npm ci` fails in `components/grid-visualizer` because `@central-icons-react` requires `CENTRAL_LICENSE_KEY`, so React types are unavailable. Shipping a ten-site refactor unverified seemed like the wrong trade, so it wants its own PR from someone with a working build.

## Verification

- Missing-icon list derived mechanically by diffing `public/networks/` against the `network` values in `crypto.ts`
- `.networkMenuIcon` confirmed to have fixed dimensions, so `visibility: hidden` is layout-stable
- **Not verified:** no build or render check, for the reason above. The Vercel preview is the real check — worth opening the USDC and USDT rail dropdowns to confirm the rows align with the icons absent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnjJ8yWJsui7jLqqrDrL4)_