### PR TITLE
Unify individual customer identification on idType/identifier/countryOfIssuance

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11769,7 +11769,7 @@ components:
         field:
           type: string
           description: Dot-notation path to the offending field.
-          example: taxIdentifier
+          example: identifier
         constraint:
           $ref: '#/components/schemas/FieldConstraint'
         message:
@@ -12430,15 +12430,16 @@ components:
               example: US
             address:
               $ref: '#/components/schemas/Address'
-            taxIdType:
+            idType:
               $ref: '#/components/schemas/IdentificationType'
-            taxIdentifier:
+            identifier:
               type: string
-              description: Tax-identification number. For US persons this is the SSN (format `###-##-####`) or ITIN. For non-US persons this is the tax number issued by `taxIdCountryOfIssuance`.
+              writeOnly: true
+              description: The individual's identification number, required to onboard them as a US account holder. Only SSN (format `###-##-####`) and ITIN are currently accepted; other identification types are rejected. Write-only — never returned in customer responses.
               example: 123-45-6789
-            taxIdCountryOfIssuance:
+            countryOfIssuance:
               type: string
-              description: Country that issued the tax identifier (ISO 3166-1 alpha-2). Required when `taxIdType` is `NON_US_TAX_ID`.
+              description: Country that issued the identification (ISO 3166-1 alpha-2). Required when `idType` is `NON_US_TAX_ID`.
               example: US
         - $ref: '#/components/schemas/CustomerEdd'
     IndividualCustomer:
@@ -12982,15 +12983,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
-        - type: object
-          properties:
-            idType:
-              $ref: '#/components/schemas/IdentificationType'
-            identifier:
-              type: string
-              writeOnly: true
-              description: The individual's tax identification number. Required to onboard the individual as a US account holder. Only SSN and ITIN are currently accepted for an individual account holder; other identification types are rejected. Write-only — never returned in customer responses.
-              example: 123-45-6789
     BusinessInfo:
       type: object
       description: Additional information required for business entities

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12439,7 +12439,7 @@ components:
               example: 123-45-6789
             countryOfIssuance:
               type: string
-              description: Country that issued the identification (ISO 3166-1 alpha-2). Required when `idType` is `NON_US_TAX_ID`.
+              description: 'Country that issued the identification (ISO 3166-1 alpha-2). Optional for an individual account holder: SSN and ITIN are US-issued, so this defaults to `US` and is rejected if set to anything else.'
               example: US
         - $ref: '#/components/schemas/CustomerEdd'
     IndividualCustomer:

