### PR TITLE
Deprecate reconciliationInstructions.transactionHash in favor of onChainTransaction

### DIFF
--- a/mintlify/changelog.mdx
+++ b/mintlify/changelog.mdx
@@ -104,10 +104,11 @@ settled transfer inline: `onChainTransaction` on the transaction's source or des
 reports the transfer's `transactionHash` and `network` once the crypto transfer settles.
 
 <Warning>
-  Deprecation. `reconciliationInstructions.transactionHash` is deprecated in favor of
-  `onChainTransaction` and will be removed in a future API version. It remains populated
-  during the deprecation window, including for the inter-VASP leg where no
-  `onChainTransaction` applies.
+  Deprecation. `reconciliationInstructions.transactionHash` is deprecated for wallet
+  transfers—read `onChainTransaction` instead, which also tells you the network. The field
+  keeps reporting the inter-VASP settlement leg of a UMA payment, which has no
+  `onChainTransaction` equivalent, and will not be removed before that leg has a
+  replacement.
 </Warning>
 
 ## Know why a payment failed

--- a/mintlify/changelog.mdx
+++ b/mintlify/changelog.mdx
@@ -97,6 +97,19 @@ Register a stablecoin with `/stablecoins`, then mint and burn directly against i
 
 See [Currencies and rails](/platform-overview/core-concepts/currencies-and-rails).
 
+## Track crypto settlement to and from external wallets
+
+A transaction that settles on-chain to or from an external crypto wallet now carries the
+settled transfer inline: `onChainTransaction` on the transaction's source or destination
+reports the transfer's `transactionHash` and `network` once the crypto transfer settles.
+
+<Warning>
+  Deprecation. `reconciliationInstructions.transactionHash` is deprecated in favor of
+  `onChainTransaction` and will be removed in a future API version. It remains populated
+  during the deprecation window, including for the inter-VASP leg where no
+  `onChainTransaction` applies.
+</Warning>
+
 ## Know why a payment failed
 
 Failure reasons now name outcomes you act on rather than internal processing steps.

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21549,7 +21549,12 @@ components:
         transactionHash:
           deprecated: true
           type: string
-          description: 'Deprecated: use the `onChainTransaction` on the relevant source or destination instead. This field remains populated during the deprecation window, including for the inter-VASP leg where no `onChainTransaction` applies. It carries the transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available — and, until removal, the on-chain hash of a crypto transfer to or from an external customer wallet, which also surfaces on `onChainTransaction`.'
+          description: |-
+            Transaction hash of the settlement transfer, when available. This field reports two different transfers, and only one of them has a replacement today:
+
+            For a crypto transfer to or from a customer's own external wallet, use the `onChainTransaction` on the relevant source or destination instead — it names the network alongside the hash. That is the transfer this field is deprecated for.
+
+            For the inter-VASP settlement leg of a UMA payment (e.g. USDC on Solana to the receiving partner), this field remains the only place the hash is reported: a UMA address is not a wallet you hold, so its source and destination carry no `onChainTransaction`. The field will not be removed before that leg has a replacement.
           example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingTransactionFailureReason:
       type: string

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -21547,8 +21547,9 @@ components:
           description: Unique reference code to include with the payment to match it with the correct incoming transaction, when available.
           example: UMA-Q12345-REF
         transactionHash:
+          deprecated: true
           type: string
-          description: Transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available. This is not a transfer to a customer's own wallet; for that, see the `onChainTransaction` on the transaction's source or destination.
+          description: 'Deprecated: use the `onChainTransaction` on the relevant source or destination instead. This field remains populated during the deprecation window, including for the inter-VASP leg where no `onChainTransaction` applies. It carries the transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available — and, until removal, the on-chain hash of a crypto transfer to or from an external customer wallet, which also surfaces on `onChainTransaction`.'
           example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingTransactionFailureReason:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21549,7 +21549,12 @@ components:
         transactionHash:
           deprecated: true
           type: string
-          description: 'Deprecated: use the `onChainTransaction` on the relevant source or destination instead. This field remains populated during the deprecation window, including for the inter-VASP leg where no `onChainTransaction` applies. It carries the transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available — and, until removal, the on-chain hash of a crypto transfer to or from an external customer wallet, which also surfaces on `onChainTransaction`.'
+          description: |-
+            Transaction hash of the settlement transfer, when available. This field reports two different transfers, and only one of them has a replacement today:
+
+            For a crypto transfer to or from a customer's own external wallet, use the `onChainTransaction` on the relevant source or destination instead — it names the network alongside the hash. That is the transfer this field is deprecated for.
+
+            For the inter-VASP settlement leg of a UMA payment (e.g. USDC on Solana to the receiving partner), this field remains the only place the hash is reported: a UMA address is not a wallet you hold, so its source and destination carry no `onChainTransaction`. The field will not be removed before that leg has a replacement.
           example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingTransactionFailureReason:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21547,8 +21547,9 @@ components:
           description: Unique reference code to include with the payment to match it with the correct incoming transaction, when available.
           example: UMA-Q12345-REF
         transactionHash:
