### PR TITLE
fix(docs): give the SCA sidebar group a lock icon

### DIFF
--- a/mintlify/style.css
+++ b/mintlify/style.css
@@ -1426,6 +1426,12 @@ ul.sidebar-group > li[data-title="Contact Verification"] > button::before {
   background-image: url('/images/icons/IconEmail2Check.svg') !important;
 }
 
+/* Strong Customer Authentication - lock */
+.sidebar-group > li[data-title="Strong Customer Authentication"] > button::before,
+ul.sidebar-group > li[data-title="Strong Customer Authentication"] > button::before {
+  background-image: url('/images/icons/lock.svg') !important;
+}
+
 /* Cards - credit card */
 .sidebar-group > li[data-title="Cards"] > button::before,
 ul.sidebar-group > li[data-title="Cards"] > button::before {


### PR DESCRIPTION
The API reference sidebar sets tag-group icons through CSS `::before` rules keyed on `li[data-title="..."]` in `mintlify/style.css`. Every OpenAPI tag in the spec had a rule except **Strong Customer Authentication**, which rendered with no icon at all.

Mintlify offers no supported way to set an icon on an auto-generated tag group from the spec itself: `icon` on a tag object fails OpenAPI validation, and `x-mint: { icon }` is silently ignored. Declaring the group explicitly in `docs.json` does render an icon, but an explicit `pages` array turns off endpoint auto-generation for the whole group — so the CSS rule is the right fix here.

Verified against `mint dev`: the group's `::before` now resolves to `lock.svg` at 20x20, and all 23 sidebar groups have an icon (none missing).

Note: `lock.svg` is also used by the *Embedded Wallet Auth* group. Happy to switch SCA to `shield.svg` if we'd rather they read distinctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
