### PR TITLE
Drop externalAccountId from the stablecoin burn source

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -24261,7 +24261,7 @@ components:
       description: Stablecoin issuer operation lifecycle status.
     StablecoinOperationSource:
       type: object
-      description: 'Source of a stablecoin operation, as reported on a `StablecoinOperation`. A single merged shape (superset of the mint funding source and burn source request variants) so the field is unambiguously deserializable regardless of operation type: `externalAccountId` is present for external-account funded mints and external-account burns, `accountId` for Grid internal account sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider internal balance sources.'
+      description: 'Source of a stablecoin operation, as reported on a `StablecoinOperation`. A single merged shape (superset of the mint funding source and burn source request variants) so the field is unambiguously deserializable regardless of operation type: `externalAccountId` is present for external-account funded mints, `accountId` for Grid internal account sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider internal balance sources.'
       required:
         - type
       properties:
@@ -24278,7 +24278,7 @@ components:
           example: ACH_DEBIT
         externalAccountId:
           type: string
-          description: Grid `ExternalAccount` funding the operation, present for ACH debit mints and external-account burns.
+          description: Grid `ExternalAccount` funding the operation, present for ACH debit mints.
           example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000101
         accountId:
           type: string
@@ -24483,19 +24483,14 @@ components:
         - type: object
           required:
             - type
-            - externalAccountId
           properties:
             type:
               type: string
               enum:
                 - EXTERNAL_ACCOUNT
-              description: External account burn. References an active Spark external account and returns funding instructions.
+              description: External account burn. The response carries funding instructions naming the provider deposit address to send the stablecoin to.
               example: EXTERNAL_ACCOUNT
-            externalAccountId:
-              type: string
-              description: Grid Spark `ExternalAccount` expected to fund the provider for the burn.
-              example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000203
-          description: External account burn source. The issuer funds the provider from a Spark external account.
+          description: External account burn source. The issuer sends the stablecoin to the provider deposit address returned in the operation's funding instructions; it may be sent from any wallet.
     StablecoinGridInternalBurnSource:
       title: Grid Internal Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24483,19 +24483,14 @@ components:
         - type: object
           required:
             - type
-            - externalAccountId
           properties:
             type:
               type: string
               enum:
                 - EXTERNAL_ACCOUNT
-              description: External account burn. References an active Spark external account and returns funding instructions.
+              description: External account burn. The response carries funding instructions naming the provider deposit address to send the stablecoin to.
               example: EXTERNAL_ACCOUNT
-            externalAccountId:
-              type: string
-              description: Grid Spark `ExternalAccount` expected to fund the provider for the burn.
-              example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000203
-          description: External account burn source. The issuer funds the provider from a Spark external account.
+          description: External account burn source. The issuer sends the stablecoin to the provider deposit address returned in the operation's funding instructions; it may be sent from any wallet.
     StablecoinGridInternalBurnSource:
       title: Grid Internal Account
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24261,7 +24261,7 @@ components:
       description: Stablecoin issuer operation lifecycle status.
     StablecoinOperationSource:
       type: object
-      description: 'Source of a stablecoin operation, as reported on a `StablecoinOperation`. A single merged shape (superset of the mint funding source and burn source request variants) so the field is unambiguously deserializable regardless of operation type: `externalAccountId` is present for external-account funded mints and external-account burns, `accountId` for Grid internal account sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider internal balance sources.'
+      description: 'Source of a stablecoin operation, as reported on a `StablecoinOperation`. A single merged shape (superset of the mint funding source and burn source request variants) so the field is unambiguously deserializable regardless of operation type: `externalAccountId` is present for external-account funded mints, `accountId` for Grid internal account sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider internal balance sources.'
       required:
         - type
       properties:
@@ -24278,7 +24278,7 @@ components:
           example: ACH_DEBIT
         externalAccountId:
           type: string
-          description: Grid `ExternalAccount` funding the operation, present for ACH debit mints and external-account burns.
+          description: Grid `ExternalAccount` funding the operation, present for ACH debit mints.
           example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000101
         accountId:
           type: string

--- a/openapi/components/schemas/stablecoins/StablecoinExternalAccountBurnSource.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinExternalAccountBurnSource.yaml
@@ -4,16 +4,11 @@ allOf:
   - type: object
     required:
       - type
-      - externalAccountId
     properties:
       type:
         type: string
         enum:
           - EXTERNAL_ACCOUNT
-        description: External account burn. References an active Spark external account and returns funding instructions.
+        description: External account burn. The response carries funding instructions naming the provider deposit address to send the stablecoin to.
         example: EXTERNAL_ACCOUNT
-      externalAccountId:
-        type: string
-        description: Grid Spark `ExternalAccount` expected to fund the provider for the burn.
-        example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000203
-    description: External account burn source. The issuer funds the provider from a Spark external account.
+    description: External account burn source. The issuer sends the stablecoin to the provider deposit address returned in the operation's funding instructions; it may be sent from any wallet.

--- a/openapi/components/schemas/stablecoins/StablecoinOperationSource.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinOperationSource.yaml
@@ -4,9 +4,8 @@ description: >-
   `StablecoinOperation`. A single merged shape (superset of the
   mint funding source and burn source request variants) so the field
   is unambiguously deserializable regardless of operation type:
-  `externalAccountId` is present for external-account funded mints and
-  external-account burns, `accountId` for Grid internal account
-  sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider
+  `externalAccountId` is present for external-account funded mints,
+  `accountId` for Grid internal account sources, and `sourceTokenIdentifier`/`cryptoNetwork` for provider
   internal balance sources.
 required:
   - type
@@ -24,7 +23,7 @@ properties:
     example: ACH_DEBIT
   externalAccountId:
     type: string
-    description: Grid `ExternalAccount` funding the operation, present for ACH debit mints and external-account burns.
+    description: Grid `ExternalAccount` funding the operation, present for ACH debit mints.
     example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000101
   accountId:
     type: string


### PR DESCRIPTION
An external-account burn is funded by sending the stablecoin to a **provider deposit address**, returned in the operation's funding instructions. The stablecoin can arrive from any wallet, and nothing correlates the sender to the account named in the request.

Requiring `externalAccountId` therefore advertised a control that does not exist: sparkcore validates the account resolves and is an active Spark external account under the platform, records it, and echoes it back — but never checks that the funds came from it. The webhook matches deliveries on `provider_operation_id`, never on sender address.

Removing it rather than making it optional, because a value we never verify is worse than no value: it reads as provenance in the API response.

Breaking for the burn source shape, which is acceptable now — the stablecoin issuance API is behind `GRID_STABLECOIN_ISSUANCE_API` (default off) and has no external consumers.

Companion sparkcore change removes the `source_external_account` column in lightsparkdev/webdev#29078, where the burn table is still unreleased.