+          deprecated: true
           type: string
-          description: Transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available. This is not a transfer to a customer's own wallet; for that, see the `onChainTransaction` on the transaction's source or destination.
+          description: 'Deprecated: use the `onChainTransaction` on the relevant source or destination instead. This field remains populated during the deprecation window, including for the inter-VASP leg where no `onChainTransaction` applies. It carries the transaction hash of the internal settlement transfer used to deliver a UMA payment — the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when available — and, until removal, the on-chain hash of a crypto transfer to or from an external customer wallet, which also surfaces on `onChainTransaction`.'
           example: '0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566'
     IncomingTransactionFailureReason:
       type: string

--- a/openapi/components/schemas/common/ReconciliationInstructions.yaml
+++ b/openapi/components/schemas/common/ReconciliationInstructions.yaml
@@ -15,11 +15,18 @@ properties:
     deprecated: true
     type: string
     description: >-
-      Deprecated: use the `onChainTransaction` on the relevant source or destination
-      instead. This field remains populated during the deprecation window, including
-      for the inter-VASP leg where no `onChainTransaction` applies. It carries the
-      transaction hash of the internal settlement transfer used to deliver a UMA payment —
-      the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when
-      available — and, until removal, the on-chain hash of a crypto transfer to or from
-      an external customer wallet, which also surfaces on `onChainTransaction`.
+      Transaction hash of the settlement transfer, when available. This field reports two
+      different transfers, and only one of them has a replacement today:
+
+
+      For a crypto transfer to or from a customer's own external wallet, use the
+      `onChainTransaction` on the relevant source or destination instead — it names the
+      network alongside the hash. That is the transfer this field is deprecated for.
+
+
+      For the inter-VASP settlement leg of a UMA payment (e.g. USDC on Solana to the
+      receiving partner), this field remains the only place the hash is reported: a UMA
+      address is not a wallet you hold, so its source and destination carry no
+      `onChainTransaction`. The field will not be removed before that leg has a
+      replacement.
     example: "0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566"

--- a/openapi/components/schemas/common/ReconciliationInstructions.yaml
+++ b/openapi/components/schemas/common/ReconciliationInstructions.yaml
@@ -12,10 +12,14 @@ properties:
       correct incoming transaction, when available.
     example: UMA-Q12345-REF
   transactionHash:
+    deprecated: true
     type: string
     description: >-
-      Transaction hash of the internal settlement transfer used to deliver a UMA payment —
+      Deprecated: use the `onChainTransaction` on the relevant source or destination
+      instead. This field remains populated during the deprecation window, including
+      for the inter-VASP leg where no `onChainTransaction` applies. It carries the
+      transaction hash of the internal settlement transfer used to deliver a UMA payment —
       the inter-VASP settlement leg (e.g. USDC on Solana to the receiving partner), when
-      available. This is not a transfer to a customer's own wallet; for that, see the
-      `onChainTransaction` on the transaction's source or destination.
+      available — and, until removal, the on-chain hash of a crypto transfer to or from
+      an external customer wallet, which also surfaces on `onChainTransaction`.
     example: "0x9f2c6b6f4b6c8f2a8d9e0b1c2d3e4f5061728394a5b6c7d8e9f00112233445566"


### PR DESCRIPTION
## Summary

- Marks `ReconciliationInstructions.transactionHash` as `deprecated: true` in the spec, pointing integrators at the per-leg `onChainTransaction` on the transaction's source or destination.
- The field stays populated during the deprecation window — including for the inter-VASP leg, where no `onChainTransaction` applies — so nothing stops working.
- Adds an August 2026 changelog entry announcing the inline field and the deprecation.

Pairs with the backend change that starts populating `onChainTransaction` in transaction responses.

## Test plan

- `make build` rebundles cleanly; `deprecated: true` present in `openapi.yaml` and `mintlify/openapi.yaml`
- `make lint` exits 0

Original PR: https://github.com/lightsparkdev/grid-api/pull/844