### PR TITLE
Add TRANSACTION_SIZE_LIMIT_EXCEEDED and DAILY_VOLUME_LIMIT_EXCEEDED error codes

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3415,6 +3415,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when the requested amount would exceed the configured daily volume limit for the withdrawal currency.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -3767,6 +3773,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error424'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when `immediatelyExecute` is set and the requested amount would exceed the configured daily volume limit for the trade corridor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -3867,6 +3879,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when executing the quote would exceed the configured daily volume limit for the trade corridor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -11841,6 +11859,7 @@ components:
             | STABLECOIN_PROVIDER_ACCOUNT_REVOKED | The stablecoin provider account link has been revoked |
             | STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED | Multiple active provider account links exist; pass `stablecoinProviderAccountId` to select one |
             | CARDHOLDER_KYC_NOT_APPROVED | The cardholder's KYC status is not `APPROVED`, so a card cannot be issued |
+            | TRANSACTION_SIZE_LIMIT_EXCEEDED | The requested amount exceeds the configured maximum single-transaction amount for this trade corridor or withdrawal currency |
           enum:
             - INVALID_INPUT
             - END_USER_TERMS_VERSION_NOT_FOUND
@@ -11883,6 +11902,7 @@ components:
             - STABLECOIN_PROVIDER_ACCOUNT_REVOKED
             - STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED
             - CARDHOLDER_KYC_NOT_APPROVED
+            - TRANSACTION_SIZE_LIMIT_EXCEEDED
         message:
           type: string
           description: Error message
@@ -13911,8 +13931,10 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+            | DAILY_VOLUME_LIMIT_EXCEEDED | The requested amount would exceed the configured daily volume limit for this trade corridor or withdrawal currency |
           enum:
             - RATE_LIMITED
+            - DAILY_VOLUME_LIMIT_EXCEEDED
         message:
           type: string
           description: Error message

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3415,6 +3415,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when the requested amount would exceed the configured daily volume limit for the withdrawal currency.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -3767,6 +3773,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error424'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when `immediatelyExecute` is set and the requested amount would exceed the configured daily volume limit for the trade corridor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -3867,6 +3879,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '429':
+          description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when executing the quote would exceed the configured daily volume limit for the trade corridor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429'
         '500':
           description: Internal service error
           content:
@@ -11841,6 +11859,7 @@ components:
             | STABLECOIN_PROVIDER_ACCOUNT_REVOKED | The stablecoin provider account link has been revoked |
             | STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED | Multiple active provider account links exist; pass `stablecoinProviderAccountId` to select one |
             | CARDHOLDER_KYC_NOT_APPROVED | The cardholder's KYC status is not `APPROVED`, so a card cannot be issued |
+            | TRANSACTION_SIZE_LIMIT_EXCEEDED | The requested amount exceeds the configured maximum single-transaction amount for this trade corridor or withdrawal currency |
           enum:
             - INVALID_INPUT
             - END_USER_TERMS_VERSION_NOT_FOUND
@@ -11883,6 +11902,7 @@ components:
             - STABLECOIN_PROVIDER_ACCOUNT_REVOKED
             - STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED
             - CARDHOLDER_KYC_NOT_APPROVED
+            - TRANSACTION_SIZE_LIMIT_EXCEEDED
         message:
           type: string
           description: Error message
@@ -13911,8 +13931,10 @@ components:
             | Error Code | Description |
             |------------|-------------|
             | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+            | DAILY_VOLUME_LIMIT_EXCEEDED | The requested amount would exceed the configured daily volume limit for this trade corridor or withdrawal currency |
           enum:
             - RATE_LIMITED
+            - DAILY_VOLUME_LIMIT_EXCEEDED
         message:
           type: string
           description: Error message

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -55,6 +55,7 @@ properties:
       | STABLECOIN_PROVIDER_ACCOUNT_REVOKED | The stablecoin provider account link has been revoked |
       | STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED | Multiple active provider account links exist; pass `stablecoinProviderAccountId` to select one |
       | CARDHOLDER_KYC_NOT_APPROVED | The cardholder's KYC status is not `APPROVED`, so a card cannot be issued |
