### PR TITLE
feat(quotes): allow a per-transaction platform fee override on POST /quotes

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21806,7 +21806,9 @@ components:
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
     PlatformFeeOverride:
       type: object
-      description: Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+      description: |-
+        Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+        Only honored on platform-authenticated requests to `POST /quotes`. Agent tokens carry no fee-control permission, so this field must be omitted on agent-authenticated requests such as `POST /agents/me/quotes`.
       required:
         - platformFixedFee
         - platformVariableFeeBps

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21804,6 +21804,40 @@ components:
         - SENDING
         - RECEIVING
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
+    PlatformFeeOverride:
+      type: object
+      description: Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+      required:
+        - platformFixedFee
+        - platformVariableFeeBps
+      properties:
+        platformFixedFee:
+          type: object
+          description: Fixed fee charged for this transaction.
+          required:
+            - amount
+            - currency
+          properties:
+            amount:
+              type: integer
+              format: int64
+              minimum: 0
+              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+              example: 50
+            currency:
+              type: string
+              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Must equal the quote's source currency (USD today).
+              example: USD
+        platformVariableFeeBps:
+          type: integer
+          minimum: 0
+          description: Variable fee in basis points (1 bps = 0.01%) to apply to the transaction's source-currency amount.
+          example: 30
+      example:
+        platformFixedFee:
+          amount: 50
+          currency: USD
+        platformVariableFeeBps: 30
     QuoteRequest:
       type: object
       required:
@@ -21849,6 +21883,8 @@ components:
           example: '12345'
         purposeOfPayment:
           $ref: '#/components/schemas/PurposeOfPayment'
+        platformFeeOverride:
+          $ref: '#/components/schemas/PlatformFeeOverride'
         scaFactor:
           $ref: '#/components/schemas/ScaFactor'
           description: Optional preferred factor for a Strong Customer Authentication challenge issued at quote creation. Only relevant for a realtime-funding source in a region where SCA is required (e.g. EU); ignored otherwise. Valid values are `SMS_OTP` (default) and `PASSKEY` — `TOTP` cannot carry the required dynamic linking and is rejected. When the quote is returned in `PENDING_AUTHORIZATION`, authorize it via `POST /quotes/{quoteId}/authorize`.

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11529,6 +11529,23 @@ components:
         - `CROSS_CURRENCY_TRANSACTION` — fee charged on a cross-currency Grid transaction
           (source currency differs from destination currency).
       example: CROSS_CURRENCY_TRANSACTION
+    FixedFee:
+      type: object
+      description: Fixed fee charged per transaction.
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+          example: 100
+        currency:
+          type: string
+          description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
     FeeConfig:
       type: object
       description: A platform-configured fee collected by Grid and settled to the platform internal account. There can be at most one fee config for a given fee type and source currency pair. The fee will apply to all transactions of the fee type that originate in the source currency.
@@ -11546,22 +11563,7 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
           example: 30
         fixedFee:
-          type: object
-          description: Fixed fee charged per transaction.
-          properties:
-            amount:
-              type: integer
-              format: int64
-              minimum: 0
-              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
-              example: 100
-            currency:
-              type: string
-              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-              example: USD
-          required:
-            - amount
-            - currency
+          $ref: '#/components/schemas/FixedFee'
       required:
         - feeType
         - sourceCurrency
@@ -21806,33 +21808,18 @@ components:
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
     PlatformFeeOverride:
       type: object
-      description: |-
-        Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
-        Only honored on platform-authenticated requests to `POST /quotes`. Agent tokens carry no fee-control permission, so this field must be omitted on agent-authenticated requests such as `POST /agents/me/quotes`.
+      description: Overrides the platform-collected fee for this transaction. When present, it replaces any configured platform-collected fees that would otherwise apply to the transaction. Currently only supported when the quote's source currency is USD; the fixed fee must be denominated in the source currency.
       required:
         - platformFixedFee
         - platformVariableFeeBps
       properties:
         platformFixedFee:
-          type: object
-          description: Fixed fee charged for this transaction.
-          required:
-            - amount
-            - currency
-          properties:
-            amount:
-              type: integer
-              format: int64
-              minimum: 0
-              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
-              example: 50
-            currency:
-              type: string
-              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Must equal the quote's source currency (USD today).
-              example: USD
+          $ref: '#/components/schemas/FixedFee'
+          description: Fixed fee charged for this transaction. Must be denominated in the quote's source currency (USD today).
         platformVariableFeeBps:
           type: integer
           minimum: 0
