### PR TITLE
[Daily-Spend-Limits]: Add UTC daily card spending limit contract

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12102,6 +12102,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Platform-level cap on a single transaction for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerTransaction`; null means no platform-level cap. The cap applies to existing cards and to cards issued later. Provider-decided card programs are unaffected.
           example: 10000
@@ -12110,6 +12111,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Platform-level cap on cumulative new spend during one UTC calendar day for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerDay`; null means no platform-level daily cap. The window resets at 00:00 UTC. Refunds, reversals, and authorization expiries do not restore capacity during the day. The cap applies to existing cards and cards issued later. Provider-decided card programs are unaffected.
           example: 50000
@@ -25643,6 +25645,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Card-specific cap on a single transaction, in the smallest unit of the card's `currency`. Null means the card has no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values without replacing this configured value. A transaction for exactly the effective limit is allowed.
           example: 5000
@@ -25651,6 +25654,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card's `currency`. The window resets at 00:00 UTC. Null means the card has no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values without replacing this configured value. Refunds, reversals, and authorization expiries do not restore capacity during the day. Spend exactly equal to the effective limit is allowed.
           example: 25000
@@ -25734,12 +25738,14 @@ components:
           type: integer
           format: int64
           minimum: 1
+          maximum: 9007199254740991
           description: Optional card-specific cap on a single transaction, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. A transaction for exactly the effective limit is allowed.
           example: 5000
         maxSpendPerDay:
           type: integer
           format: int64
           minimum: 1
+          maximum: 9007199254740991
           description: Optional card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. The window resets at 00:00 UTC, and refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Spend exactly equal to the effective limit is allowed.
           example: 25000
     CardUpdateRequest:
@@ -25768,6 +25774,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: 'Replacement card-specific per-transaction cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 10000
@@ -25776,6 +25783,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: 'Replacement card-specific UTC-calendar-day cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. Refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 25000

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -92,7 +92,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
     patch:
       summary: Update platform configuration
-      description: Update platform configuration settings. Setting `cardConfigs.maxSpendPerTransaction` establishes a platform-level card cap; Grid enforces the lower of that cap and each card's configured `maxSpendPerTransaction` without replacing the card-specific value.
+      description: Update platform configuration settings. `cardConfigs` can establish platform-level per-transaction and UTC-calendar-day card caps. Grid enforces the lower of each platform cap and its corresponding card-specific value without replacing the card-specific value. Daily limits reset at 00:00 UTC.
       operationId: updatePlatformConfig
       tags:
         - Platform Configuration
@@ -141,6 +141,7 @@ paths:
                   bodyText: Use this code to finish adding your Acme card to your digital wallet.
               cardConfigs:
                 maxSpendPerTransaction: 10000
+                maxSpendPerDay: 50000
       responses:
         '200':
           description: Configuration updated successfully
@@ -8424,7 +8425,7 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        An optional `maxSpendPerTransaction` value sets the card-specific cap on a single transaction. The limit is enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. Omit it for no card-specific cap. If the platform config sets `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card and platform values. Both values use the smallest unit of the card's currency.
+        Optional `maxSpendPerTransaction` and `maxSpendPerDay` values set the card-specific caps on one transaction and one UTC calendar day. The limits are enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. If the platform config sets the corresponding `cardConfigs` value, Grid enforces the lower of the card and platform caps. All values use the smallest unit of the card's currency.
 
         If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
 
@@ -8450,6 +8451,7 @@ paths:
                   fundingSources:
                     - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                   maxSpendPerTransaction: 5000
+                  maxSpendPerDay: 25000
       responses:
         '201':
           description: Card created successfully. Newly-created cards start in `PROCESSING` while the issuer provisions them. Cards funded by an Embedded Wallet internal account also require an active delegated key for that funding source before Authorization Decisioning can use it.
@@ -8621,11 +8623,12 @@ paths:
     patch:
       summary: Update a card
       description: |
-        Update a card's `state`, bound `fundingSources`, and / or `maxSpendPerTransaction`. At least one field must be supplied.
+        Update a card's `state`, bound `fundingSources`, and / or `maxSpendPerTransaction`, or `maxSpendPerDay`. At least one field must be supplied.
 
         - `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`. `CLOSED` is terminal and irreversible. Any other transition returns `409 INVALID_STATE_TRANSITION`.
         - `fundingSources`, when supplied, fully replaces the card's bound funding sources. Array order determines the priority Authorization Decisioning tries them in. Each id must belong to the cardholder and be denominated in the card's currency; the list must contain at least one source. `fundingSources` cannot be supplied alongside `state: CLOSED`.
         - `maxSpendPerTransaction`, when supplied, replaces the card-specific per-transaction cap. Supply a positive integer in the smallest unit of the card's currency to set it or null to clear it. If the platform config sets `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card and platform values. Limits are supported only for card programs where Grid makes the authorization decision. `maxSpendPerTransaction` cannot be supplied alongside `state: CLOSED`.
+        - `maxSpendPerDay`, when supplied, replaces the card-specific cap on cumulative new spend during one UTC calendar day. Supply a positive integer in the smallest unit of the card's currency to set it or null to clear it. If the platform config sets `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the card and platform values. Refunds, reversals, and authorization expiries do not restore capacity during the day. `maxSpendPerDay` cannot be supplied alongside `state: CLOSED`.
 
         This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
