### PR TITLE
Add payment rail to external account creation

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -20169,6 +20169,10 @@ components:
               example: ext_acc_123456
             ownershipType:
               $ref: '#/components/schemas/OwnershipType'
+            paymentRail:
+              description: Selects the canonical payment rail for account creation. Required account fields and supported currency and rail combinations are validated by the implementation. When omitted, the implementation infers supported rails from the account fields for backward compatibility.
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
             defaultUmaDepositAccount:
               type: boolean
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
@@ -20191,6 +20195,10 @@ components:
           example: ext_acc_123456
         ownershipType:
           $ref: '#/components/schemas/OwnershipType'
+        paymentRail:
+          description: Selects the canonical payment rail for account creation. Required account fields and supported currency and rail combinations are validated by the implementation. When omitted, the implementation infers supported rails from the account fields for backward compatibility.
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountCreateInfoOneOf'
     BeneficialOwnerListResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20169,6 +20169,10 @@ components:
               example: ext_acc_123456
             ownershipType:
               $ref: '#/components/schemas/OwnershipType'
+            paymentRail:
+              description: Selects the canonical payment rail for account creation. Required account fields and supported currency and rail combinations are validated by the implementation. When omitted, the implementation infers supported rails from the account fields for backward compatibility.
+              allOf:
+                - $ref: '#/components/schemas/PaymentRail'
             defaultUmaDepositAccount:
               type: boolean
               description: Whether to set the external account as the default UMA deposit account. When set to true, incoming payments to this customer's UMA address will be automatically deposited into this external account. False if not provided. Note that only one external account can be set as the default UMA deposit account for a customer, so if there is already a default UMA deposit account, this will override the existing default UMA deposit account. If there is no default UMA deposit account, incoming UMA payments will be deposited into the primary internal account for the customer.
@@ -20191,6 +20195,10 @@ components:
           example: ext_acc_123456
         ownershipType:
           $ref: '#/components/schemas/OwnershipType'
+        paymentRail:
+          description: Selects the canonical payment rail for account creation. Required account fields and supported currency and rail combinations are validated by the implementation. When omitted, the implementation infers supported rails from the account fields for backward compatibility.
+          allOf:
+            - $ref: '#/components/schemas/PaymentRail'
         accountInfo:
           $ref: '#/components/schemas/ExternalAccountCreateInfoOneOf'
     BeneficialOwnerListResponse:

--- a/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/ExternalAccountCreateRequest.yaml
@@ -20,6 +20,15 @@ allOf:
         example: ext_acc_123456
       ownershipType:
         $ref: ./OwnershipType.yaml
+      paymentRail:
+        description: >-
+          Selects the canonical payment rail for account creation. Required
+          account fields and supported currency and rail combinations are
+          validated by the implementation. When omitted, the implementation
+          infers supported rails from the account fields for backward
+          compatibility.
+        allOf:
+          - $ref: ../common/PaymentRail.yaml
       defaultUmaDepositAccount:
         type: boolean
         description: >-

--- a/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
+++ b/openapi/components/schemas/external_accounts/PlatformExternalAccountCreateRequest.yaml
@@ -13,5 +13,14 @@ properties:
     example: ext_acc_123456
   ownershipType:
     $ref: ./OwnershipType.yaml
+  paymentRail:
+    description: >-
+      Selects the canonical payment rail for account creation. Required
+      account fields and supported currency and rail combinations are
+      validated by the implementation. When omitted, the implementation
+      infers supported rails from the account fields for backward
+      compatibility.
+    allOf:
+      - $ref: ../common/PaymentRail.yaml
   accountInfo:
     $ref: ./ExternalAccountCreateInfoOneOf.yaml


### PR DESCRIPTION
## Summary

- Add optional `paymentRail` to customer and platform external account create requests.
- Use the existing `PaymentRail` schema and preserve field inference when callers omit the field.
- Regenerate the root and Mintlify OpenAPI specifications.

## Context

This contract supports [AT-6324](https://lightspark.atlassian.net/browse/AT-6324), found during [AT-6321](https://lightspark.atlassian.net/browse/AT-6321).

Webdev regeneration, backend validation and persistence, and Nage changes depend on this schema change.

## Checks

- `make build`
- `make lint`
- Focused assertions for optionality, `PaymentRail` references, omission behavior, and generated-spec parity

Made with [Cursor](https://cursor.com)

[AT-6324]: https://lightspark.atlassian.net/browse/AT-6324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AT-6321]: https://lightspark.atlassian.net/browse/AT-6321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