### PR TITLE
docs: use lowerCamelCase in platform fee formula

### DIFF
--- a/mintlify/payouts-and-b2b/payment-flow/assessing-fees.mdx
+++ b/mintlify/payouts-and-b2b/payment-flow/assessing-fees.mdx
@@ -67,8 +67,8 @@ Every fixed fee on the transaction — yours and Grid's — is subtracted first.
 rates are then applied together to what remains:
 
 ```text
-total_variable_fee = (sending_amount - platform_fixed_fee - grid_fixed_fee)
-                     x (platform_variable_fee + grid_variable_fee)
+totalVariableFee = (sendingAmount - platformFixedFee - gridFixedFee)
+                   x (platformVariableFee + gridVariableFee)
 ```
 
 Your share of that total is your own rate's portion of it. Each component is rounded


### PR DESCRIPTION
The fee formula in the "Assessing Fees" page used `snake_case` identifiers, while every field name elsewhere on that page — `variableFeeBps`, `fixedFee`, `platformFixedFee`, `platformVariableFeeBps`, `platformFeesIncluded` — is lowerCamelCase.

```diff
-total_variable_fee = (sending_amount - platform_fixed_fee - grid_fixed_fee)
-                     x (platform_variable_fee + grid_variable_fee)
+totalVariableFee = (sendingAmount - platformFixedFee - gridFixedFee)
+                   x (platformVariableFee + gridVariableFee)
```

Continuation line re-aligned to the opening paren after the shorter left-hand side.

I scanned the rest of `mintlify/**/*.mdx` for the same inconsistency — this was the only snake_case pseudo-identifier block. The remaining underscores are intentional: enum values (`CROSS_CURRENCY_TRANSACTION`), error codes (`payment_rejected`), sample ID strings (`maria_garcia_account`), and Python variables in a code sample. The worked-example block just below the formula ("after fixed fees = …") is prose labels rather than field names, so it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AufUiRnyVojiDGAYoRNCkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01AufUiRnyVojiDGAYoRNCkn)_