@@ -8666,10 +8669,12 @@ paths:
                 summary: Set the card's per-transaction spending limit
                 value:
                   maxSpendPerTransaction: 10000
+                  maxSpendPerDay: 25000
               clearSpendingLimit:
-                summary: Remove the card's per-transaction spending limit
+                summary: Remove the card's spending limits
                 value:
                   maxSpendPerTransaction: null
+                  maxSpendPerDay: null
               freezeAndUpdateSources:
                 summary: Freeze the card and replace its funding sources in one call
                 value:
@@ -11343,6 +11348,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: 5000
+                    maxSpendPerDay: 25000
                     currency: USD
                     processorRef: card_b81c2a4f
                     issuerRef: lead_card_7a1b9c3d
@@ -11363,6 +11369,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: null
+                    maxSpendPerDay: null
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:12:00Z'
@@ -11385,6 +11392,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: 5000
+                    maxSpendPerDay: 25000
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-09T09:00:00Z'
@@ -11460,6 +11468,7 @@ webhooks:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000003
                     maxSpendPerTransaction: null
+                    maxSpendPerDay: null
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:30:00Z'
@@ -12096,6 +12105,14 @@ components:
             - type: 'null'
           description: Platform-level cap on a single transaction for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerTransaction`; null means no platform-level cap. The cap applies to existing cards and to cards issued later. Provider-decided card programs are unaffected.
           example: 10000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: Platform-level cap on cumulative new spend during one UTC calendar day for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerDay`; null means no platform-level daily cap. The window resets at 00:00 UTC. Refunds, reversals, and authorization expiries do not restore capacity during the day. The cap applies to existing cards and cards issued later. Provider-decided card programs are unaffected.
+          example: 50000
     FeeType:
       type: string
       enum:
@@ -12311,7 +12328,7 @@ components:
             to subsequent delivery attempts.
         cardConfigs:
           $ref: '#/components/schemas/CardConfig'
-          description: Update platform-level card settings. Fields omitted from the nested object are left unchanged. For `maxSpendPerTransaction`, supply null to clear the platform cap or a positive integer to set it. Omit this field at the top level to leave all card settings unchanged.
+          description: Update platform-level card settings. Fields omitted from the nested object are left unchanged. For either spending limit, supply null to clear the platform cap or a positive integer to set it. Omit this field at the top level to leave all card settings unchanged.
         feeConfigs:
           type: array
           items:
@@ -25571,6 +25588,7 @@ components:
         - form
         - fundingSources
         - maxSpendPerTransaction
+        - maxSpendPerDay
         - createdAt
         - updatedAt
       properties:
@@ -25628,6 +25646,14 @@ components:
             - type: 'null'
           description: Card-specific cap on a single transaction, in the smallest unit of the card's `currency`. Null means the card has no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values without replacing this configured value. A transaction for exactly the effective limit is allowed.
           example: 5000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: Card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card's `currency`. The window resets at 00:00 UTC. Null means the card has no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values without replacing this configured value. Refunds, reversals, and authorization expiries do not restore capacity during the day. Spend exactly equal to the effective limit is allowed.
+          example: 25000
         currency:
           type: string
           description: Currency the card transacts in (ISO 4217 for fiat, tickers for crypto). Derived from the funding sources at issue time — all funding sources bound to a card must be denominated in the same card-eligible currency.
@@ -25710,9 +25736,15 @@ components:
           minimum: 1
           description: Optional card-specific cap on a single transaction, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. A transaction for exactly the effective limit is allowed.
           example: 5000
+        maxSpendPerDay:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Optional card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. The window resets at 00:00 UTC, and refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Spend exactly equal to the effective limit is allowed.
+          example: 25000
     CardUpdateRequest:
       type: object
-      description: Update request for `PATCH /cards/{id}`. At least one of `state`, `fundingSources`, or `maxSpendPerTransaction` must be supplied. `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`; any other transition returns `409 INVALID_STATE_TRANSITION`. `CLOSED` is terminal and irreversible and cannot be combined with `fundingSources` or `maxSpendPerTransaction`. `fundingSources`, when supplied, fully replaces the card's bound funding sources — the array order determines the priority Authorization Decisioning tries them in.
+      description: Update request for `PATCH /cards/{id}`. At least one of `state`, `fundingSources`, `maxSpendPerTransaction`, or `maxSpendPerDay` must be supplied. `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`; any other transition returns `409 INVALID_STATE_TRANSITION`. `CLOSED` is terminal and irreversible and cannot be combined with `fundingSources`, `maxSpendPerTransaction`, or `maxSpendPerDay`. `fundingSources`, when supplied, fully replaces the card's bound funding sources — the array order determines the priority Authorization Decisioning tries them in.
       properties:
         state:
           type: string
@@ -25739,6 +25771,14 @@ components:
             - type: 'null'
           description: 'Replacement card-specific per-transaction cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 10000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: 'Replacement card-specific UTC-calendar-day cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. Refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
+          example: 25000
     CardRevealResponse:
       type: object
       required:

