### PR TITLE
docs(cards): PATCH /cards/{id} is platform-authenticated, not SCA-railed

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8247,11 +8247,7 @@ paths:
         - `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`. `CLOSED` is terminal and irreversible. Any other transition returns `409 INVALID_STATE_TRANSITION`.
         - `fundingSources`, when supplied, fully replaces the card's bound funding sources. Array order determines the priority Authorization Decisioning tries them in. Each id must belong to the cardholder and be denominated in the card's currency; the list must contain at least one source. `fundingSources` cannot be supplied alongside `state: CLOSED`.
 
-        Because both updates are sensitive state changes, this endpoint uses Grid's 202 → signed-retry pattern (same shape as `DELETE /auth/credentials/{id}` and `POST /internal-accounts/{id}/export`):
-
-        1. Call `PATCH /cards/{id}` with the target fields and no signing headers. The response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
-
-        2. Sign the `payloadToSign` with the session private key of a verified authentication credential on the card's owning internal account and retry with the signature as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The signed retry returns `200` with the updated `Card`.
+        This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
         Effects:
         - `state: FROZEN`: Authorization Decisioning declines new auths with `CARD_PAUSED`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
@@ -8265,21 +8261,6 @@ paths:
         - Cards
       security:
         - BasicAuth: []
-      parameters:
-        - name: Grid-Wallet-Signature
-          in: header
-          required: false
-          description: Signature over the `payloadToSign` returned in a prior `202` response, produced with the session private key of a verified authentication credential on the card's owning internal account and base64-encoded. Required on the signed retry; ignored on the initial call.
-          schema:
-            type: string
-          example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
-        - name: Request-Id
-          in: header
-          required: false
-          description: The `requestId` returned in a prior `202` response, echoed back on the signed retry so the server can correlate it with the issued challenge. Required on the signed retry; must be paired with `Grid-Wallet-Signature`.
-          schema:
-            type: string
-          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
       requestBody:
         required: true
         content:
@@ -8313,17 +8294,11 @@ paths:
                   state: CLOSED
       responses:
         '200':
-          description: Signed retry accepted. Returns the updated card.
+          description: Card updated. Returns the updated card.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Card'
-        '202':
-          description: Challenge issued. The response contains a `payloadToSign` that must be signed with the session private key of a verified authentication credential on the card's owning internal account, along with a `requestId` that must be echoed back on the retry.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SignedRequestChallenge'
         '400':
           description: Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a supplied funding source does not belong to the cardholder or is not denominated in the card's currency, and for general invalid parameters.
           content:
@@ -8331,7 +8306,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error400'
         '401':
-          description: Unauthorized. Returned when the provided `Grid-Wallet-Signature` is missing, malformed, or does not match a pending update challenge for this card, or when the `Request-Id` does not match an unexpired pending challenge.
+          description: Unauthorized. Returned when the platform credential is missing or invalid, or does not grant access to this card.
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8247,11 +8247,7 @@ paths:
         - `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`. `CLOSED` is terminal and irreversible. Any other transition returns `409 INVALID_STATE_TRANSITION`.
         - `fundingSources`, when supplied, fully replaces the card's bound funding sources. Array order determines the priority Authorization Decisioning tries them in. Each id must belong to the cardholder and be denominated in the card's currency; the list must contain at least one source. `fundingSources` cannot be supplied alongside `state: CLOSED`.
 
-        Because both updates are sensitive state changes, this endpoint uses Grid's 202 → signed-retry pattern (same shape as `DELETE /auth/credentials/{id}` and `POST /internal-accounts/{id}/export`):
-
-        1. Call `PATCH /cards/{id}` with the target fields and no signing headers. The response is `202` with a `payloadToSign`, `requestId`, and `expiresAt`.
-
-        2. Sign the `payloadToSign` with the session private key of a verified authentication credential on the card's owning internal account and retry with the signature as the `Grid-Wallet-Signature` header and the `requestId` echoed back as the `Request-Id` header. The signed retry returns `200` with the updated `Card`.
+        This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
         Effects:
         - `state: FROZEN`: Authorization Decisioning declines new auths with `CARD_PAUSED`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
@@ -8265,21 +8261,6 @@ paths:
         - Cards
       security:
         - BasicAuth: []
-      parameters:
-        - name: Grid-Wallet-Signature
-          in: header
-          required: false
-          description: Signature over the `payloadToSign` returned in a prior `202` response, produced with the session private key of a verified authentication credential on the card's owning internal account and base64-encoded. Required on the signed retry; ignored on the initial call.
-          schema:
-            type: string
-          example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
-        - name: Request-Id
-          in: header
-          required: false
-          description: The `requestId` returned in a prior `202` response, echoed back on the signed retry so the server can correlate it with the issued challenge. Required on the signed retry; must be paired with `Grid-Wallet-Signature`.
-          schema:
-            type: string
-          example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
       requestBody:
         required: true
         content:
@@ -8313,17 +8294,11 @@ paths:
                   state: CLOSED
       responses:
         '200':
-          description: Signed retry accepted. Returns the updated card.
+          description: Card updated. Returns the updated card.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Card'
-        '202':
-          description: Challenge issued. The response contains a `payloadToSign` that must be signed with the session private key of a verified authentication credential on the card's owning internal account, along with a `requestId` that must be echoed back on the retry.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SignedRequestChallenge'
         '400':
           description: Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a supplied funding source does not belong to the cardholder or is not denominated in the card's currency, and for general invalid parameters.
           content:
@@ -8331,7 +8306,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error400'
         '401':
