### PR TITLE
ci: block manual edits to generated schemas

### DIFF
--- a/.github/workflows/generated-schemas.yml
+++ b/.github/workflows/generated-schemas.yml
@@ -1,0 +1,54 @@
+name: Generated Schemas
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'openapi/components/schemas/**'
+
+jobs:
+  no-manual-edits:
+    name: Check for manual edits
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for manual edits to generated schemas
+        if: >-
+          github.event.pull_request.user.login != 'lightspark-copybara[bot]' &&
+          !contains(github.event.pull_request.labels.*.name, 'edit-generated-schemas')
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          manifest=openapi/generated-schemas.txt
+          if [ ! -f "$manifest" ]; then
+            echo "$manifest does not exist yet; nothing to check."
+            exit 0
+          fi
+
+          : > edited.txt
+          git diff --name-only "origin/$BASE_REF...HEAD" > changed.txt
+          while IFS= read -r file; do
+            case "$file" in
+              openapi/components/schemas/*) ;;
+              *) continue ;;
+            esac
+            if grep -qxF "$(basename "$file")" "$manifest"; then
+              echo "  $file" >> edited.txt
+            fi
+          done < changed.txt
+
+          if [ -s edited.txt ]; then
+            echo "::error::These schemas are generated. Edits to them are overwritten by the next sync."
+            cat edited.txt
+            echo "Add the 'edit-generated-schemas' label to override."
+            exit 1
+          fi
+
+          echo "No generated schemas were edited."


### PR DESCRIPTION
Some schemas under `openapi/components/schemas/` are generated and synced automatically, so manual edits to them are reverted by the next sync.

This adds a check that fails a pull request which edits one of those files. The list comes from `openapi/generated-schemas.txt`, which the sync writes. Until that file exists, the check passes.

To make an intentional edit, add the `edit-generated-schemas` label.