### PR TITLE
docs: include businessType in the business-customer create examples

### DIFF
--- a/.claude/skills/grid-api/SKILL.md
+++ b/.claude/skills/grid-api/SKILL.md
@@ -165,6 +165,8 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
 
 # Create customer (BUSINESS)
 # businessInfo REQUIRES legalName, taxId, and incorporatedOn (ISO date YYYY-MM-DD).
+# Always send businessType too: it's optional to the schema, but receivers can
+# require it, and without it POST /quotes fails with MISSING_MANDATORY_USER_INFO.
 curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -X POST -H "Content-Type: application/json" \
   -d '{
@@ -173,7 +175,8 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     "businessInfo": {
       "legalName": "Acme Corporation, Inc.",
       "taxId": "47-1234567",
-      "incorporatedOn": "2018-03-14"
+      "incorporatedOn": "2018-03-14",
+      "businessType": "INFORMATION"
     }
   }' \
   "$GRID_BASE_URL/customers" | jq .

--- a/mintlify/global-p2p/onboarding/configuring-customers.mdx
+++ b/mintlify/global-p2p/onboarding/configuring-customers.mdx
@@ -130,7 +130,8 @@ curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
       "legalName": "Acme Corporation",
       "registrationNumber": "789012345",
       "taxId": "123-45-6789",
-      "incorporatedOn": "2018-03-14"
+      "incorporatedOn": "2018-03-14",
+      "businessType": "INFORMATION"
     },
     "address": {
       "line1": "456 Oak Avenue",

--- a/mintlify/ramps/onboarding/configuring-customers.mdx
+++ b/mintlify/ramps/onboarding/configuring-customers.mdx
@@ -74,7 +74,8 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers' \
     "businessInfo": {
       "legalName": "Acme Corporation",
       "taxId": "12-3456789",
-      "incorporatedOn": "2018-03-14"
+      "incorporatedOn": "2018-03-14",
+      "businessType": "INFORMATION"
     },
     "address": {...}
   }'

--- a/mintlify/snippets/creating-customers/customers.mdx
+++ b/mintlify/snippets/creating-customers/customers.mdx
@@ -118,7 +118,8 @@ curl -sS -X POST "https://api.lightspark.com/grid/2025-10-13/customers" \
       "legalName": "Acme Corporation",
       "registrationNumber": "789012345",
       "taxId": "123-45-6789",
-      "incorporatedOn": "2018-03-14"
+      "incorporatedOn": "2018-03-14",
+      "businessType": "INFORMATION"
     },
     "address": {
       "line1": "456 Oak Avenue",

--- a/mintlify/snippets/kyc/kyc-regulated.mdx
+++ b/mintlify/snippets/kyc/kyc-regulated.mdx
@@ -68,7 +68,8 @@ The examples below show a more comprehensive set of data. Not all fields are str
         "legalName": "Acme Corporation",
         "registrationNumber": "789012345",
         "taxId": "123-45-6789",
-        "incorporatedOn": "2018-03-14"
+        "incorporatedOn": "2018-03-14",
+        "businessType": "INFORMATION"
       },
       "address": {
         "line1": "456 Oak Avenue",

--- a/mintlify/snippets/kyc/kyc-unregulated.mdx
+++ b/mintlify/snippets/kyc/kyc-unregulated.mdx
@@ -241,7 +241,8 @@ The shape of the flow depends on the customer type:
         "legalName": "Acme Corporation",
         "registrationNumber": "789012345",
         "taxId": "123-45-6789",
-        "incorporatedOn": "2018-03-14"
+        "incorporatedOn": "2018-03-14",
+        "businessType": "INFORMATION"
       },
       "address": {
         "line1": "456 Oak Avenue",


### PR DESCRIPTION
## What

Adds `businessType` to the six `POST /customers` business-customer examples (`kyc-regulated`, `kyc-unregulated`, `creating-customers/customers`, the `global-p2p` and `ramps` configuring-customers pages, and the `grid-api` skill snippet).

## Why

`businessType` is optional in the schema and appeared in none of our examples. But a receiver advertises the sender fields it requires via `requiredPayerDataFields` on the lookup response, and GBP receivers require this one.

That makes for a confusing failure: a business customer created by copying the docs passes KYB, shows `kybStatus: APPROVED`, and then fails **every** GBP quote with `MISSING_MANDATORY_USER_INFO` before the payment is attempted. It reads as a corridor or provider problem rather than a field that was never set at creation.

Setting it in the examples means the copy-paste path produces a customer that can actually pay. Existing customers can be fixed with `PATCH /customers/{id}`, or unblocked for a single payment by passing `senderCustomerInfo` on the quote.

## Test Plan

Verified every edited `businessInfo` block still parses as JSON, and that `INFORMATION` is a member of the `BusinessType` enum in `openapi/components/schemas/customers/BusinessType.yaml`. No spec changes, so no rebundle needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)