### PR TITLE
Add optional primary contact name to business info

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12613,6 +12613,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BusinessCustomerFields:
       type: object
       required:
@@ -12737,6 +12747,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BeneficialOwnerRole:
       type: string
       enum:
@@ -13080,6 +13100,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BusinessCustomerCreateRequest:
       title: Business Customer Create Request
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12613,6 +12613,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BusinessCustomerFields:
       type: object
       required:
@@ -12737,6 +12747,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BeneficialOwnerRole:
       type: string
       enum:
@@ -13080,6 +13100,16 @@ components:
           description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
           example:
             - US
+        primaryContactFirstName:
+          type: string
+          maxLength: 250
+          description: First name of the business's primary contact — a registered director or authorised representative of the business. Required in regions where a named individual is verified against the business during onboarding (e.g. the EU). The customer's `email` and `phoneNumber` are this person's contact details.
+          example: Jane
+        primaryContactLastName:
+          type: string
+          maxLength: 250
+          description: Last name of the business's primary contact.
+          example: Smith
     BusinessCustomerCreateRequest:
       title: Business Customer Create Request
       allOf:

--- a/openapi/components/schemas/customers/BusinessInfo.yaml
+++ b/openapi/components/schemas/customers/BusinessInfo.yaml
@@ -105,3 +105,17 @@ properties:
     description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
     example:
       - US
+  primaryContactFirstName:
+    type: string
+    maxLength: 250
+    description: >-
+      First name of the business's primary contact — a registered director or
+      authorised representative of the business. Required in regions where a named
+      individual is verified against the business during onboarding (e.g. the EU).
+      The customer's `email` and `phoneNumber` are this person's contact details.
+    example: Jane
+  primaryContactLastName:
+    type: string
+    maxLength: 250
+    description: Last name of the business's primary contact.
+    example: Smith

--- a/openapi/components/schemas/customers/BusinessInfoResponse.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoResponse.yaml
@@ -106,3 +106,17 @@ properties:
     description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
     example:
       - US
+  primaryContactFirstName:
+    type: string
+    maxLength: 250
+    description: >-
+      First name of the business's primary contact — a registered director or
+      authorised representative of the business. Required in regions where a named
+      individual is verified against the business during onboarding (e.g. the EU).
+      The customer's `email` and `phoneNumber` are this person's contact details.
+    example: Jane
+  primaryContactLastName:
+    type: string
+    maxLength: 250
+    description: Last name of the business's primary contact.
+    example: Smith

--- a/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
+++ b/openapi/components/schemas/customers/BusinessInfoUpdate.yaml
@@ -101,3 +101,17 @@ properties:
     description: List of countries of the business's expected transaction counterparties (ISO 3166-1 alpha-2)
     example:
       - US
+  primaryContactFirstName:
+    type: string
+    maxLength: 250
+    description: >-
+      First name of the business's primary contact — a registered director or
+      authorised representative of the business. Required in regions where a named
+      individual is verified against the business during onboarding (e.g. the EU).
+      The customer's `email` and `phoneNumber` are this person's contact details.
+    example: Jane
+  primaryContactLastName:
+    type: string
+    maxLength: 250
+    description: Last name of the business's primary contact.
+    example: Smith


### PR DESCRIPTION
## Summary

Adds two optional properties — `primaryContactFirstName` and `primaryContactLastName` — to `BusinessInfo`, `BusinessInfoUpdate`, and `BusinessInfoResponse`.

Businesses onboarding in regions that verify a named individual against the business (the EU, for example) have to identify their registered director or authorised representative. Today the business info schemas carry no way to name that person, so there is nowhere for an integrator to send it.

## Why two plain properties rather than a `primaryContact` object

The customer's existing top-level `email` and `phoneNumber` already are that person's contact details — they're documented as "Required in regions that verify the email address before identity verification". Nesting a fresh contact object with its own email and phone would create a second, competing pair of channels for the same human, and the verification endpoints (`POST /customers/{id}/verify-email`, `/verify-phone`) verify the customer-level ones. Only the name was missing, so only the name is added.

Both fields are optional, so existing integrations are unaffected.

## Test plan

- `make build` — bundles cleanly to `openapi.yaml` + `mintlify/openapi.yaml`
- `npx spectral lint openapi.yaml --fail-severity=error` — 0 errors, and no new findings against the added properties
- `oasdiff breaking <main> <head> --fail-on ERR` — "No breaking changes to report", so no `info.version` bump

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/804