+          maximum: 10000
           description: Variable fee in basis points (1 bps = 0.01%) to apply to the transaction's source-currency amount.
           example: 30
       example:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21806,7 +21806,9 @@ components:
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
     PlatformFeeOverride:
       type: object
-      description: Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+      description: |-
+        Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+        Only honored on platform-authenticated requests to `POST /quotes`. Agent tokens carry no fee-control permission, so this field must be omitted on agent-authenticated requests such as `POST /agents/me/quotes`.
       required:
         - platformFixedFee
         - platformVariableFeeBps

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21804,6 +21804,40 @@ components:
         - SENDING
         - RECEIVING
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
+    PlatformFeeOverride:
+      type: object
+      description: Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
+      required:
+        - platformFixedFee
+        - platformVariableFeeBps
+      properties:
+        platformFixedFee:
+          type: object
+          description: Fixed fee charged for this transaction.
+          required:
+            - amount
+            - currency
+          properties:
+            amount:
+              type: integer
+              format: int64
+              minimum: 0
+              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+              example: 50
+            currency:
+              type: string
+              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Must equal the quote's source currency (USD today).
+              example: USD
+        platformVariableFeeBps:
+          type: integer
+          minimum: 0
+          description: Variable fee in basis points (1 bps = 0.01%) to apply to the transaction's source-currency amount.
+          example: 30
+      example:
+        platformFixedFee:
+          amount: 50
+          currency: USD
+        platformVariableFeeBps: 30
     QuoteRequest:
       type: object
       required:
@@ -21849,6 +21883,8 @@ components:
           example: '12345'
         purposeOfPayment:
           $ref: '#/components/schemas/PurposeOfPayment'
+        platformFeeOverride:
+          $ref: '#/components/schemas/PlatformFeeOverride'
         scaFactor:
           $ref: '#/components/schemas/ScaFactor'
           description: Optional preferred factor for a Strong Customer Authentication challenge issued at quote creation. Only relevant for a realtime-funding source in a region where SCA is required (e.g. EU); ignored otherwise. Valid values are `SMS_OTP` (default) and `PASSKEY` — `TOTP` cannot carry the required dynamic linking and is rejected. When the quote is returned in `PENDING_AUTHORIZATION`, authorize it via `POST /quotes/{quoteId}/authorize`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11529,6 +11529,23 @@ components:
         - `CROSS_CURRENCY_TRANSACTION` — fee charged on a cross-currency Grid transaction
           (source currency differs from destination currency).
       example: CROSS_CURRENCY_TRANSACTION
+    FixedFee:
+      type: object
+      description: Fixed fee charged per transaction.
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
+          example: 100
+        currency:
+          type: string
+          description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
+          example: USD
     FeeConfig:
       type: object
       description: A platform-configured fee collected by Grid and settled to the platform internal account. There can be at most one fee config for a given fee type and source currency pair. The fee will apply to all transactions of the fee type that originate in the source currency.
@@ -11546,22 +11563,7 @@ components:
           description: Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
           example: 30
         fixedFee:
-          type: object
-          description: Fixed fee charged per transaction.
-          properties:
-            amount:
-              type: integer
-              format: int64
-              minimum: 0
-              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
-              example: 100
-            currency:
-              type: string
-              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Some cryptocurrencies may use their own ticker symbols (e.g. "BTC" for Bitcoin, "USDC" for USDC, etc.)
-              example: USD
-          required:
-            - amount
-            - currency
+          $ref: '#/components/schemas/FixedFee'
       required:
         - feeType
         - sourceCurrency
@@ -21806,33 +21808,18 @@ components:
       description: The side of the quote which should be locked and specified in the `lockedCurrencyAmount`. For example, if I want to send exactly $5 MXN from my wallet, I would set this to "sending", and the `lockedCurrencyAmount` to 500 (in cents). If I want the receiver to receive exactly $10 USD, I would set this to "receiving" and the `lockedCurrencyAmount` to 10000 (in cents).
     PlatformFeeOverride:
       type: object