--- a/mintlify/snippets/sandbox-verification.mdx
+++ b/mintlify/snippets/sandbox-verification.mdx
@@ -13,7 +13,7 @@ The **last 3 characters** of the `fullName` on `POST /customers` (with `customer
 
 Because terminal suffixes resolve at creation, only `001` and `003` customers can be submitted for verification. Use any non-suffixed name to mint ready-to-transact approved customers, and a `001` name to exercise the full submission flow.
 
-Submitting for verification has the same data requirements as production: full name, birth date, nationality, `taxIdType` + `taxIdentifier`, address, and an identity document uploaded via `POST /documents`. Anything missing comes back as `verificationStatus: RESOLVE_ERRORS` with one entry per problem in `errors`:
+Submitting for verification has the same data requirements as production: full name, birth date, nationality, `idType` + `identifier`, address, and an identity document uploaded via `POST /documents`. Anything missing comes back as `verificationStatus: RESOLVE_ERRORS` with one entry per problem in `errors`:
 
 ```json
 {
@@ -22,8 +22,8 @@ Submitting for verification has the same data requirements as production: full n
     {
       "resourceId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
       "type": "MISSING_FIELD",
-      "field": "taxIdentifier",
-      "reason": "Tax identifier is required"
+      "field": "identifier",
+      "reason": "Identifier is required"
     },
     {
       "resourceId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
@@ -74,8 +74,8 @@ Fix-and-resubmit example — the standard integration loop:
     -H "Content-Type: application/json" \
     -d '{
       "customerType": "INDIVIDUAL",
-      "taxIdType": "SSN",
-      "taxIdentifier": "111-22-3333",
+      "idType": "SSN",
+      "identifier": "111-22-3333",
       "address": { "line1": "123 Main St", "city": "Seattle", "state": "WA", "postalCode": "98101", "country": "US" }
     }'
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11769,7 +11769,7 @@ components:
         field:
           type: string
           description: Dot-notation path to the offending field.
-          example: taxIdentifier
+          example: identifier
         constraint:
           $ref: '#/components/schemas/FieldConstraint'
         message:
@@ -12430,15 +12430,16 @@ components:
               example: US
             address:
               $ref: '#/components/schemas/Address'
-            taxIdType:
+            idType:
               $ref: '#/components/schemas/IdentificationType'
-            taxIdentifier:
+            identifier:
               type: string
-              description: Tax-identification number. For US persons this is the SSN (format `###-##-####`) or ITIN. For non-US persons this is the tax number issued by `taxIdCountryOfIssuance`.
+              writeOnly: true
+              description: The individual's identification number, required to onboard them as a US account holder. Only SSN (format `###-##-####`) and ITIN are currently accepted; other identification types are rejected. Write-only — never returned in customer responses.
               example: 123-45-6789
-            taxIdCountryOfIssuance:
+            countryOfIssuance:
               type: string
-              description: Country that issued the tax identifier (ISO 3166-1 alpha-2). Required when `taxIdType` is `NON_US_TAX_ID`.
+              description: Country that issued the identification (ISO 3166-1 alpha-2). Required when `idType` is `NON_US_TAX_ID`.
               example: US
         - $ref: '#/components/schemas/CustomerEdd'
     IndividualCustomer:
@@ -12982,15 +12983,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/CustomerCreateRequest'
         - $ref: '#/components/schemas/IndividualCustomerFields'
-        - type: object
-          properties:
-            idType:
-              $ref: '#/components/schemas/IdentificationType'
-            identifier:
-              type: string
-              writeOnly: true
-              description: The individual's tax identification number. Required to onboard the individual as a US account holder. Only SSN and ITIN are currently accepted for an individual account holder; other identification types are rejected. Write-only — never returned in customer responses.
-              example: 123-45-6789
     BusinessInfo:
       type: object
       description: Additional information required for business entities

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12439,7 +12439,7 @@ components:
               example: 123-45-6789
             countryOfIssuance:
               type: string
-              description: Country that issued the identification (ISO 3166-1 alpha-2). Required when `idType` is `NON_US_TAX_ID`.
+              description: 'Country that issued the identification (ISO 3166-1 alpha-2). Optional for an individual account holder: SSN and ITIN are US-issued, so this defaults to `US` and is rejected if set to anything else.'
               example: US
         - $ref: '#/components/schemas/CustomerEdd'
     IndividualCustomer:

--- a/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml
@@ -2,17 +2,3 @@ title: Individual Customer Create Request
 allOf:
   - $ref: ./CustomerCreateRequest.yaml
   - $ref: ./IndividualCustomerFields.yaml
-  - type: object
-    properties:
-      idType:
-        $ref: ./IdentificationType.yaml
-      identifier:
-        type: string
-        writeOnly: true
-        description: >-
-          The individual's tax identification number. Required to onboard the
-          individual as a US account holder. Only SSN and ITIN are currently
-          accepted for an individual account holder; other identification
-          types are rejected. Write-only — never returned in customer
-          responses.
-        example: 123-45-6789

--- a/openapi/components/schemas/customers/IndividualCustomerFields.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerFields.yaml
@@ -38,7 +38,8 @@ allOf:
       countryOfIssuance:
         type: string
         description: >-
-          Country that issued the identification (ISO 3166-1 alpha-2). Required
-          when `idType` is `NON_US_TAX_ID`.
+          Country that issued the identification (ISO 3166-1 alpha-2). Optional
+          for an individual account holder: SSN and ITIN are US-issued, so this
+          defaults to `US` and is rejected if set to anything else.
         example: US
   - $ref: ./CustomerEdd.yaml

--- a/openapi/components/schemas/customers/IndividualCustomerFields.yaml
+++ b/openapi/components/schemas/customers/IndividualCustomerFields.yaml
@@ -24,19 +24,21 @@ allOf:
         example: US
       address:
         $ref: ../common/Address.yaml
-      taxIdType:
+      idType:
         $ref: ./IdentificationType.yaml
-      taxIdentifier:
+      identifier:
         type: string
+        writeOnly: true
         description: >-
-          Tax-identification number. For US persons this is the SSN (format
-          `###-##-####`) or ITIN. For non-US persons this is the tax number
-          issued by `taxIdCountryOfIssuance`.
+          The individual's identification number, required to onboard them as
+          a US account holder. Only SSN (format `###-##-####`) and ITIN are
+          currently accepted; other identification types are rejected.
+          Write-only — never returned in customer responses.
         example: 123-45-6789
-      taxIdCountryOfIssuance:
+      countryOfIssuance:
         type: string
         description: >-
-          Country that issued the tax identifier (ISO 3166-1 alpha-2). Required
-          when `taxIdType` is `NON_US_TAX_ID`.
+          Country that issued the identification (ISO 3166-1 alpha-2). Required
+          when `idType` is `NON_US_TAX_ID`.
         example: US
   - $ref: ./CustomerEdd.yaml

--- a/openapi/components/schemas/errors/FieldError.yaml
+++ b/openapi/components/schemas/errors/FieldError.yaml
@@ -10,7 +10,7 @@ properties:
   field:
     type: string
     description: Dot-notation path to the offending field.
-    example: taxIdentifier
+    example: identifier
   constraint:
     $ref: ./FieldConstraint.yaml
   message:


### PR DESCRIPTION
## Summary

Individual customers accepted two interchangeable identification vocabularies: `taxIdType` / `taxIdentifier` / `taxIdCountryOfIssuance`, and `idType` / `identifier`. Beneficial owners only ever had `idType` / `identifier` / `countryOfIssuance`. This drops the `taxId*` set so both resources speak one vocabulary.

| Removed | Replacement |
|---|---|
| `taxIdType` | `idType` |
| `taxIdentifier` | `identifier` |
| `taxIdCountryOfIssuance` | `countryOfIssuance` |

`identifier` now lives on the shared `IndividualCustomerFields` as `writeOnly`, which lets `IndividualCustomerCreateRequest` drop its duplicate declaration. `taxIdentifier` was not write-only, so the schema advertised a response field that is never populated; the unified field fixes that.

Other `taxId`-prefixed fields are untouched — `BusinessInfo.taxId` (EIN), `BrlAccountInfoBase.taxId` and `BusinessBeneficiary.taxId` (CPF/CNPJ) are a different concept with no `idType` counterpart.

No `info.version` bump: these fields have no integrator on them yet, and a bump would mean cutting a new dated `servers.url` path for a pre-adoption cleanup.

## Changes

- `openapi/components/schemas/customers/IndividualCustomerFields.yaml` — rename the three properties, mark `identifier` write-only
- `openapi/components/schemas/customers/IndividualCustomerCreateRequest.yaml` — drop the now-duplicate `idType` / `identifier` block
- `openapi/components/schemas/errors/FieldError.yaml` — example field name
- `mintlify/snippets/sandbox-verification.mdx` — requirement prose, the `RESOLVE_ERRORS` sample, and the PATCH example
- `openapi.yaml`, `mintlify/openapi.yaml` — `make build` output

## Test plan

- `make build` — exit 0, both bundles regenerated
- `make lint` — exit 0, 0 errors; warning/info counts unchanged from `main` (658 problems, all pre-existing)
- `grep -rn "taxIdType\|taxIdentifier\|taxIdCountryOfIssuance" openapi/ mintlify/` — no matches

The consuming server change lands separately in webdev, which regenerates its Python models from this bundle. Merge this first.

Requested by @akanter

Original PR: https://github.com/lightsparkdev/grid-api/pull/832