--- a/mintlify/snippets/cards/freezing-and-closing.mdx
+++ b/mintlify/snippets/cards/freezing-and-closing.mdx
@@ -1,15 +1,13 @@
-Freeze, close, and other sensitive card updates use Grid's
-`202 → signed-retry` pattern — the same one used by Embedded Wallet
-credential revocation and wallet export. This page covers the flow,
-what each transition does, and how to handle the signing step.
+Freeze, close, and other card updates use a single authenticated
+`PATCH /cards/{id}` request and return the updated card with `200 OK`.
 
 
 `PATCH /cards/{id}` covers freeze / unfreeze (`state`), funding source
-updates (`fundingSources`), and per-transaction spending limits
-(`maxSpendPerTransaction`). See
+updates (`fundingSources`), per-transaction spending limits
+(`maxSpendPerTransaction`), and UTC-calendar-day spending limits
+(`maxSpendPerDay`). See
 [Funding sources](/cards/card-management/funding-sources) for the
-funding-source-only flow. The signed-retry mechanics below apply to all
-fields.
+funding-source-only flow.
 
 ## Valid state transitions
 
@@ -26,23 +24,6 @@ particular, you cannot un-freeze a `CLOSED` card — close is terminal.
 You can also combine a state change with a funding source replacement
 in one PATCH — just include both fields in the body.
 
-## The signed-retry flow
-
-Each request follows the same two-call shape:
-
-```text
-1. PATCH /cards/{id}                      ─►  202  with payloadToSign, requestId, expiresAt
-2. PATCH /cards/{id}                      ─►  200  with the updated Card
-   Headers:
-     Grid-Wallet-Signature: <sig>
-     Request-Id: <requestId from step 1>
-```
-
-The signature is produced with the session private key of a verified
-authentication credential on the card's owning internal account.
-
-### Step 1 — initial call
-
 ```bash
 curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
@@ -50,40 +31,8 @@ curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
   -d '{ "state": "FROZEN" }'
 ```
 
-Response — `202 Accepted`:
-
-```json
-{
-  "payloadToSign": "Y2hhbGxlbmdlLXBheWxvYWQtdG8tc2lnbg==",
-  "requestId": "7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21",
-  "expiresAt": "2026-05-08T15:35:00Z"
-}
-```
-
-### Step 2 — signed retry
-
-Sign `payloadToSign` with the session private key of a verified
-authentication credential on the card's owning internal account, then
-retry the same request with the signature and the request id echoed
-back:
-
-```bash
-curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
-  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
-  -H "Content-Type: application/json" \
-  -H "Grid-Wallet-Signature: <base64 signature>" \
-  -H "Request-Id: 7c4a8d09-ca37-4e3e-9e0d-8c2b3e9a1f21" \
-  -d '{ "state": "FROZEN" }'
-```
-
-Response — `200 OK` with the updated `Card` and a
+The response is `200 OK` with the updated `Card` and a
 `CARD.STATE_CHANGE` webhook.
-
-<Note>
-The signing flow is identical to the one used by Embedded Wallet
-credential revocation. If you've already wired that up, you can reuse
-the same key-handling code for cards.
-</Note>
 
 ## What freeze does
 
@@ -118,8 +67,6 @@ setting `state: "CLOSED"`. The operation is permanent:
 curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -H "Grid-Wallet-Signature: <base64 signature>" \
-  -H "Request-Id: <requestId from prior 202>" \
   -d '{ "state": "CLOSED" }'
 ```
 
@@ -135,8 +82,6 @@ To set or change the per-transaction spending limit:
 curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -H "Grid-Wallet-Signature: <base64 signature>" \
-  -H "Request-Id: <requestId from prior 202>" \
   -d '{ "maxSpendPerTransaction": 10000 }'
 ```
 
@@ -145,8 +90,21 @@ card's currency) or `null` to clear it. Omitting the field leaves the
 current limit unchanged. `maxSpendPerTransaction` cannot be supplied
 alongside `state: CLOSED`.
 
+## Updating the daily limit
+
+Set `maxSpendPerDay` to a positive integer in the smallest unit of the card's
+currency, or set it to `null` to clear the card-specific daily limit. The
+window resets at 00:00 UTC. Refunds, reversals, and authorization expiries do
+not restore capacity during the same day.
+
+```bash
+curl -X PATCH "$GRID_BASE_URL/cards/Card:019542f5-b3e7-1d02-0000-000000000010" \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{ "maxSpendPerDay": 25000 }'
+```
+
 ## Sandbox behavior
 
 In Sandbox the state changes are instant — no issuer round-trip is
-simulated, but the signed-retry shape is the same as production so
-you can exercise the full client flow.
+simulated. The request and response shape is the same as production.

--- a/mintlify/snippets/cards/issuing-cards.mdx
+++ b/mintlify/snippets/cards/issuing-cards.mdx
@@ -15,7 +15,8 @@ curl -X POST "$GRID_BASE_URL/cards" \
     "fundingSources": [
       "InternalAccount:019542f5-b3e7-1d02-0000-000000000002"
     ],