-          description: Unauthorized. Returned when the provided `Grid-Wallet-Signature` is missing, malformed, or does not match a pending update challenge for this card, or when the `Request-Id` does not match an unexpired pending challenge.
+          description: Unauthorized. Returned when the platform credential is missing or invalid, or does not grant access to this card.
           content:
             application/json:
               schema:

--- a/openapi/paths/cards/cards_{id}.yaml
+++ b/openapi/paths/cards/cards_{id}.yaml
@@ -70,21 +70,17 @@ patch:
     `state: CLOSED`.
 
 
-    Because both updates are sensitive state changes, this endpoint uses
-    Grid's 202 → signed-retry pattern (same shape as
-    `DELETE /auth/credentials/{id}` and `POST /internal-accounts/{id}/export`):
-
-
-    1. Call `PATCH /cards/{id}` with the target fields and no signing
-    headers. The response is `202` with a `payloadToSign`, `requestId`, and
-    `expiresAt`.
-
-
-    2. Sign the `payloadToSign` with the session private key of a verified
-    authentication credential on the card's owning internal account and
-    retry with the signature as the `Grid-Wallet-Signature` header and the
-    `requestId` echoed back as the `Request-Id` header. The signed retry
-    returns `200` with the updated `Card`.
+    This endpoint is authenticated by the platform credential alone and
+    returns `200` directly. It deliberately does not use Grid's 202 →
+    signed-retry pattern: that pattern signs with the session key of a
+    credential on the owning internal account, so it models actions taken
+    *by* the end user on their own credentials or funds. Freezing or
+    closing a card is routinely an action taken *about* a user and without
+    them present - fraud response, offboarding, an ops-driven freeze - and
+    requiring the cardholder's signature would make exactly those cases
+    impossible. Operations that expose sensitive card data
+    (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed
+    instead, because there the cardholder is the party being served.
 
 
     Effects:
@@ -118,30 +114,6 @@ patch:
     - Cards
   security:
     - BasicAuth: []
-  parameters:
-    - name: Grid-Wallet-Signature
-      in: header
-      required: false
-      description: >-
-        Signature over the `payloadToSign` returned in a prior `202`
-        response, produced with the session private key of a verified
-        authentication credential on the card's owning internal account and
-        base64-encoded. Required on the signed retry; ignored on the initial
-        call.
-      schema:
-        type: string
-      example: MEUCIQDx7k2N0aK4p8f3vR9J6yT5wL1mB0sXnG2hQ4vJ8zYkCgIgZ4rP9dT7eWfU3oM6KjR1qSpNvBwL0tXyA2iG8fH5dE=
-    - name: Request-Id
-      in: header
-      required: false
-      description: >-
-        The `requestId` returned in a prior `202` response, echoed back on
-        the signed retry so the server can correlate it with the issued
-        challenge. Required on the signed retry; must be paired with
-        `Grid-Wallet-Signature`.
-      schema:
-        type: string
-      example: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21
   requestBody:
     required: true
     content:
@@ -175,21 +147,11 @@ patch:
               state: CLOSED
   responses:
     '200':
-      description: Signed retry accepted. Returns the updated card.
+      description: Card updated. Returns the updated card.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas/cards/Card.yaml
-    '202':
-      description: >-
-        Challenge issued. The response contains a `payloadToSign` that must
-        be signed with the session private key of a verified authentication
-        credential on the card's owning internal account, along with a
-        `requestId` that must be echoed back on the retry.
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas/common/SignedRequestChallenge.yaml
     '400':
       description: >-
         Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a
@@ -202,10 +164,8 @@ patch:
             $ref: ../../components/schemas/errors/Error400.yaml
     '401':
       description: >-
-        Unauthorized. Returned when the provided `Grid-Wallet-Signature` is
-        missing, malformed, or does not match a pending update challenge for
-        this card, or when the `Request-Id` does not match an unexpired
-        pending challenge.
+        Unauthorized. Returned when the platform credential is missing or
+        invalid, or does not grant access to this card.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Reason

`PATCH /cards/{id}` documented a `202` -> signed-retry flow that the implementation never had: it returns `200` directly, authenticated by the platform credential. One of the two has to give.

The spec should give, because the documented flow is wrong for this verb. The 202 pattern signs the challenge with the session private key of a verified authentication credential **on the card's owning internal account** - the end user's key. That models actions taken *by* a user on their own credentials or funds, which is why `DELETE /auth/credentials/{id}` and `POST /internal-accounts/{id}/export` use it.

Freezing or closing a card is routinely an action taken *about* a user and without them present: fraud response, offboarding, an ops-driven freeze. Under the documented flow none of those are possible through the public API, and the cardholder may be the adversary. We would have had to add a platform-authenticated bypass almost immediately, and that bypass would have become the path everyone actually used.

## Overview

- Drops the 202 -> signed-retry prose and replaces it with why this endpoint is platform-authenticated.
- Drops the `Grid-Wallet-Signature` and `Request-Id` header parameters.
- Drops the `202` response.
- `200` is no longer described as "signed retry accepted".
- Rewrites the `401` description, which described signature and challenge failures.

Sensitive-data operations stay SCA-railed: `POST /cards/{id}/reveal` and 3DS password retrieval are unchanged, because there the cardholder is the party being served and user-present signing is the right model.

## Notes

No implementation change accompanies this - sparkcore already behaves this way, so this closes the divergence rather than opening one. Nothing is affected downstream: the card program is gated behind `GRID_CARD_PROGRAM_ENABLED` and is not public.

Redocly validates clean; warning count unchanged at 50, none in this file. Spectral does not run locally (see #795).