+      | TRANSACTION_SIZE_LIMIT_EXCEEDED | The requested amount exceeds the configured maximum single-transaction amount for this trade corridor or withdrawal currency |
     enum:
       - INVALID_INPUT
       - END_USER_TERMS_VERSION_NOT_FOUND
@@ -97,6 +98,7 @@ properties:
       - STABLECOIN_PROVIDER_ACCOUNT_REVOKED
       - STABLECOIN_PROVIDER_ACCOUNT_SELECTION_REQUIRED
       - CARDHOLDER_KYC_NOT_APPROVED
+      - TRANSACTION_SIZE_LIMIT_EXCEEDED
   message:
     type: string
     description: Error message

--- a/openapi/components/schemas/errors/Error429.yaml
+++ b/openapi/components/schemas/errors/Error429.yaml
@@ -15,8 +15,10 @@ properties:
       | Error Code | Description |
       |------------|-------------|
       | RATE_LIMITED | Too many requests in a short window; retry after the interval indicated by the `Retry-After` response header |
+      | DAILY_VOLUME_LIMIT_EXCEEDED | The requested amount would exceed the configured daily volume limit for this trade corridor or withdrawal currency |
     enum:
       - RATE_LIMITED
+      - DAILY_VOLUME_LIMIT_EXCEEDED
   message:
     type: string
     description: Error message

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -158,6 +158,15 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error424.yaml
+    '429':
+      description: >-
+        Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when
+        `immediatelyExecute` is set and the requested amount would exceed the
+        configured daily volume limit for the trade corridor.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error429.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/quotes/quotes_{quoteId}_execute.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}_execute.yaml
@@ -107,6 +107,15 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error409.yaml
+    '429':
+      description: >-
+        Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when
+        executing the quote would exceed the configured daily volume limit
+        for the trade corridor.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error429.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -60,6 +60,15 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '429':
+      description: >-
+        Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when
+        the requested amount would exceed the configured daily volume limit
+        for the withdrawal currency.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error429.yaml
     '500':
       description: Internal service error
       content:


### PR DESCRIPTION
## Summary

Adds two new error codes to the shared Grid error contract so platforms can distinguish a single-transaction size limit breach from a daily volume limit breach:

- `TRANSACTION_SIZE_LIMIT_EXCEEDED` — added to the `Error400` enum, returned when a requested amount exceeds a configured maximum single-transaction amount for a trade corridor or withdrawal currency.
- `DAILY_VOLUME_LIMIT_EXCEEDED` — added to the `Error429` enum, returned when a requested amount would exceed a configured daily volume limit for a trade corridor or withdrawal currency.

`POST /quotes`, `POST /quotes/{quoteId}/execute`, and `POST /transfer-out` already advertised the applicable `Error400` response; this PR adds the new `429` response to those three endpoints so the daily-volume-limit error is documented alongside the existing `Error429` (rate-limiting) usage.

Both additions are purely additive (no request/response shape changes, no removed fields), so the dated API version is unchanged.

## Changes

- `openapi/components/schemas/errors/Error400.yaml` — add `TRANSACTION_SIZE_LIMIT_EXCEEDED` enum value and description-table entry.
- `openapi/components/schemas/errors/Error429.yaml` — add `DAILY_VOLUME_LIMIT_EXCEEDED` enum value and description-table entry.
- `openapi/paths/quotes/quotes.yaml` — add `429` response.
- `openapi/paths/quotes/quotes_{quoteId}_execute.yaml` — add `429` response.
- `openapi/paths/transfers/transfer_out.yaml` — add `429` response.
- `openapi.yaml`, `mintlify/openapi.yaml` — regenerated via `make build`.

## Verification

- `make build` — rebundled spec; re-ran a second time to confirm no drift (clean working tree after both runs).
- `make lint` — exits 0; same warning/info counts as `main` (0 errors before and after).
- Ran `oasdiff breaking` against `main`: 0 errors, only expected `response-property-enum-value-added` warnings for the two new codes, confirming the change is non-breaking.
- `bolt-codex-review` — no P0/P1/P2 findings.

This is a documentation/config-only change (OpenAPI spec + generated bundles); no behavioral source code was written, so no new tests were added per the config/generated-output exception.

Requested by @jklein24

Original PR: https://github.com/lightsparkdev/grid-api/pull/819