-    "maxSpendPerTransaction": 5000
+    "maxSpendPerTransaction": 5000,
+    "maxSpendPerDay": 25000
   }'
 ```
 
@@ -26,6 +27,7 @@ curl -X POST "$GRID_BASE_URL/cards" \
 | `form` | Yes | `VIRTUAL` in v1. `PHYSICAL` will be added later. |
 | `fundingSources` | Yes | Ordered array of `InternalAccount` ids. Each must belong to the cardholder and share one card-eligible currency. The first entry is tried first by Authorization Decisioning. |
 | `maxSpendPerTransaction` | No | Largest amount a single card transaction may authorize, in the smallest unit of the card's currency. Omit for no limit. Supported only for card programs where Grid makes the authorization decision. |
+| `maxSpendPerDay` | No | Cumulative new spend allowed per UTC calendar day, in the smallest unit of the card's currency. Refunds, reversals, and expiries do not restore capacity that day. |
 
 The card's `currency` is derived from the funding sources at issue time
 and surfaces on the returned `Card` resource — all bound sources share

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12102,6 +12102,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Platform-level cap on a single transaction for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerTransaction`; null means no platform-level cap. The cap applies to existing cards and to cards issued later. Provider-decided card programs are unaffected.
           example: 10000
@@ -12110,6 +12111,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Platform-level cap on cumulative new spend during one UTC calendar day for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerDay`; null means no platform-level daily cap. The window resets at 00:00 UTC. Refunds, reversals, and authorization expiries do not restore capacity during the day. The cap applies to existing cards and cards issued later. Provider-decided card programs are unaffected.
           example: 50000
@@ -25643,6 +25645,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Card-specific cap on a single transaction, in the smallest unit of the card's `currency`. Null means the card has no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values without replacing this configured value. A transaction for exactly the effective limit is allowed.
           example: 5000
@@ -25651,6 +25654,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: Card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card's `currency`. The window resets at 00:00 UTC. Null means the card has no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values without replacing this configured value. Refunds, reversals, and authorization expiries do not restore capacity during the day. Spend exactly equal to the effective limit is allowed.
           example: 25000
@@ -25734,12 +25738,14 @@ components:
           type: integer
           format: int64
           minimum: 1
+          maximum: 9007199254740991
           description: Optional card-specific cap on a single transaction, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. A transaction for exactly the effective limit is allowed.
           example: 5000
         maxSpendPerDay:
           type: integer
           format: int64
           minimum: 1
+          maximum: 9007199254740991
           description: Optional card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. The window resets at 00:00 UTC, and refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Spend exactly equal to the effective limit is allowed.
           example: 25000
     CardUpdateRequest:
@@ -25768,6 +25774,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: 'Replacement card-specific per-transaction cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 10000
@@ -25776,6 +25783,7 @@ components:
             - type: integer
               format: int64
               minimum: 1
+              maximum: 9007199254740991
             - type: 'null'
           description: 'Replacement card-specific UTC-calendar-day cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. Refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 25000

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -92,7 +92,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
     patch:
       summary: Update platform configuration
-      description: Update platform configuration settings. Setting `cardConfigs.maxSpendPerTransaction` establishes a platform-level card cap; Grid enforces the lower of that cap and each card's configured `maxSpendPerTransaction` without replacing the card-specific value.
+      description: Update platform configuration settings. `cardConfigs` can establish platform-level per-transaction and UTC-calendar-day card caps. Grid enforces the lower of each platform cap and its corresponding card-specific value without replacing the card-specific value. Daily limits reset at 00:00 UTC.
       operationId: updatePlatformConfig
       tags:
         - Platform Configuration
@@ -141,6 +141,7 @@ paths:
                   bodyText: Use this code to finish adding your Acme card to your digital wallet.
               cardConfigs:
                 maxSpendPerTransaction: 10000
+                maxSpendPerDay: 50000
       responses:
         '200':
           description: Configuration updated successfully
@@ -8424,7 +8425,7 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
-        An optional `maxSpendPerTransaction` value sets the card-specific cap on a single transaction. The limit is enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. Omit it for no card-specific cap. If the platform config sets `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card and platform values. Both values use the smallest unit of the card's currency.
+        Optional `maxSpendPerTransaction` and `maxSpendPerDay` values set the card-specific caps on one transaction and one UTC calendar day. The limits are enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. If the platform config sets the corresponding `cardConfigs` value, Grid enforces the lower of the card and platform caps. All values use the smallest unit of the card's currency.
 
         If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
 
@@ -8450,6 +8451,7 @@ paths:
                   fundingSources:
                     - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                   maxSpendPerTransaction: 5000
+                  maxSpendPerDay: 25000
       responses:
         '201':
           description: Card created successfully. Newly-created cards start in `PROCESSING` while the issuer provisions them. Cards funded by an Embedded Wallet internal account also require an active delegated key for that funding source before Authorization Decisioning can use it.
@@ -8621,11 +8623,12 @@ paths:
     patch:
       summary: Update a card
       description: |
