### PR TITLE
docs(quotes): document that quote create and execute require TRANSACT

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3934,6 +3934,10 @@ paths:
 
         **Important:** If you are transferring funds in the same currency (no exchange required),
         use the `/transfer-in` or `/transfer-out` endpoints instead.
+
+        Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+        sufficient. A quote is the instrument a later execute draws on, and
+        `immediatelyExecute` moves funds within this same request.
       operationId: createQuote
       tags:
         - Cross-Currency Transfers
@@ -4052,7 +4056,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error401'
         '403':
-          description: Customer has not accepted the End User Terms
+          description: Forbidden. The token lacks the `TRANSACT` permission, or the customer has not accepted the End User Terms.
           content:
             application/json:
               schema:
@@ -4103,6 +4107,12 @@ paths:
         the quote's `paymentInstructions[].accountOrWalletInfo` entry with the
         session private key of a verified authentication credential on the source
         Embedded Wallet.
+
+        Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+        sufficient to release a transfer. On an `EMBEDDED_WALLET` source this is in
+        addition to the `Grid-Wallet-Signature` header: the signature proves the
+        wallet holder authorized the payment, while `TRANSACT` is what authorizes
+        your integration to release it.
 
         Once executed, the quote cannot be cancelled and the transfer will be processed.
       operationId: executeQuote
@@ -4163,6 +4173,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden. The token lacks the `TRANSACT` permission.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
         '404':
           description: Quote not found
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3934,6 +3934,10 @@ paths:
 
         **Important:** If you are transferring funds in the same currency (no exchange required),
         use the `/transfer-in` or `/transfer-out` endpoints instead.
+
+        Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+        sufficient. A quote is the instrument a later execute draws on, and
+        `immediatelyExecute` moves funds within this same request.
       operationId: createQuote
       tags:
         - Cross-Currency Transfers
@@ -4052,7 +4056,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error401'
         '403':
-          description: Customer has not accepted the End User Terms
+          description: Forbidden. The token lacks the `TRANSACT` permission, or the customer has not accepted the End User Terms.
           content:
             application/json:
               schema:
@@ -4103,6 +4107,12 @@ paths:
         the quote's `paymentInstructions[].accountOrWalletInfo` entry with the
         session private key of a verified authentication credential on the source
         Embedded Wallet.
+
+        Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+        sufficient to release a transfer. On an `EMBEDDED_WALLET` source this is in
+        addition to the `Grid-Wallet-Signature` header: the signature proves the
+        wallet holder authorized the payment, while `TRANSACT` is what authorizes
+        your integration to release it.
 
         Once executed, the quote cannot be cancelled and the transfer will be processed.
       operationId: executeQuote
@@ -4163,6 +4173,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden. The token lacks the `TRANSACT` permission.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
         '404':
           description: Quote not found
           content:

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -17,6 +17,10 @@ post:
 
     **Important:** If you are transferring funds in the same currency (no exchange required),
     use the `/transfer-in` or `/transfer-out` endpoints instead.
+
+    Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+    sufficient. A quote is the instrument a later execute draws on, and
+    `immediatelyExecute` moves funds within this same request.
   operationId: createQuote
   tags:
     - Cross-Currency Transfers
@@ -141,7 +145,9 @@ post:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
     '403':
-      description: Customer has not accepted the End User Terms
+      description: >-
+        Forbidden. The token lacks the `TRANSACT` permission, or the customer has
+        not accepted the End User Terms.
       content:
         application/json:
           schema:

--- a/openapi/paths/quotes/quotes_{quoteId}_execute.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}_execute.yaml
@@ -14,6 +14,12 @@ post:
     session private key of a verified authentication credential on the source
     Embedded Wallet.
 
+    Requires a token with the `TRANSACT` permission; `VIEW` alone is not
+    sufficient to release a transfer. On an `EMBEDDED_WALLET` source this is in
+    addition to the `Grid-Wallet-Signature` header: the signature proves the
+    wallet holder authorized the payment, while `TRANSACT` is what authorizes
+    your integration to release it.
+
     Once executed, the quote cannot be cancelled and the transfer will be processed.
   operationId: executeQuote
   tags:
@@ -95,6 +101,12 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '403':
+      description: Forbidden. The token lacks the `TRANSACT` permission.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error403.yaml
     '404':
       description: Quote not found
       content:


### PR DESCRIPTION
## Summary

Neither `POST /quotes` nor `POST /quotes/{quoteId}/execute` stated which token permission it requires, and neither documented a `403` for a permission refusal on execute.

Execute is the one worth spelling out. Its description covers `Grid-Wallet-Signature` in detail for `EMBEDDED_WALLET` sources, which reads as though the signature is the whole authorization story. It isn't: the signature proves the **wallet holder** approved the payment, while `TRANSACT` is what authorizes **your integration** to release it. An integrator building a read-only service could reasonably conclude a `VIEW` token plus a signature was a supported way to execute.

## Changes

- `openapi/paths/quotes/quotes_{quoteId}_execute.yaml` — state the `TRANSACT` requirement and how it relates to `Grid-Wallet-Signature`; add the `403`
- `openapi/paths/quotes/quotes.yaml` — state the `TRANSACT` requirement (a quote is the instrument execute draws on, and `immediatelyExecute` moves funds in the same request); extend the existing `403` description, which previously named only the End User Terms case
- Regenerated bundles via `make build`: `openapi.yaml`, `mintlify/openapi.yaml`

## Verification

- `make build` — bundles regenerate cleanly; the bundle diff is exactly these four additions, no reformatting of unrelated paths
- `make lint` — *"Woohoo! Your API description is valid."*, **0 errors** (pre-existing warnings/infos on unrelated beneficiary schemas only)

Original PR: https://github.com/lightsparkdev/grid-api/pull/842