### PR TITLE
feat: add bankAddress to USD funding payment instructions

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14632,6 +14632,12 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            bankAddress:
+              type: string
+              description: The postal address of the financial institution holding the account, on a single line. Optional on every rail, and recommended for wires, where some originating banks require the beneficiary institution's address before they will send.
+              example: 885 Teaneck Road, Teaneck, NJ 07666
+              minLength: 1
+              maxLength: 255
     PaymentBrlAccountInfo:
       title: BRL Account
       allOf:

--- a/mintlify/snippets/internal-accounts.mdx
+++ b/mintlify/snippets/internal-accounts.mdx
@@ -84,7 +84,8 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/internal-accou
             "accountNumber": "9876543210",
             "routingNumber": "021000021",
             "accountHolderName": "Lightspark Payments FBO John Doe",
-            "bankName": "JP Morgan Chase"
+            "bankName": "JP Morgan Chase",
+            "bankAddress": "270 Park Avenue, New York, NY 10017"
           }
         },
         {
@@ -145,7 +146,8 @@ Each internal account includes `fundingPaymentInstructions` that tell your custo
         "accountNumber": "9876543210",
         "routingNumber": "021000021",
         "accountHolderName": "Lightspark Payments FBO John Doe",
-        "bankName": "JP Morgan Chase"
+        "bankName": "JP Morgan Chase",
+        "bankAddress": "270 Park Avenue, New York, NY 10017"
       }
     }
     ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14632,6 +14632,12 @@ components:
               type: string
               description: Unique reference code that must be included with the payment to properly credit it
               example: UMA-Q12345-REF
+            bankAddress:
+              type: string
+              description: The postal address of the financial institution holding the account, on a single line. Optional on every rail, and recommended for wires, where some originating banks require the beneficiary institution's address before they will send.
+              example: 885 Teaneck Road, Teaneck, NJ 07666
+              minLength: 1
+              maxLength: 255
     PaymentBrlAccountInfo:
       title: BRL Account
       allOf:

--- a/openapi/components/schemas/common/PaymentUsdAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentUsdAccountInfo.yaml
@@ -12,3 +12,13 @@ allOf:
           Unique reference code that must be included with the payment to properly
           credit it
         example: UMA-Q12345-REF
+      bankAddress:
+        type: string
+        description: >-
+          The postal address of the financial institution holding the account, on
+          a single line. Optional on every rail, and recommended for wires, where
+          some originating banks require the beneficiary institution's address
+          before they will send.
+        example: 885 Teaneck Road, Teaneck, NJ 07666
+        minLength: 1
+        maxLength: 255


### PR DESCRIPTION
## What this does

USD funding payment instructions tell someone how to send money into a Grid internal account. They carry an account number, a routing number, and the bank's name.

They do not carry the bank's address. Many originating banks will not send a wire until they have the beneficiary institution's postal address, so a platform has to look it up somewhere else and paste it in by hand.

This PR adds an optional `bankAddress` field to `PaymentUsdAccountInfo`.

## How it works

`bankAddress` is a single-line string, up to 255 characters. It is optional on every rail. It matters most on wires, where the originating bank asks for it.

The field is additive. Nothing that reads USD funding instructions today has to change.

## Where the field sits

It went on `PaymentUsdAccountInfo` rather than on the shared `UsdAccountInfoBase`.

The base is also composed into USD external accounts. Those have no place to store a bank address, so adding it there would have advertised an input that the API accepts and then silently drops.

## What else changed

The bundled `openapi.yaml` and `mintlify/openapi.yaml` were rebuilt with `make build`, so the API reference picks the field up. `make lint` passes.

The two USD funding examples in the internal accounts docs snippet now show `bankAddress` alongside `bankName`.

## Related

The backend that fills this field in is lightsparkdev/webdev#32807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