-        Update a card's `state`, bound `fundingSources`, and / or `maxSpendPerTransaction`. At least one field must be supplied.
+        Update a card's `state`, bound `fundingSources`, and / or `maxSpendPerTransaction`, or `maxSpendPerDay`. At least one field must be supplied.
 
         - `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`. `CLOSED` is terminal and irreversible. Any other transition returns `409 INVALID_STATE_TRANSITION`.
         - `fundingSources`, when supplied, fully replaces the card's bound funding sources. Array order determines the priority Authorization Decisioning tries them in. Each id must belong to the cardholder and be denominated in the card's currency; the list must contain at least one source. `fundingSources` cannot be supplied alongside `state: CLOSED`.
         - `maxSpendPerTransaction`, when supplied, replaces the card-specific per-transaction cap. Supply a positive integer in the smallest unit of the card's currency to set it or null to clear it. If the platform config sets `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card and platform values. Limits are supported only for card programs where Grid makes the authorization decision. `maxSpendPerTransaction` cannot be supplied alongside `state: CLOSED`.
+        - `maxSpendPerDay`, when supplied, replaces the card-specific cap on cumulative new spend during one UTC calendar day. Supply a positive integer in the smallest unit of the card's currency to set it or null to clear it. If the platform config sets `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the card and platform values. Refunds, reversals, and authorization expiries do not restore capacity during the day. `maxSpendPerDay` cannot be supplied alongside `state: CLOSED`.
 
         This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
@@ -8666,10 +8669,12 @@ paths:
                 summary: Set the card's per-transaction spending limit
                 value:
                   maxSpendPerTransaction: 10000
+                  maxSpendPerDay: 25000
               clearSpendingLimit:
-                summary: Remove the card's per-transaction spending limit
+                summary: Remove the card's spending limits
                 value:
                   maxSpendPerTransaction: null
+                  maxSpendPerDay: null
               freezeAndUpdateSources:
                 summary: Freeze the card and replace its funding sources in one call
                 value:
@@ -11343,6 +11348,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: 5000
+                    maxSpendPerDay: 25000
                     currency: USD
                     processorRef: card_b81c2a4f
                     issuerRef: lead_card_7a1b9c3d
@@ -11363,6 +11369,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: null
+                    maxSpendPerDay: null
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:12:00Z'
@@ -11385,6 +11392,7 @@ webhooks:
                     fundingSources:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                     maxSpendPerTransaction: 5000
+                    maxSpendPerDay: 25000
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-09T09:00:00Z'
@@ -11460,6 +11468,7 @@ webhooks:
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                       - InternalAccount:019542f5-b3e7-1d02-0000-000000000003
                     maxSpendPerTransaction: null
