### PR TITLE
Add Ethereum and Plasma USDT funding support

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -556,7 +556,7 @@ Use this flow when the user asks for a "realtime quote" or "just in time" funded
 
 **Compatible instant methods:**
 
-- **Crypto:** BTC (Lightning, Spark), USDC (Solana, Base, Polygon, Ethereum), USDT (Tron)
+- **Crypto:** BTC (Lightning, Spark), USDC (Solana, Base, Polygon, Ethereum), USDT (Tron, Ethereum, Plasma)
 - **Fiat:** RTP, SEPA Instant, and other instant payment rails
 
 **Flow:**

--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -53,9 +53,10 @@ The **Available Rails** column lists the payment rails Grid may use for the crea
 |------|----------|-------------------|
 | SPARK_WALLET | BTC | Spark wallet address |
 | LIGHTNING | BTC | Lightning invoice, bolt12 offer, or lightning address |
-| ETHEREUM_WALLET | USDC | Ethereum L1 wallet address (0x...) |
+| ETHEREUM_WALLET | USDC, USDT | Ethereum L1 wallet address (0x...) |
 | SOLANA_WALLET | USDC | Solana wallet address |
 | TRON_WALLET | USDT | TRON wallet address |
+| PLASMA_WALLET | USDT | Plasma wallet address (0x...) |
 | POLYGON_WALLET | USDC | Polygon wallet address (0x...) |
 | BASE_WALLET | USDC | Base wallet address (0x...) |
 
@@ -976,9 +977,10 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
 #### Other Crypto Wallets
 
 - **TRON_WALLET**: USDT, requires `address`
+- **PLASMA_WALLET**: USDT, requires `address` (0x format)
 - **POLYGON_WALLET**: USDC, requires `address` (0x format)
 - **BASE_WALLET**: USDC, requires `address` (0x format)
-- **ETHEREUM_WALLET**: USDC, requires `address` (0x format)
+- **ETHEREUM_WALLET**: USDC or USDT, requires `address` (0x format)
 
 **Note:** Crypto wallets do NOT require beneficiary information.
 

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21604,7 +21604,7 @@ components:
               example: USD
             cryptoNetwork:
               type: string
-              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `SPARK`, `LIGHTNING`, `BITCOIN`.'
+              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `TRON`, `PLASMA`, `SPARK`, `LIGHTNING`, `BITCOIN`.'
               example: SOLANA
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:

--- a/mintlify/snippets/internal-accounts.mdx
+++ b/mintlify/snippets/internal-accounts.mdx
@@ -197,6 +197,20 @@ Each internal account includes `fundingPaymentInstructions` that tell your custo
     ```
   </Accordion>
 
+  <Accordion title="Ethereum Stablecoin Funding">
+    For Ethereum L1 wallet accounts (USDC or USDT), using an Ethereum wallet as the funding source:
+
+    ```json
+    {
+      "accountOrWalletInfo": {
+        "accountType": "ETHEREUM_WALLET",
+        "assetType": "USDT",
+        "address": "0xAbCDEF1234567890aBCdEf1234567890ABcDef12"
+      }
+    }
+    ```
+  </Accordion>
+
   <Accordion title="Tron Stablecoin Funding">
     For Tron wallet accounts, using a Tron wallet as the funding source:
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21604,7 +21604,7 @@ components:
               example: USD
             cryptoNetwork:
               type: string
-              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `SPARK`, `LIGHTNING`, `BITCOIN`.'
+              description: 'The crypto network to use for the funding source. Required when `currency` is a stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit on, so the correct deposit address can be generated. Example values: `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `TRON`, `PLASMA`, `SPARK`, `LIGHTNING`, `BITCOIN`.'
               example: SOLANA
           description: Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.). This will require manual just-in-time funding using `paymentInstructions` in the response. Because quotes expire quickly, this option is only valid for instant payment methods. Do not try to fund a quote with a non-instant payment method (ACH, etc.).
     QuoteSourceOneOf:

--- a/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
+++ b/openapi/components/schemas/quotes/RealtimeFundingQuoteSource.yaml
@@ -29,7 +29,8 @@ allOf:
           The crypto network to use for the funding source. Required when `currency` is a
           stablecoin (e.g. USDC, USDT). Specifies which network the customer will deposit
           on, so the correct deposit address can be generated. Example values:
-          `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `SPARK`, `LIGHTNING`, `BITCOIN`.
+          `SOLANA`, `ETHEREUM`, `BASE`, `POLYGON`, `TRON`, `PLASMA`, `SPARK`,
+          `LIGHTNING`, `BITCOIN`.
         example: SOLANA
     description: >-
       Fund the quote using a real-time funding source (RTP, SEPA Instant, Spark, Stables, etc.).


### PR DESCRIPTION
## Summary
Extends stablecoin funding capabilities to support USDT on Ethereum L1 and Plasma networks, and updates USDC support on Ethereum to explicitly include USDT as an alternative asset type.

## Changes

- **Internal Accounts Documentation**: Added new "Ethereum Stablecoin Funding" accordion section with example JSON for funding Ethereum L1 wallet accounts with USDT
- **Account Types Reference**: 
  - Updated `ETHEREUM_WALLET` to support both USDC and USDT (previously USDC only)
  - Added new `PLASMA_WALLET` account type for USDT funding
  - Updated documentation to reflect these changes across multiple sections
- **OpenAPI Specs**: Updated `cryptoNetwork` field descriptions in `RealtimeFundingQuoteSource` to include `TRON` and `PLASMA` as example values
- **Skill Documentation**: Updated compatible instant methods to reflect USDT support on Tron, Ethereum, and Plasma networks

## Implementation Details

All changes are documentation-only updates to OpenAPI schemas and Mintlify MDX files. The OpenAPI source files in `openapi/components/schemas/` were updated, and `make build` should be run to rebundle the generated `openapi.yaml` files.

https://claude.ai/code/session_01PLo8HsJf9FMrmfNE99NSQ5