### PR TITLE
Make the VASP url optional

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -23104,7 +23104,6 @@ components:
       type: object
       required:
         - vaspName
-        - url
       properties:
         vaspName:
           type: string
@@ -23113,7 +23112,7 @@ components:
         url:
           type: string
           format: uri
-          description: The VASP's website.
+          description: The VASP's website, when known.
           example: https://www.kraken.com
       description: A Virtual Asset Service Provider (VASP) — an exchange or other custodial platform — recognized for counterparty declarations.
     VaspListResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23104,7 +23104,6 @@ components:
       type: object
       required:
         - vaspName
-        - url
       properties:
         vaspName:
           type: string
@@ -23113,7 +23112,7 @@ components:
         url:
           type: string
           format: uri
-          description: The VASP's website.
+          description: The VASP's website, when known.
           example: https://www.kraken.com
       description: A Virtual Asset Service Provider (VASP) — an exchange or other custodial platform — recognized for counterparty declarations.
     VaspListResponse:

--- a/openapi/components/schemas/vasps/Vasp.yaml
+++ b/openapi/components/schemas/vasps/Vasp.yaml
@@ -1,7 +1,6 @@
 type: object
 required:
   - vaspName
-  - url
 properties:
   vaspName:
     type: string
@@ -12,7 +11,7 @@ properties:
   url:
     type: string
     format: uri
-    description: The VASP's website.
+    description: The VASP's website, when known.
     example: https://www.kraken.com
 description: >-
   A Virtual Asset Service Provider (VASP) — an exchange or other custodial


### PR DESCRIPTION
## Summary

Follow-up to #827. `Vasp.url` was marked required, but the upstream directory returns an empty string for it on most entries, so it can't be promised. Drops it from `required` and softens the description to "when known".

## Testing
`make build` bundles cleanly; `redocly lint` and `spectral lint` match the pre-existing baseline on `main` exactly (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ux8rU9Sm2sNFD1FUafY1wV)_