### PR TITLE
Add compliance context to transactions

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -20637,6 +20637,22 @@ components:
         | `FAILED` | An error occurred during payment |
         | `REFUNDED` | Payment was unable to complete and refunded |
         | `EXPIRED` | Quote has expired |
+    TransactionPendingReason:
+      type: string
+      enum:
+        - COUNTERPARTY_DECLARATION_REQUIRED
+        - WALLET_VERIFICATION_REQUIRED
+        - COUNTERPARTY_INFORMATION_REQUIRED
+        - COMPLIANCE_REVIEW
+      description: |
+        Why a transaction is pending.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `COUNTERPARTY_DECLARATION_REQUIRED` | The customer must declare who controls the sending wallet. |
+        | `WALLET_VERIFICATION_REQUIRED` | The customer must verify ownership of the sending wallet. |
+        | `COUNTERPARTY_INFORMATION_REQUIRED` | Information about the sender is required. |
+        | `COMPLIANCE_REVIEW` | The customer's action is complete and the deposit remains under compliance review. |
     TransactionDirection:
       type: string
       enum:
@@ -20797,6 +20813,9 @@ components:
           example: Transaction:019542f5-b3e7-1d02-0000-000000000004
         status:
           $ref: '#/components/schemas/TransactionStatus'
+        pendingReason:
+          $ref: '#/components/schemas/TransactionPendingReason'
+          description: Present when compliance review or required customer action is delaying settlement.
         type:
           $ref: '#/components/schemas/TransactionType'
         direction:
@@ -21007,7 +21026,8 @@ components:
         - MISSING_MANDATORY_PAYEE_DATA
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+        - COMPLIANCE_REJECTED
+      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. COMPLIANCE_REJECTED means compliance blocked the incoming funds. If the transaction is not in a failed state, this field is omitted.
     IncomingTransaction:
       title: Incoming Transaction
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20637,6 +20637,22 @@ components:
         | `FAILED` | An error occurred during payment |
         | `REFUNDED` | Payment was unable to complete and refunded |
         | `EXPIRED` | Quote has expired |
+    TransactionPendingReason:
+      type: string
+      enum:
+        - COUNTERPARTY_DECLARATION_REQUIRED
+        - WALLET_VERIFICATION_REQUIRED
+        - COUNTERPARTY_INFORMATION_REQUIRED
+        - COMPLIANCE_REVIEW
+      description: |
+        Why a transaction is pending.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `COUNTERPARTY_DECLARATION_REQUIRED` | The customer must declare who controls the sending wallet. |
+        | `WALLET_VERIFICATION_REQUIRED` | The customer must verify ownership of the sending wallet. |
+        | `COUNTERPARTY_INFORMATION_REQUIRED` | Information about the sender is required. |
+        | `COMPLIANCE_REVIEW` | The customer's action is complete and the deposit remains under compliance review. |
     TransactionDirection:
       type: string
       enum:
@@ -20797,6 +20813,9 @@ components:
           example: Transaction:019542f5-b3e7-1d02-0000-000000000004
         status:
           $ref: '#/components/schemas/TransactionStatus'
+        pendingReason:
+          $ref: '#/components/schemas/TransactionPendingReason'
+          description: Present when compliance review or required customer action is delaying settlement.
         type:
           $ref: '#/components/schemas/TransactionType'
         direction:
@@ -21007,7 +21026,8 @@ components:
         - MISSING_MANDATORY_PAYEE_DATA
         - QUOTE_EXPIRED
         - QUOTE_EXECUTION_FAILED
-      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. If the transaction is not in a failed state, this field is omitted.
+        - COMPLIANCE_REJECTED
+      description: Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed. COMPLIANCE_REJECTED means compliance blocked the incoming funds. If the transaction is not in a failed state, this field is omitted.
     IncomingTransaction:
       title: Incoming Transaction
       allOf:

--- a/openapi/components/schemas/transactions/IncomingTransactionFailureReason.yaml
+++ b/openapi/components/schemas/transactions/IncomingTransactionFailureReason.yaml
@@ -8,7 +8,9 @@ enum:
   - MISSING_MANDATORY_PAYEE_DATA
   - QUOTE_EXPIRED
   - QUOTE_EXECUTION_FAILED
+  - COMPLIANCE_REJECTED
 description: >-
   Reason for failure of an incoming transaction. This is used to provide more
-  context on why a transaction failed. If the transaction is not in a failed
-  state, this field is omitted.
+  context on why a transaction failed. COMPLIANCE_REJECTED means compliance
+  blocked the incoming funds. If the transaction is not in a failed state,
+  this field is omitted.

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -14,6 +14,11 @@ properties:
     example: Transaction:019542f5-b3e7-1d02-0000-000000000004
   status:
     $ref: ./TransactionStatus.yaml
+  pendingReason:
+    $ref: ./TransactionPendingReason.yaml
+    description: >-
+      Present when compliance review or required customer action is delaying
+      settlement.
   type:
     $ref: ./TransactionType.yaml
   direction:

--- a/openapi/components/schemas/transactions/TransactionPendingReason.yaml
+++ b/openapi/components/schemas/transactions/TransactionPendingReason.yaml
@@ -1,0 +1,15 @@
+type: string
+enum:
+  - COUNTERPARTY_DECLARATION_REQUIRED
+  - WALLET_VERIFICATION_REQUIRED
+  - COUNTERPARTY_INFORMATION_REQUIRED
+  - COMPLIANCE_REVIEW
+description: |
+  Why a transaction is pending.
+
+  | Reason | Description |
+  |--------|-------------|
+  | `COUNTERPARTY_DECLARATION_REQUIRED` | The customer must declare who controls the sending wallet. |
+  | `WALLET_VERIFICATION_REQUIRED` | The customer must verify ownership of the sending wallet. |
+  | `COUNTERPARTY_INFORMATION_REQUIRED` | Information about the sender is required. |
+  | `COMPLIANCE_REVIEW` | The customer's action is complete and the deposit remains under compliance review. |


### PR DESCRIPTION
## Summary

- Add an optional `pendingReason` field to all transactions.
- Add provider-neutral reasons for required customer action and compliance review.
- Add `COMPLIANCE_REJECTED` to incoming transaction failure reasons.
- Reconcile with #689’s granular outgoing payout failure reasons, retaining its complete enum and descriptions.

## Test plan

- `make build`
- `make lint-openapi` (0 errors)

Original PR: https://github.com/lightsparkdev/grid-api/pull/822