-      description: |-
-        Overrides the platform fee for this transaction. When present, it replaces all platform fees that would otherwise apply to the transaction — no standing fee config is required. Only supported when the quote's source currency is USD today; the fixed fee must be denominated in the source currency.
-        Only honored on platform-authenticated requests to `POST /quotes`. Agent tokens carry no fee-control permission, so this field must be omitted on agent-authenticated requests such as `POST /agents/me/quotes`.
+      description: Overrides the platform-collected fee for this transaction. When present, it replaces any configured platform-collected fees that would otherwise apply to the transaction. Currently only supported when the quote's source currency is USD; the fixed fee must be denominated in the source currency.
       required:
         - platformFixedFee
         - platformVariableFeeBps
       properties:
         platformFixedFee:
-          type: object
-          description: Fixed fee charged for this transaction.
-          required:
-            - amount
-            - currency
-          properties:
-            amount:
-              type: integer
-              format: int64
-              minimum: 0
-              description: Fee amount in the smallest unit of the fixed fee's `currency` (e.g., cents for USD).
-              example: 50
-            currency:
-              type: string
-              description: Three-letter currency code (ISO 4217) the fixed fee is denominated in. Must equal the quote's source currency (USD today).
-              example: USD
+          $ref: '#/components/schemas/FixedFee'
+          description: Fixed fee charged for this transaction. Must be denominated in the quote's source currency (USD today).
         platformVariableFeeBps:
           type: integer
           minimum: 0
+          maximum: 10000
           description: Variable fee in basis points (1 bps = 0.01%) to apply to the transaction's source-currency amount.
           example: 30
       example:

--- a/openapi/components/schemas/config/FeeConfig.yaml
+++ b/openapi/components/schemas/config/FeeConfig.yaml
@@ -18,27 +18,7 @@ properties:
       Variable fee in basis points (1 bps = 0.01%) to apply to a transaction's source-currency amount.
     example: 30
   fixedFee:
-    type: object
-    description: Fixed fee charged per transaction.
-    properties:
-      amount:
-        type: integer
-        format: int64
-        minimum: 0
-        description: >-
-          Fee amount in the smallest unit of the fixed fee's `currency`
-          (e.g., cents for USD).
-        example: 100
-      currency:
-        type: string
-        description: >-
-          Three-letter currency code (ISO 4217) the fixed fee is denominated
-          in. Some cryptocurrencies may use their own ticker symbols (e.g.
-          "BTC" for Bitcoin, "USDC" for USDC, etc.)
-        example: USD
-    required:
-      - amount
-      - currency
+    $ref: ./FixedFee.yaml
 required:
   - feeType
   - sourceCurrency

--- a/openapi/components/schemas/config/FixedFee.yaml
+++ b/openapi/components/schemas/config/FixedFee.yaml
@@ -1,0 +1,21 @@
+type: object
+description: Fixed fee charged per transaction.
+required:
+  - amount
+  - currency
+properties:
+  amount:
+    type: integer
+    format: int64
+    minimum: 0
+    description: >-
+      Fee amount in the smallest unit of the fixed fee's `currency`
+      (e.g., cents for USD).
+    example: 100
+  currency:
+    type: string
+    description: >-
+      Three-letter currency code (ISO 4217) the fixed fee is denominated
+      in. Some cryptocurrencies may use their own ticker symbols (e.g.
+      "BTC" for Bitcoin, "USDC" for USDC, etc.)
+    example: USD

--- a/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
+++ b/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
@@ -4,6 +4,10 @@ description: >-
   all platform fees that would otherwise apply to the transaction — no standing
   fee config is required. Only supported when the quote's source currency is
   USD today; the fixed fee must be denominated in the source currency.
+
+  Only honored on platform-authenticated requests to `POST /quotes`. Agent
+  tokens carry no fee-control permission, so this field must be omitted on
+  agent-authenticated requests such as `POST /agents/me/quotes`.
 required:
   - platformFixedFee
   - platformVariableFeeBps

--- a/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
+++ b/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
@@ -1,41 +1,23 @@
 type: object
 description: >-
-  Overrides the platform fee for this transaction. When present, it replaces
-  all platform fees that would otherwise apply to the transaction — no standing
-  fee config is required. Only supported when the quote's source currency is
-  USD today; the fixed fee must be denominated in the source currency.
+  Overrides the platform-collected fee for this transaction. When present,
+  it replaces any configured platform-collected fees that would otherwise
+  apply to the transaction. Currently only supported when the quote's source
+  currency is USD; the fixed fee must be denominated in the source currency.
 