+                    maxSpendPerDay: null
                     currency: USD
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:30:00Z'
@@ -12096,6 +12105,14 @@ components:
             - type: 'null'
           description: Platform-level cap on a single transaction for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerTransaction`; null means no platform-level cap. The cap applies to existing cards and to cards issued later. Provider-decided card programs are unaffected.
           example: 10000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: Platform-level cap on cumulative new spend during one UTC calendar day for every card whose authorization decisions are made by Grid. The value is interpreted in the smallest unit of each card's currency. Grid enforces the lower of this cap and the card's configured `maxSpendPerDay`; null means no platform-level daily cap. The window resets at 00:00 UTC. Refunds, reversals, and authorization expiries do not restore capacity during the day. The cap applies to existing cards and cards issued later. Provider-decided card programs are unaffected.
+          example: 50000
     FeeType:
       type: string
       enum:
@@ -12311,7 +12328,7 @@ components:
             to subsequent delivery attempts.
         cardConfigs:
           $ref: '#/components/schemas/CardConfig'
-          description: Update platform-level card settings. Fields omitted from the nested object are left unchanged. For `maxSpendPerTransaction`, supply null to clear the platform cap or a positive integer to set it. Omit this field at the top level to leave all card settings unchanged.
+          description: Update platform-level card settings. Fields omitted from the nested object are left unchanged. For either spending limit, supply null to clear the platform cap or a positive integer to set it. Omit this field at the top level to leave all card settings unchanged.
         feeConfigs:
           type: array
           items:
@@ -25571,6 +25588,7 @@ components:
         - form
         - fundingSources
         - maxSpendPerTransaction
+        - maxSpendPerDay
         - createdAt
         - updatedAt
       properties:
@@ -25628,6 +25646,14 @@ components:
             - type: 'null'
           description: Card-specific cap on a single transaction, in the smallest unit of the card's `currency`. Null means the card has no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values without replacing this configured value. A transaction for exactly the effective limit is allowed.
           example: 5000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: Card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card's `currency`. The window resets at 00:00 UTC. Null means the card has no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values without replacing this configured value. Refunds, reversals, and authorization expiries do not restore capacity during the day. Spend exactly equal to the effective limit is allowed.
+          example: 25000
         currency:
           type: string
           description: Currency the card transacts in (ISO 4217 for fiat, tickers for crypto). Derived from the funding sources at issue time — all funding sources bound to a card must be denominated in the same card-eligible currency.
@@ -25710,9 +25736,15 @@ components:
           minimum: 1
           description: Optional card-specific cap on a single transaction, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific cap. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. A transaction for exactly the effective limit is allowed.
           example: 5000
+        maxSpendPerDay:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Optional card-specific cap on cumulative new spend during one UTC calendar day, in the smallest unit of the card currency derived from its funding sources. Omit this field for no card-specific daily cap. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. The window resets at 00:00 UTC, and refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Spend exactly equal to the effective limit is allowed.
+          example: 25000
     CardUpdateRequest:
       type: object
-      description: Update request for `PATCH /cards/{id}`. At least one of `state`, `fundingSources`, or `maxSpendPerTransaction` must be supplied. `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`; any other transition returns `409 INVALID_STATE_TRANSITION`. `CLOSED` is terminal and irreversible and cannot be combined with `fundingSources` or `maxSpendPerTransaction`. `fundingSources`, when supplied, fully replaces the card's bound funding sources — the array order determines the priority Authorization Decisioning tries them in.
+      description: Update request for `PATCH /cards/{id}`. At least one of `state`, `fundingSources`, `maxSpendPerTransaction`, or `maxSpendPerDay` must be supplied. `state` transitions are limited to `ACTIVE ⇄ FROZEN` and `ACTIVE | FROZEN → CLOSED`; any other transition returns `409 INVALID_STATE_TRANSITION`. `CLOSED` is terminal and irreversible and cannot be combined with `fundingSources`, `maxSpendPerTransaction`, or `maxSpendPerDay`. `fundingSources`, when supplied, fully replaces the card's bound funding sources — the array order determines the priority Authorization Decisioning tries them in.
       properties:
         state:
           type: string
@@ -25739,6 +25771,14 @@ components:
             - type: 'null'
           description: 'Replacement card-specific per-transaction cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the two values. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
           example: 10000
+        maxSpendPerDay:
+          anyOf:
+            - type: integer
+              format: int64
+              minimum: 1
+            - type: 'null'
+          description: 'Replacement card-specific UTC-calendar-day cap, in the smallest unit of the card''s currency. Omit this field to leave the current cap unchanged, supply null to clear it, or supply a positive integer to set it. When the platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces the lower of the two values. Refunds, reversals, and authorization expiries do not restore capacity during the day. Supported only for card programs whose authorization decisions are made by Grid. Cannot be supplied alongside `state: CLOSED`.'
+          example: 25000
     CardRevealResponse:
       type: object
       required:

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -68,6 +68,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Card-specific cap on a single transaction, in the smallest unit of the
@@ -81,6 +82,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Card-specific cap on cumulative new spend during one UTC calendar day,

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -6,6 +6,7 @@ required:
   - form
   - fundingSources
   - maxSpendPerTransaction
+  - maxSpendPerDay
   - createdAt
   - updatedAt
 properties:
@@ -75,6 +76,21 @@ properties:
       enforces the lower of the two values without replacing this configured
       value. A transaction for exactly the effective limit is allowed.
     example: 5000
+  maxSpendPerDay:
+    anyOf:
+      - type: integer
+        format: int64
+        minimum: 1
+      - type: 'null'
+    description: >-
+      Card-specific cap on cumulative new spend during one UTC calendar day,
+      in the smallest unit of the card's `currency`. The window resets at
+      00:00 UTC. Null means the card has no card-specific daily cap. When the
+      platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces
+      the lower of the two values without replacing this configured value.
+      Refunds, reversals, and authorization expiries do not restore capacity
+      during the day. Spend exactly equal to the effective limit is allowed.
+    example: 25000
   currency:
     type: string
     description: >-

--- a/openapi/components/schemas/cards/CardCreateRequest.yaml
+++ b/openapi/components/schemas/cards/CardCreateRequest.yaml
@@ -47,6 +47,7 @@ properties:
     type: integer
     format: int64
     minimum: 1
+    maximum: 9007199254740991
     description: >-
       Optional card-specific cap on a single transaction, in the smallest unit
       of the card currency derived from its funding sources. Omit this field
@@ -60,6 +61,7 @@ properties:
     type: integer
     format: int64
     minimum: 1
+    maximum: 9007199254740991
     description: >-
       Optional card-specific cap on cumulative new spend during one UTC
       calendar day, in the smallest unit of the card currency derived from its

--- a/openapi/components/schemas/cards/CardCreateRequest.yaml
+++ b/openapi/components/schemas/cards/CardCreateRequest.yaml
@@ -56,3 +56,17 @@ properties:
       are made by Grid. A transaction for exactly the effective limit is
       allowed.
     example: 5000
+  maxSpendPerDay:
+    type: integer
+    format: int64
+    minimum: 1
+    description: >-
+      Optional card-specific cap on cumulative new spend during one UTC
+      calendar day, in the smallest unit of the card currency derived from its
+      funding sources. Omit this field for no card-specific daily cap. When the
+      platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces
+      the lower of the two values. The window resets at 00:00 UTC, and refunds,
+      reversals, and authorization expiries do not restore capacity during the
+      day. Supported only for card programs whose authorization decisions are
+      made by Grid. Spend exactly equal to the effective limit is allowed.
+    example: 25000

--- a/openapi/components/schemas/cards/CardUpdateRequest.yaml
+++ b/openapi/components/schemas/cards/CardUpdateRequest.yaml
@@ -1,11 +1,13 @@
 type: object
 description: >-
   Update request for `PATCH /cards/{id}`. At least one of `state`,
-  `fundingSources`, or `maxSpendPerTransaction` must be supplied. `state`
+  `fundingSources`, `maxSpendPerTransaction`, or `maxSpendPerDay` must be
+  supplied. `state`
   transitions are limited to `ACTIVE ⇄ FROZEN` and
   `ACTIVE | FROZEN → CLOSED`; any other transition returns
   `409 INVALID_STATE_TRANSITION`. `CLOSED` is terminal and irreversible and
-  cannot be combined with `fundingSources` or `maxSpendPerTransaction`.
+  cannot be combined with `fundingSources`, `maxSpendPerTransaction`, or
+  `maxSpendPerDay`.
   `fundingSources`, when supplied, fully replaces the card's bound
   funding sources — the array order determines the priority Authorization
   Decisioning tries them in.
@@ -52,3 +54,19 @@ properties:
       whose authorization decisions are made by Grid. Cannot be supplied
       alongside `state: CLOSED`.
     example: 10000
+  maxSpendPerDay:
+    anyOf:
+      - type: integer
+        format: int64
+        minimum: 1
+      - type: 'null'
+    description: >-
+      Replacement card-specific UTC-calendar-day cap, in the smallest unit of
+      the card's currency. Omit this field to leave the current cap unchanged,
+      supply null to clear it, or supply a positive integer to set it. When the
+      platform config also supplies `cardConfigs.maxSpendPerDay`, Grid enforces
+      the lower of the two values. Refunds, reversals, and authorization
+      expiries do not restore capacity during the day. Supported only for card
+      programs whose authorization decisions are made by Grid. Cannot be
+      supplied alongside `state: CLOSED`.
+    example: 25000

--- a/openapi/components/schemas/cards/CardUpdateRequest.yaml
+++ b/openapi/components/schemas/cards/CardUpdateRequest.yaml
@@ -44,6 +44,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Replacement card-specific per-transaction cap, in the smallest unit of
@@ -59,6 +60,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Replacement card-specific UTC-calendar-day cap, in the smallest unit of

--- a/openapi/components/schemas/config/CardConfig.yaml
+++ b/openapi/components/schemas/config/CardConfig.yaml
@@ -6,6 +6,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Platform-level cap on a single transaction for every card whose
@@ -20,6 +21,7 @@ properties:
       - type: integer
         format: int64
         minimum: 1
+        maximum: 9007199254740991
       - type: 'null'
     description: >-
       Platform-level cap on cumulative new spend during one UTC calendar day

--- a/openapi/components/schemas/config/CardConfig.yaml
+++ b/openapi/components/schemas/config/CardConfig.yaml
@@ -15,3 +15,19 @@ properties:
       no platform-level cap. The cap applies to existing cards and to cards
       issued later. Provider-decided card programs are unaffected.
     example: 10000
+  maxSpendPerDay:
+    anyOf:
+      - type: integer
+        format: int64
+        minimum: 1
+      - type: 'null'
+    description: >-
+      Platform-level cap on cumulative new spend during one UTC calendar day
+      for every card whose authorization decisions are made by Grid. The value
+      is interpreted in the smallest unit of each card's currency. Grid
+      enforces the lower of this cap and the card's configured
+      `maxSpendPerDay`; null means no platform-level daily cap. The window
+      resets at 00:00 UTC. Refunds, reversals, and authorization expiries do not
+      restore capacity during the day. The cap applies to existing cards and
+      cards issued later. Provider-decided card programs are unaffected.
+    example: 50000

--- a/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
+++ b/openapi/components/schemas/config/PlatformConfigUpdateRequest.yaml
@@ -27,7 +27,7 @@ properties:
     $ref: ./CardConfig.yaml
     description: >-
       Update platform-level card settings. Fields omitted from the nested
-      object are left unchanged. For `maxSpendPerTransaction`, supply null to
+      object are left unchanged. For either spending limit, supply null to
       clear the platform cap or a positive integer to set it. Omit this field
       at the top level to leave all card settings unchanged.
   feeConfigs:

--- a/openapi/paths/cards/cards.yaml
+++ b/openapi/paths/cards/cards.yaml
@@ -7,14 +7,13 @@ post:
     with `CARDHOLDER_KYC_NOT_APPROVED`.
 
 
-    An optional `maxSpendPerTransaction` value sets the card-specific cap on a
-    single transaction. The limit is enforced by Grid for card programs where
-    Grid makes the authorization decision, whether the card is funded by an
-    Embedded Wallet account or custodial fiat. Omit it for no card-specific
-    cap. If the platform config sets
-    `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card
-    and platform values. Both values use the smallest unit of the card's
-    currency.
+    Optional `maxSpendPerTransaction` and `maxSpendPerDay` values set the
+    card-specific caps on one transaction and one UTC calendar day. The limits
+    are enforced by Grid for card programs where Grid makes the authorization
+    decision, whether the card is funded by an Embedded Wallet account or
+    custodial fiat. If the platform config sets the corresponding
+    `cardConfigs` value, Grid enforces the lower of the card and platform caps.
+    All values use the smallest unit of the card's currency.
 
 
     If any funding source is an Embedded Wallet internal account, the
