### PR TITLE
docs: fix internal accounts typo

### DIFF
--- a/mintlify/snippets/internal-accounts.mdx
+++ b/mintlify/snippets/internal-accounts.mdx
@@ -1,6 +1,6 @@
 Internal accounts are Lightspark managed accounts that hold funds within the Grid platform. They allow you to receive deposits and send payments to external bank accounts or other payment destinations.
 
-They are useful for holding funds on behalf or the platform or customers which will be used for instant, 24/7 quotes and transfers out of the system.
+They are useful for holding funds on behalf of the platform or customers which will be used for instant, 24/7 quotes and transfers out of the system.
 
 Internal accounts are created for both:
 


### PR DESCRIPTION
## Reason

Correct a typo in the shared internal account documentation.

## Overview

Change `on behalf or the platform` to `on behalf of the platform` in the reusable internal-accounts snippet. All pages that import the snippet receive the corrected wording.

## Test Plan

- `make lint`
- `mint openapi-check openapi.yaml`
- `./node_modules/.bin/markdownlint --disable MD012 MD040 -- mintlify/snippets/internal-accounts.mdx`
- `git diff --check`