-  Only honored on platform-authenticated requests to `POST /quotes`. Agent
-  tokens carry no fee-control permission, so this field must be omitted on
-  agent-authenticated requests such as `POST /agents/me/quotes`.
 required:
   - platformFixedFee
   - platformVariableFeeBps
 properties:
   platformFixedFee:
-    type: object
-    description: Fixed fee charged for this transaction.
-    required:
-      - amount
-      - currency
-    properties:
-      amount:
-        type: integer
-        format: int64
-        minimum: 0
-        description: >-
-          Fee amount in the smallest unit of the fixed fee's `currency`
-          (e.g., cents for USD).
-        example: 50
-      currency:
-        type: string
-        description: >-
-          Three-letter currency code (ISO 4217) the fixed fee is denominated
-          in. Must equal the quote's source currency (USD today).
-        example: USD
+    $ref: ../config/FixedFee.yaml
+    description: >-
+      Fixed fee charged for this transaction. Must be denominated in the
+      quote's source currency (USD today).
   platformVariableFeeBps:
     type: integer
     minimum: 0
+    maximum: 10000
     description: >-
       Variable fee in basis points (1 bps = 0.01%) to apply to the
       transaction's source-currency amount.

--- a/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
+++ b/openapi/components/schemas/quotes/PlatformFeeOverride.yaml
@@ -1,0 +1,43 @@
+type: object
+description: >-
+  Overrides the platform fee for this transaction. When present, it replaces
+  all platform fees that would otherwise apply to the transaction — no standing
+  fee config is required. Only supported when the quote's source currency is
+  USD today; the fixed fee must be denominated in the source currency.
+required:
+  - platformFixedFee
+  - platformVariableFeeBps
+properties:
+  platformFixedFee:
+    type: object
+    description: Fixed fee charged for this transaction.
+    required:
+      - amount
+      - currency
+    properties:
+      amount:
+        type: integer
+        format: int64
+        minimum: 0
+        description: >-
+          Fee amount in the smallest unit of the fixed fee's `currency`
+          (e.g., cents for USD).
+        example: 50
+      currency:
+        type: string
+        description: >-
+          Three-letter currency code (ISO 4217) the fixed fee is denominated
+          in. Must equal the quote's source currency (USD today).
+        example: USD
+  platformVariableFeeBps:
+    type: integer
+    minimum: 0
+    description: >-
+      Variable fee in basis points (1 bps = 0.01%) to apply to the
+      transaction's source-currency amount.
+    example: 30
+example:
+  platformFixedFee:
+    amount: 50
+    currency: USD
+  platformVariableFeeBps: 30

--- a/openapi/components/schemas/quotes/QuoteRequest.yaml
+++ b/openapi/components/schemas/quotes/QuoteRequest.yaml
@@ -67,6 +67,8 @@ properties:
     example: '12345'
   purposeOfPayment:
     $ref: ./PurposeOfPayment.yaml
+  platformFeeOverride:
+    $ref: ./PlatformFeeOverride.yaml
   scaFactor:
     $ref: ../sca/ScaFactor.yaml
     description: >-


### PR DESCRIPTION
## What

Adds an optional `platformFeeOverride` object to the `QuoteRequest` schema (new `components/schemas/quotes/PlatformFeeOverride.yaml`, bundles regenerated).

When present, the override replaces all platform fees that would otherwise apply to the transaction:
- `platformFixedFee` ({amount, currency}) and `platformVariableFeeBps` are both **required** within the object; negatives rejected at schema level (`minimum: 0`)
- No standing fee config is required and there is no cap relative to one
- USD source currency only today (including same-currency USD transfers); the fixed fee currency must equal the quote's source currency — 400 `INVALID_INPUT` otherwise
- `TRANSACTION_OVERRIDE` is deliberately NOT added to `config/FeeType.yaml`: platforms must not create standing override configs via `PATCH /config`

No response-shape changes. Optional-field addition — passes the oasdiff breaking-change check.

## Why

Grid Fees Phase 2d (AT-6193, epic AT-6136): platforms need per-transaction control of their own fee (promos, VIP pricing, negotiated rates) without editing standing config.

Sparkcore implementation: lightsparkdev/webdev stack for AT-6128 / AT-6194 (vendored client regen included there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)