### PR TITLE
docs: document which transaction type a transfer or deposit creates

### DIFF
--- a/mintlify/payouts-and-b2b/payment-flow/list-transactions.mdx
+++ b/mintlify/payouts-and-b2b/payment-flow/list-transactions.mdx
@@ -81,7 +81,11 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/transactions?platformCus
 
 ### Filter by transaction type
 
-Get only incoming or outgoing transactions:
+Get only incoming or outgoing transactions. A transaction's type is keyed on its
+destination — anything landing in an internal account is `INCOMING`, and anything landing in
+an external account or at a UMA address is `OUTGOING`. See
+[Transaction Lifecycle](/platform-overview/core-concepts/transaction-lifecycle#incoming-or-outgoing)
+for the full table.
 
 <Tabs>
 <Tab title="Outgoing Only">

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -7,6 +7,34 @@ description: "Follow a payment from creation to settlement"
 
 Understanding the transaction lifecycle helps you build robust payment flows, handle edge cases, and provide accurate status updates to your customers.
 
+## Incoming or outgoing
+
+Every transfer creates a transaction, and its `type` is keyed on the **destination** —
+where the money came from makes no difference:
+
+| Destination | `type` | Webhook family |
+|---|---|---|
+| Internal account | `INCOMING` | `INCOMING_PAYMENT.<STATUS>` |
+| External account | `OUTGOING` | `OUTGOING_PAYMENT.<STATUS>` |
+| UMA address | `OUTGOING` | `OUTGOING_PAYMENT.<STATUS>` |
+
+In practice:
+
+- A payout from an internal account to an external account is `OUTGOING`.
+- A pull from an external account into an internal account is `INCOMING`, even though you
+  initiated it.
+- A transfer between two internal accounts is `INCOMING`.
+- A deposit that lands by paying an internal account's
+  [payment instructions](/payouts-and-b2b/depositing-funds/internal-accounts) is `INCOMING`,
+  as is a payment received at one of your customers' UMA addresses.
+
+The type decides which lifecycle below applies and which webhooks you receive, so branch on
+it rather than on which endpoint you called.
+
+<Info>
+  Card spending produces a third type, `CARD`, which follows its own lifecycle.
+</Info>
+
 ## Outgoing Transaction Flow
 
 **Your customer/platform sends funds to an external recipient.**
@@ -158,9 +186,10 @@ Where a refund lands depends on how the transaction was funded:
 
 ## Webhooks
 
-Outgoing payment webhooks use the format `OUTGOING_PAYMENT.<STATUS>`. The webhook request body contains the full transaction resource.
+Payment webhooks use the format `<TYPE>_PAYMENT.<STATUS>`, matching the transaction's `type`.
+The webhook request body contains the full transaction resource.
 
-### Event Types
+### Outgoing event types
 
 | Event | Description |
 |-------|-------------|
@@ -173,6 +202,20 @@ Outgoing payment webhooks use the format `OUTGOING_PAYMENT.<STATUS>`. The webhoo
 | `OUTGOING_PAYMENT.REFUND_PENDING` | Refund initiated |
 | `OUTGOING_PAYMENT.REFUND_COMPLETED` | Refund settled |
 | `OUTGOING_PAYMENT.REFUND_FAILED` | Refund failed |
+
+### Incoming event types
+
+| Event | Description |
+|-------|-------------|
+| `INCOMING_PAYMENT.PENDING` | Funds are on their way to the internal account |
+| `INCOMING_PAYMENT.COMPLETED` | Funds credited to the internal account |
+| `INCOMING_PAYMENT.FAILED` | The deposit failed |
+| `INCOMING_PAYMENT.REFUND_PENDING` | Refund initiated |
+| `INCOMING_PAYMENT.REFUND_COMPLETED` | Refund settled |
+| `INCOMING_PAYMENT.REFUND_FAILED` | Refund failed |
+
+The incoming family has no `PENDING_AUTHORIZATION`, `PROCESSING`, or `EXPIRED` event — those
+belong to executing a quote, which is the sending side of a transfer.
 
 ### Example Payloads
 

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -214,8 +214,16 @@ The webhook request body contains the full transaction resource.
 | `INCOMING_PAYMENT.REFUND_COMPLETED` | Refund settled |
 | `INCOMING_PAYMENT.REFUND_FAILED` | Refund failed |
 
-The incoming family has no `PENDING_AUTHORIZATION`, `PROCESSING`, or `EXPIRED` event — those
-belong to executing a quote, which is the sending side of a transfer.
+The incoming family fires fewer events than the outgoing one: there is no
+`INCOMING_PAYMENT.PROCESSING`, `INCOMING_PAYMENT.PENDING_AUTHORIZATION`, or
+`INCOMING_PAYMENT.EXPIRED`.
+
+<Warning>
+  That is a difference in which **events fire**, not in which states exist. An incoming
+  transaction's `status` field uses the same set as any other transaction and does reach
+  `PROCESSING`. Read the transaction rather than inferring its state from the webhooks you
+  have received.
+</Warning>
 
 ### Example Payloads
 

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -208,14 +208,12 @@ The webhook request body contains the full transaction resource.
 | Event | Description |
 |-------|-------------|
 | `INCOMING_PAYMENT.PENDING` | Funds are on their way to the internal account |
+| `INCOMING_PAYMENT.PROCESSING` | Funding received, credit in progress |
 | `INCOMING_PAYMENT.COMPLETED` | Funds credited to the internal account |
 | `INCOMING_PAYMENT.FAILED` | The deposit failed |
 | `INCOMING_PAYMENT.REFUND_PENDING` | Refund initiated |
 | `INCOMING_PAYMENT.REFUND_COMPLETED` | Refund settled |
 | `INCOMING_PAYMENT.REFUND_FAILED` | Refund failed |
-
-Read the transaction in the webhook body for its precise `status`; the event name is a
-coarser signal than the `status` field it carries.
 
 ### Example Payloads
 

--- a/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
+++ b/mintlify/platform-overview/core-concepts/transaction-lifecycle.mdx
@@ -214,16 +214,8 @@ The webhook request body contains the full transaction resource.
 | `INCOMING_PAYMENT.REFUND_COMPLETED` | Refund settled |
 | `INCOMING_PAYMENT.REFUND_FAILED` | Refund failed |
 
-The incoming family fires fewer events than the outgoing one: there is no
-`INCOMING_PAYMENT.PROCESSING`, `INCOMING_PAYMENT.PENDING_AUTHORIZATION`, or
-`INCOMING_PAYMENT.EXPIRED`.
-
-<Warning>
-  That is a difference in which **events fire**, not in which states exist. An incoming
-  transaction's `status` field uses the same set as any other transaction and does reach
-  `PROCESSING`. Read the transaction rather than inferring its state from the webhooks you
-  have received.
-</Warning>
+Read the transaction in the webhook body for its precise `status`; the event name is a
+coarser signal than the `status` field it carries.
 
 ### Example Payloads
 

--- a/mintlify/snippets/terminology.mdx
+++ b/mintlify/snippets/terminology.mdx
@@ -126,7 +126,7 @@ Understanding how entities map to your specific use case helps clarify your inte
 
 **Transactions** represent completed or in-progress payment transfers. Each transaction:
 
-- Has a type (INCOMING or OUTGOING from the platform's perspective)
+- Has a type (INCOMING or OUTGOING), keyed on whether the destination is an internal account
 - Has a status (PENDING, COMPLETED, FAILED, etc.)
 - References a customer (sender for outgoing, recipient for incoming) or a platform internal account
 - Specifies source and destination (accounts or UMA addresses)


### PR DESCRIPTION
> [!NOTE]
> **Top of a three-PR stack:** #858 (spec) → #856 (transfer deprecation) → this. Base is `claude/transfer-api-deprecation-docs-6ycamq`, so the diff here is only the 3 files below. Each merge retargets this automatically.

## The gap

Nothing in the docs said whether a given transfer produces an `INCOMING` or an `OUTGOING` transaction. Worse, the Transaction Lifecycle page contained **zero occurrences of the word "incoming"** — it described only the outgoing flow, despite `INCOMING_PAYMENT.*` webhooks existing and being referenced from six other pages.

## The rule

The type is keyed on the **destination**, regardless of source:

| Destination | `type` | Webhook family |
|---|---|---|
| Internal account | `INCOMING` | `INCOMING_PAYMENT.<STATUS>` |
| External account | `OUTGOING` | `OUTGOING_PAYMENT.<STATUS>` |
| UMA address | `OUTGOING` | `OUTGOING_PAYMENT.<STATUS>` |

Consequences worth spelling out, and now spelled out:

- A pull from an external account into an internal account is `INCOMING`, even though the platform initiated it.
- A transfer between two internal accounts is `INCOMING`.
- A deposit that lands by paying an internal account's payment instructions is `INCOMING`, as is a payment received at a customer's UMA address.

This mirrors the dispatch in `gen_convert_to_transaction` (`sparkcore/grid/objects/transaction.py:159`), which routes `EntGridReceiveOperation` to incoming unconditionally and branches a send operation on `gen_send_op_destination_is_internal_account`. That helper carries the same truth table in its docstring at `transaction.py:738`. The branch is gated on `GK.GRID_INCOMING_TRANSACTION_REFACTOR`, which is rolled out, so the table describes current behavior for all platforms.

## Changes

- **`transaction-lifecycle.mdx`** — new **Incoming or outgoing** section at the top, ahead of the flow sections, since the type decides which lifecycle and webhook family apply.
- **`transaction-lifecycle.mdx`** — split the webhook event table into outgoing and incoming families. The incoming list was missing entirely. Its `INCOMING_PAYMENT.PROCESSING` row corresponds to the enum value added in #858.
- **`terminology.mdx`** — said the type was "from the platform's perspective", which does not tell a reader how to predict it. Now states the rule.
- **`list-transactions.mdx`** — the *Filter by transaction type* section had the reader choosing `type=INCOMING|OUTGOING` with no way to know which their payout is. Now states the rule and links to the table.

## Two things this PR previously got wrong

Recorded because both were corrected in place and a reviewer reading only the head would not see them:

1. An early revision claimed incoming transactions have no `PROCESSING` **state**. False — they do; both incoming converters map `display_status` through, and `gen_convert_send_op_to_incoming_transaction` maps `SENT` onto `PROCESSING` explicitly (`transaction.py:891`). Only the *webhook event* is missing.
2. The next revision then explained that missing event as an intentional design difference, which would have enshrined a bug. It is a sparkcore bug; #858 adds the enum and describes the emission fix.

## Validation

- `make lint` exits 0 — 663 problems, unchanged from baseline (all pre-existing)
- Docs-only: no files under `openapi/`, so the bundle, oasdiff, and SDK generation are untouched by this PR
- The `#incoming-or-outgoing` anchor is linked from `list-transactions.mdx`; the heading carries no punctuation, so the slug is unambiguous