@@ -50,6 +49,7 @@ post:
               fundingSources:
                 - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
               maxSpendPerTransaction: 5000
+              maxSpendPerDay: 25000
   responses:
     '201':
       description: >-

--- a/openapi/paths/cards/cards_{id}.yaml
+++ b/openapi/paths/cards/cards_{id}.yaml
@@ -55,7 +55,8 @@ patch:
   summary: Update a card
   description: >
     Update a card's `state`, bound `fundingSources`, and / or
-    `maxSpendPerTransaction`. At least one field must be supplied.
+    `maxSpendPerTransaction`, or `maxSpendPerDay`. At least one field must be
+    supplied.
 
 
     - `state` transitions are limited to `ACTIVE ⇄ FROZEN` and
@@ -75,6 +76,14 @@ patch:
     `cardConfigs.maxSpendPerTransaction`, Grid enforces the lower of the card
     and platform values. Limits are supported only for card programs where
     Grid makes the authorization decision. `maxSpendPerTransaction` cannot be
+    supplied alongside `state: CLOSED`.
+
+    - `maxSpendPerDay`, when supplied, replaces the card-specific cap on
+    cumulative new spend during one UTC calendar day. Supply a positive integer
+    in the smallest unit of the card's currency to set it or null to clear it.
+    If the platform config sets `cardConfigs.maxSpendPerDay`, Grid enforces the
+    lower of the card and platform values. Refunds, reversals, and authorization
+    expiries do not restore capacity during the day. `maxSpendPerDay` cannot be
     supplied alongside `state: CLOSED`.
 
 
@@ -147,10 +156,12 @@ patch:
             summary: Set the card's per-transaction spending limit
             value:
               maxSpendPerTransaction: 10000
+              maxSpendPerDay: 25000
           clearSpendingLimit:
-            summary: Remove the card's per-transaction spending limit
+            summary: Remove the card's spending limits
             value:
               maxSpendPerTransaction: null
+              maxSpendPerDay: null
           freezeAndUpdateSources:
             summary: Freeze the card and replace its funding sources in one call
             value:

--- a/openapi/paths/platform/config.yaml
+++ b/openapi/paths/platform/config.yaml
@@ -28,10 +28,11 @@ get:
 patch:
   summary: Update platform configuration
   description: >-
-    Update platform configuration settings. Setting
-    `cardConfigs.maxSpendPerTransaction` establishes a platform-level card
-    cap; Grid enforces the lower of that cap and each card's configured
-    `maxSpendPerTransaction` without replacing the card-specific value.
+    Update platform configuration settings. `cardConfigs` can establish
+    platform-level per-transaction and UTC-calendar-day card caps. Grid
+    enforces the lower of each platform cap and its corresponding card-specific
+    value without replacing the card-specific value. Daily limits reset at
+    00:00 UTC.
   operationId: updatePlatformConfig
   tags:
     - Platform Configuration
@@ -80,6 +81,7 @@ patch:
               bodyText: Use this code to finish adding your Acme card to your digital wallet.
           cardConfigs:
             maxSpendPerTransaction: 10000
+            maxSpendPerDay: 50000
   responses:
     '200':
       description: Configuration updated successfully

--- a/openapi/webhooks/card-funding-source-change.yaml
+++ b/openapi/webhooks/card-funding-source-change.yaml
@@ -61,6 +61,7 @@ post:
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000003
                 maxSpendPerTransaction: null
+                maxSpendPerDay: null
                 currency: USD
                 createdAt: '2026-05-08T14:10:00Z'
                 updatedAt: '2026-05-08T14:30:00Z'

--- a/openapi/webhooks/card-state-change.yaml
+++ b/openapi/webhooks/card-state-change.yaml
@@ -61,6 +61,7 @@ post:
                 fundingSources:
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 maxSpendPerTransaction: 5000
+                maxSpendPerDay: 25000
                 currency: USD
                 processorRef: card_b81c2a4f
                 issuerRef: lead_card_7a1b9c3d
@@ -81,6 +82,7 @@ post:
                 fundingSources:
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 maxSpendPerTransaction: null
+                maxSpendPerDay: null
                 currency: USD
                 createdAt: '2026-05-08T14:10:00Z'
                 updatedAt: '2026-05-08T14:12:00Z'
@@ -103,6 +105,7 @@ post:
                 fundingSources:
                   - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
                 maxSpendPerTransaction: 5000
+                maxSpendPerDay: 25000
                 currency: USD
                 createdAt: '2026-05-08T14:10:00Z'
                 updatedAt: '2026-05-09T09:00:00Z'


### PR DESCRIPTION
Cards can cap individual authorizations but cannot bound cumulative spend across a day. This contract adds card- and platform-level `maxSpendPerDay` controls with the lower configured value taking precedence.

Daily windows reset at 00:00 UTC. Refunds, reversals, and authorization expiries do not restore capacity during the same day, keeping the limit deterministic for integrators.

The card-management guide documents limit updates as direct BasicAuth `PATCH /cards/{id}` requests returning `200 OK`, matching the endpoint contract.

## Test Plan

- `make lint-openapi` — passed with existing warnings and no errors
- `git diff --check`

---
created with claude session 4488e661-03aa-4894-8387-647fcee1344e
