### PR TITLE
feat(external-accounts): require bankAccountType on USD account creation

### DIFF
--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -42,7 +42,7 @@ The **Available Rails** column lists the payment rails Grid may use for the crea
 | UAE | AED_ACCOUNT | AED | BANK_TRANSFER | IBAN |
 | Uganda | UGX_ACCOUNT | UGX | MOBILE_MONEY | Phone number + Provider |
 | United Kingdom | GBP_ACCOUNT | GBP | FASTER_PAYMENTS | Sort code + Account number |
-| United States | USD_ACCOUNT | USD | ACH, WIRE, RTP, FEDNOW | Routing number + Account number |
+| United States | USD_ACCOUNT | USD | ACH, WIRE, RTP, FEDNOW | Routing number + Account number + Account type |
 | Vietnam | VND_ACCOUNT | VND | BANK_TRANSFER | Bank name + SWIFT + Account number |
 | West Africa (CFA) | XOF_ACCOUNT | XOF | MOBILE_MONEY | Phone number + Provider + Region |
 | Zambia | ZMW_ACCOUNT | ZMW | MOBILE_MONEY | Phone number + Provider |
@@ -290,6 +290,7 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       "accountType": "USD_ACCOUNT",
       "routingNumber": "123456789",
       "accountNumber": "12345678901",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Full Name",
@@ -312,6 +313,7 @@ Required fields:
 
 - `routingNumber`: 9-digit ABA routing number
 - `accountNumber`: Bank account number
+- `bankAccountType`: `CHECKING` or `SAVINGS`
 
 ### India (INR_ACCOUNT)
 

--- a/.claude/skills/grid-api/references/workflows.md
+++ b/.claude/skills/grid-api/references/workflows.md
@@ -297,6 +297,7 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
       "accountType": "USD_ACCOUNT",
       "routingNumber": "123456789",
       "accountNumber": "12345678901",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "John Doe",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,10 @@ jobs:
       
       - name: Lint
         run: make lint
+
+      # bankAccountFields.generated.ts is generated from openapi/; fail if it drifts.
+      - name: Verify generated wallet bank fields
+        run: |
+          for app in components/grid-wallet-demo components/grid-wallet-prod; do
+            (cd "$app" && npm run verify:bank-fields)
+          done

--- a/cli/README.md
+++ b/cli/README.md
@@ -164,6 +164,7 @@ grid accounts external create \
   --account-type USD_ACCOUNT \
   --account-number "123456789" \
   --routing-number "021000021" \
+  --bank-account-type CHECKING \
   --beneficiary-type INDIVIDUAL \
   --beneficiary-name "John Doe"
 

--- a/cli/src/commands/accounts.ts
+++ b/cli/src/commands/accounts.ts
@@ -162,6 +162,10 @@ export function registerAccountsCommand(
     )
     .option("--account-number <number>", "Bank account number")
     .option("--routing-number <number>", "ABA routing number (USD)")
+    .option(
+      "--bank-account-type <type>",
+      "CHECKING or SAVINGS (required for USD_ACCOUNT)"
+    )
     .option("--clabe <number>", "CLABE number (MXN)")
     .option("--pix-key <key>", "PIX key (BRL)")
     .option("--pix-key-type <type>", "PIX key type: CPF, CNPJ, EMAIL, PHONE, RANDOM (BRL)")
@@ -202,6 +206,9 @@ export function registerAccountsCommand(
       if (options.beneficiaryBirthDate) {
         validations.push(validateDate(options.beneficiaryBirthDate, "beneficiary-birth-date"));
       }
+      if (options.bankAccountType) {
+        validations.push(validateBankAccountType(options.bankAccountType));
+      }
       const validation = validateAll(validations);
       if (!validation.valid) {
         output(formatError(validation.error!));
@@ -217,6 +224,7 @@ export function registerAccountsCommand(
       };
       setInfo("accountNumber", options.accountNumber);
       setInfo("routingNumber", options.routingNumber);
+      setInfo("bankAccountType", options.bankAccountType);
       setInfo("clabeNumber", options.clabe);
       setInfo("pixKey", options.pixKey);
       setInfo("pixKeyType", options.pixKeyType);
@@ -244,6 +252,16 @@ export function registerAccountsCommand(
         return;
       }
 
+      if (options.accountType === "USD_ACCOUNT" && !options.bankAccountType) {
+        output(
+          formatError(
+            "--bank-account-type is required for USD_ACCOUNT. Pass CHECKING or SAVINGS."
+          )
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const body: Record<string, unknown> = {
         customerId: options.customerId,
         currency: options.currency,
@@ -260,6 +278,18 @@ export function registerAccountsCommand(
       );
       outputResponse(response);
     });
+}
+
+const VALID_BANK_ACCOUNT_TYPES = new Set(["CHECKING", "SAVINGS"]);
+
+function validateBankAccountType(value: string): ValidationResult {
+  if (!VALID_BANK_ACCOUNT_TYPES.has(value)) {
+    return {
+      valid: false,
+      error: `--bank-account-type must be CHECKING or SAVINGS (got: ${value})`,
+    };
+  }
+  return { valid: true };
 }
 
 function isFiatAccountType(accountType: string): boolean {

--- a/cli/test/accounts.test.ts
+++ b/cli/test/accounts.test.ts
@@ -38,6 +38,8 @@ describe("accounts external create — beneficiary gating", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
       "--beneficiary-type",
       "BUSINESS",
       "--beneficiary-name",
@@ -75,6 +77,8 @@ describe("accounts external create — beneficiary gating", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
       "--beneficiary-type",
       "INDIVIDUAL",
       "--beneficiary-name",
@@ -103,6 +107,8 @@ describe("accounts external create", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
       "--beneficiary-type",
       "INDIVIDUAL",
       "--beneficiary-name",
@@ -118,6 +124,7 @@ describe("accounts external create", () => {
         accountType: "USD_ACCOUNT",
         accountNumber: "1234567890",
         routingNumber: "021000021",
+        bankAccountType: "CHECKING",
         beneficiary: { beneficiaryType: "INDIVIDUAL", fullName: "Ada Lovelace" },
       },
     });
@@ -138,6 +145,8 @@ describe("accounts external create", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
     ]);
 
     expect(calls).toBe(0);
@@ -159,6 +168,8 @@ describe("accounts external create", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
       "--beneficiary-type",
       "INDIVIDUAL",
       // --beneficiary-name omitted
@@ -182,6 +193,8 @@ describe("accounts external create", () => {
       "1234567890",
       "--routing-number",
       "021000021",
+      "--bank-account-type",
+      "CHECKING",
       "--beneficiary-type",
       "INDIVIDUAL",
       "--beneficiary-name",
@@ -195,6 +208,85 @@ describe("accounts external create", () => {
       platformAccountId: "ext_acc_1",
       defaultUmaDepositAccount: true,
     });
+  });
+
+  it("sends SAVINGS through so the ACH transaction code matches the account", async () => {
+    const { request } = await runCli([
+      "accounts",
+      "external",
+      "create",
+      "--customer-id",
+      "Customer:abc",
+      "--currency",
+      "USD",
+      "--account-type",
+      "USD_ACCOUNT",
+      "--account-number",
+      "1234567890",
+      "--routing-number",
+      "021000021",
+      "--bank-account-type",
+      "SAVINGS",
+      "--beneficiary-type",
+      "INDIVIDUAL",
+      "--beneficiary-name",
+      "Ada Lovelace",
+    ]);
+
+    expect(request?.body).toMatchObject({
+      accountInfo: { accountType: "USD_ACCOUNT", bankAccountType: "SAVINGS" },
+    });
+  });
+
+  it("does not send a request when USD_ACCOUNT omits bankAccountType", async () => {
+    const { request, calls } = await runCli([
+      "accounts",
+      "external",
+      "create",
+      "--customer-id",
+      "Customer:abc",
+      "--currency",
+      "USD",
+      "--account-type",
+      "USD_ACCOUNT",
+      "--account-number",
+      "1234567890",
+      "--routing-number",
+      "021000021",
+      "--beneficiary-type",
+      "INDIVIDUAL",
+      "--beneficiary-name",
+      "Ada Lovelace",
+    ]);
+
+    expect(calls).toBe(0);
+    expect(request).toBeNull();
+  });
+
+  it("rejects a bankAccountType outside CHECKING and SAVINGS", async () => {
+    const { calls } = await runCli([
+      "accounts",
+      "external",
+      "create",
+      "--customer-id",
+      "Customer:abc",
+      "--currency",
+      "USD",
+      "--account-type",
+      "USD_ACCOUNT",
+      "--account-number",
+      "1234567890",
+      "--routing-number",
+      "021000021",
+      "--bank-account-type",
+      "MONEY_MARKET",
+      "--beneficiary-type",
+      "INDIVIDUAL",
+      "--beneficiary-name",
+      "Ada Lovelace",
+    ]);
+
+    expect(calls).toBe(0);
   });
 });
 

--- a/components/grid-visualizer/src/data/account-types.ts
+++ b/components/grid-visualizer/src/data/account-types.ts
@@ -16,6 +16,7 @@ export const accountTypeSpecs: Record<string, AccountTypeSpec> = {
     fields: [
       { name: 'accountNumber', example: '123456789' },
       { name: 'routingNumber', example: '021000021' },
+      { name: 'bankAccountType', example: 'CHECKING', description: 'CHECKING or SAVINGS' },
     ],
     beneficiaryRequired: true,
   },

--- a/components/grid-wallet-demo/scripts/generate-bank-fields.mjs
+++ b/components/grid-wallet-demo/scripts/generate-bank-fields.mjs
@@ -29,6 +29,7 @@ const CRYPTO = new Set([
   'POLYGON_WALLET',
   'BASE_WALLET',
   'ETHEREUM_WALLET',
+  'PLASMA_WALLET',
 ]);
 
 // Handled by the POST builder, not shown as editable account fields:

--- a/components/grid-wallet-demo/src/data/bankAccountFields.generated.ts
+++ b/components/grid-wallet-demo/src/data/bankAccountFields.generated.ts
@@ -460,6 +460,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         ],
         "description": "The bank account type",
         "example": "CHECKING"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the beneficiary's bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -557,19 +566,82 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
       }
     ]
   },
+  "ILS_ACCOUNT": {
+    "accountType": "ILS_ACCOUNT",
+    "currency": "ILS",
+    "fields": [
+      {
+        "key": "iban",
+        "required": true,
+        "kind": "text",
+        "pattern": "^IL[0-9]{21}$",
+        "minLength": 23,
+        "maxLength": 23,
+        "description": "Israeli IBAN (23 characters, starting with IL)",
+        "example": "IL620108000000099999999"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
+      }
+    ]
+  },
   "INR_ACCOUNT": {
     "accountType": "INR_ACCOUNT",
     "currency": "INR",
     "fields": [
       {
         "key": "vpa",
-        "required": true,
+        "required": false,
         "kind": "text",
         "pattern": "^[a-zA-Z0-9.\\-_]+@[a-zA-Z0-9]+$",
         "minLength": 3,
         "maxLength": 255,
         "description": "The UPI Virtual Payment Address",
         "example": "user@upi"
+      },
+      {
+        "key": "accountNumber",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[0-9]{9,18}$",
+        "minLength": 9,
+        "maxLength": 18,
+        "description": "Indian bank account number (9–18 digits)",
+        "example": "000111222333"
+      },
+      {
+        "key": "ifsc",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[A-Z]{4}0[A-Z0-9]{6}$",
+        "minLength": 11,
+        "maxLength": 11,
+        "description": "The Indian Financial System Code (IFSC) of the beneficiary's bank branch (NEFT/RTGS)",
+        "example": "HDFC0001234"
+      },
+      {
+        "key": "rail",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 32,
+        "description": "The payment rail to route the payout over: NEFT or RTGS. Omitted, the payout resolves it by amount.",
+        "example": "NEFT"
+      },
+      {
+        "key": "bankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -606,6 +678,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         ],
         "description": "The bank account type",
         "example": "CHECKING"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -738,6 +819,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
     "accountType": "PHP_ACCOUNT",
     "currency": "PHP",
     "fields": [
+      {
+        "key": "rail",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 32,
+        "description": "The payment rail to route the payout over: INSTAPAY or PESONET. Omitted, the payout resolves it by amount.",
+        "example": "INSTAPAY"
+      },
       {
         "key": "bankName",
         "required": true,
@@ -1067,6 +1157,53 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         "maxLength": 9,
         "description": "The ABA routing number",
         "example": "021000021"
+      },
+      {
+        "key": "bankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 140,
+        "description": "The name of the financial institution holding the account. Optional on every rail, and recommended for wires, where it identifies the beneficiary's institution on the payment message.",
+        "example": "Chase Bank"
+      },
+      {
+        "key": "bankAccountType",
+        "required": true,
+        "kind": "select",
+        "enum": [
+          "CHECKING",
+          "SAVINGS"
+        ],
+        "description": "Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.",
+        "example": "CHECKING"
+      },
+      {
+        "key": "intermediaryBankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 140,
+        "description": "The name of the intermediary financial institution, for accounts reachable only through a correspondent bank. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "JPMorgan Chase Bank"
+      },
+      {
+        "key": "intermediaryRoutingNumber",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[0-9]{9}$",
+        "minLength": 9,
+        "maxLength": 9,
+        "description": "The ABA routing number of the intermediary financial institution. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "021000021"
+      },
+      {
+        "key": "fiToFiInformation",
+        "required": false,
+        "kind": "text",
+        "maxLength": 210,
+        "description": "Bank-to-bank instructions carried alongside the payment. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "/BNF/Invoice 4471"
       }
     ]
   },

--- a/components/grid-wallet-prod/scripts/generate-bank-fields.mjs
+++ b/components/grid-wallet-prod/scripts/generate-bank-fields.mjs
@@ -29,6 +29,7 @@ const CRYPTO = new Set([
   'POLYGON_WALLET',
   'BASE_WALLET',
   'ETHEREUM_WALLET',
+  'PLASMA_WALLET',
 ]);
 
 // Handled by the POST builder, not shown as editable account fields:

--- a/components/grid-wallet-prod/src/data/bankAccountFields.generated.ts
+++ b/components/grid-wallet-prod/src/data/bankAccountFields.generated.ts
@@ -460,6 +460,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         ],
         "description": "The bank account type",
         "example": "CHECKING"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the beneficiary's bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -557,19 +566,82 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
       }
     ]
   },
+  "ILS_ACCOUNT": {
+    "accountType": "ILS_ACCOUNT",
+    "currency": "ILS",
+    "fields": [
+      {
+        "key": "iban",
+        "required": true,
+        "kind": "text",
+        "pattern": "^IL[0-9]{21}$",
+        "minLength": 23,
+        "maxLength": 23,
+        "description": "Israeli IBAN (23 characters, starting with IL)",
+        "example": "IL620108000000099999999"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
+      }
+    ]
+  },
   "INR_ACCOUNT": {
     "accountType": "INR_ACCOUNT",
     "currency": "INR",
     "fields": [
       {
         "key": "vpa",
-        "required": true,
+        "required": false,
         "kind": "text",
         "pattern": "^[a-zA-Z0-9.\\-_]+@[a-zA-Z0-9]+$",
         "minLength": 3,
         "maxLength": 255,
         "description": "The UPI Virtual Payment Address",
         "example": "user@upi"
+      },
+      {
+        "key": "accountNumber",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[0-9]{9,18}$",
+        "minLength": 9,
+        "maxLength": 18,
+        "description": "Indian bank account number (9–18 digits)",
+        "example": "000111222333"
+      },
+      {
+        "key": "ifsc",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[A-Z]{4}0[A-Z0-9]{6}$",
+        "minLength": 11,
+        "maxLength": 11,
+        "description": "The Indian Financial System Code (IFSC) of the beneficiary's bank branch (NEFT/RTGS)",
+        "example": "HDFC0001234"
+      },
+      {
+        "key": "rail",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 32,
+        "description": "The payment rail to route the payout over: NEFT or RTGS. Omitted, the payout resolves it by amount.",
+        "example": "NEFT"
+      },
+      {
+        "key": "bankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -606,6 +678,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         ],
         "description": "The bank account type",
         "example": "CHECKING"
+      },
+      {
+        "key": "bankName",
+        "required": true,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 255,
+        "description": "The name of the bank",
+        "example": "Example Bank"
       }
     ]
   },
@@ -738,6 +819,15 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
     "accountType": "PHP_ACCOUNT",
     "currency": "PHP",
     "fields": [
+      {
+        "key": "rail",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 32,
+        "description": "The payment rail to route the payout over: INSTAPAY or PESONET. Omitted, the payout resolves it by amount.",
+        "example": "INSTAPAY"
+      },
       {
         "key": "bankName",
         "required": true,
@@ -1067,6 +1157,53 @@ export const BANK_ACCOUNT_SCHEMAS: Record<string, BankAccountSchema> = {
         "maxLength": 9,
         "description": "The ABA routing number",
         "example": "021000021"
+      },
+      {
+        "key": "bankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 140,
+        "description": "The name of the financial institution holding the account. Optional on every rail, and recommended for wires, where it identifies the beneficiary's institution on the payment message.",
+        "example": "Chase Bank"
+      },
+      {
+        "key": "bankAccountType",
+        "required": true,
+        "kind": "select",
+        "enum": [
+          "CHECKING",
+          "SAVINGS"
+        ],
+        "description": "Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.",
+        "example": "CHECKING"
+      },
+      {
+        "key": "intermediaryBankName",
+        "required": false,
+        "kind": "text",
+        "minLength": 1,
+        "maxLength": 140,
+        "description": "The name of the intermediary financial institution, for accounts reachable only through a correspondent bank. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "JPMorgan Chase Bank"
+      },
+      {
+        "key": "intermediaryRoutingNumber",
+        "required": false,
+        "kind": "text",
+        "pattern": "^[0-9]{9}$",
+        "minLength": 9,
+        "maxLength": 9,
+        "description": "The ABA routing number of the intermediary financial institution. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "021000021"
+      },
+      {
+        "key": "fiToFiInformation",
+        "required": false,
+        "kind": "text",
+        "maxLength": 210,
+        "description": "Bank-to-bank instructions carried alongside the payment. Used on the WIRE rail; ignored on ACH, RTP and FEDNOW.",
+        "example": "/BNF/Invoice 4471"
       }
     ]
   },

--- a/mintlify/changelog.mdx
+++ b/mintlify/changelog.mdx
@@ -11,6 +11,19 @@ changes and roadmap, [book a live demo](https://www.lightspark.com/contact) or
 
 <Update label="August 2026">
 
+## `bankAccountType` is required on USD external accounts
+
+Creating an external account with `accountType: USD_ACCOUNT` now requires
+`bankAccountType`. Send `CHECKING` or `SAVINGS` on `POST /customers/external-accounts`,
+`POST /platform/external-accounts`, and `POST /agents/me/external-accounts`.
+
+- Grid uses `bankAccountType` to set the ACH transaction code. Accounts created without
+  it were sent as checking, and the receiving bank returned a notification of change to
+  correct savings accounts.
+- External accounts created before this change are unaffected.
+
+See [External accounts](/ramps/accounts/external-accounts) for a full request body.
+
 ## `/transfer-in` and `/transfer-out` are deprecated
 
 Same-currency transfers now go through the quote endpoint, so one integration covers

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14766,7 +14766,7 @@ components:
           example: Chase Bank
         bankAccountType:
           type: string
-          description: Whether the account is a checking or a savings account. Optional on every rail; when omitted, the account is treated as a checking account.
+          description: Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.
           enum:
             - CHECKING
             - SAVINGS
@@ -21560,8 +21560,16 @@ components:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
         - type: object
           required:
+            - bankAccountType
             - beneficiary
           properties:
+            bankAccountType:
+              type: string
+              description: Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.
+              enum:
+                - CHECKING
+                - SAVINGS
+              example: CHECKING
             beneficiary:
               oneOf:
                 - title: Individual Beneficiary

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -77,7 +77,9 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
 ```
 
 <Note>
-  Category must be `CHECKING` or `SAVINGS`. Routing number must be 9 digits.
+  `bankAccountType` is required and must be `CHECKING` or `SAVINGS`. Grid uses it to set the
+  ACH transaction code, so a value that does not match the account causes the receiving bank
+  to return a notification of change. `routingNumber` must be 9 digits.
 </Note>
 
 <Note>

--- a/mintlify/snippets/global-accounts/walkthrough.mdx
+++ b/mintlify/snippets/global-accounts/walkthrough.mdx
@@ -153,6 +153,7 @@ curl -X POST "$GRID_BASE_URL/customers/external-accounts" \
       "accountType": "USD_ACCOUNT",
       "accountNumber": "1234567890",
       "routingNumber": "021000021",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Jane Doe",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14766,7 +14766,7 @@ components:
           example: Chase Bank
         bankAccountType:
           type: string
-          description: Whether the account is a checking or a savings account. Optional on every rail; when omitted, the account is treated as a checking account.
+          description: Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.
           enum:
             - CHECKING
             - SAVINGS
@@ -21560,8 +21560,16 @@ components:
         - $ref: '#/components/schemas/UsdAccountInfoBase'
         - type: object
           required:
+            - bankAccountType
             - beneficiary
           properties:
+            bankAccountType:
+              type: string
+              description: Whether the account is a checking or a savings account. Grid uses this to set the ACH transaction code, so a value that does not match the account causes the receiving bank to return a notification of change.
+              enum:
+                - CHECKING
+                - SAVINGS
+              example: CHECKING
             beneficiary:
               oneOf:
                 - title: Individual Beneficiary

--- a/openapi/components/schemas/common/UsdAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/UsdAccountInfoBase.yaml
@@ -30,8 +30,9 @@ properties:
     example: Chase Bank
   bankAccountType:
     type: string
-    description: Whether the account is a checking or a savings account. Optional
-      on every rail; when omitted, the account is treated as a checking account.
+    description: Whether the account is a checking or a savings account. Grid uses
+      this to set the ACH transaction code, so a value that does not match the account
+      causes the receiving bank to return a notification of change.
     enum:
     - CHECKING
     - SAVINGS

--- a/openapi/components/schemas/external_accounts/UsdExternalAccountCreateInfo.yaml
+++ b/openapi/components/schemas/external_accounts/UsdExternalAccountCreateInfo.yaml
@@ -4,8 +4,21 @@ allOf:
 - $ref: ../common/UsdAccountInfoBase.yaml
 - type: object
   required:
+  - bankAccountType
   - beneficiary
   properties:
+    # Inlined, not a shared $ref: the required-property lint rule only counts a
+    # property defined in this branch, and a component would rename the SDK enum.
+    bankAccountType:
+      type: string
+      description: >-
+        Whether the account is a checking or a savings account. Grid uses this to
+        set the ACH transaction code, so a value that does not match the account
+        causes the receiving bank to return a notification of change.
+      enum:
+      - CHECKING
+      - SAVINGS
+      example: CHECKING
     beneficiary:
       oneOf:
       - title: Individual Beneficiary

--- a/samples/frontend/src/steps/CreateExternalAccount.tsx
+++ b/samples/frontend/src/steps/CreateExternalAccount.tsx
@@ -126,6 +126,7 @@ const COUNTRY_CONFIGS: Record<string, {
       accountType: "USD_ACCOUNT",
       accountNumber: "1234567890",
       routingNumber: "021000021",
+      bankAccountType: "CHECKING",
       paymentRails: ["ACH"]
     },
     beneficiary: {

--- a/samples/kotlin/src/main/kotlin/com/grid/sample/routes/ExternalAccounts.kt
+++ b/samples/kotlin/src/main/kotlin/com/grid/sample/routes/ExternalAccounts.kt
@@ -110,6 +110,11 @@ private fun buildAccountInfo(accountType: String, accountInfo: JsonNode): Extern
                 .accountType(UsdExternalAccountCreateInfo.AccountType.USD_ACCOUNT)
                 .accountNumber(accountInfo.requireText("accountNumber"))
                 .routingNumber(accountInfo.requireText("routingNumber"))
+                .bankAccountType(
+                    UsdExternalAccountCreateInfo.BankAccountType.of(
+                        accountInfo.requireText("bankAccountType"),
+                    ),
+                )
                 .beneficiary(buildUsdBeneficiary(beneficiaryNode))
                 .build()
             ExternalAccountCreate.AccountInfo.ofUsdAccount(info)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,6 +110,7 @@ g -X POST -H 'Content-Type: application/json' \
       "paymentRails": ["RTP"],
       "routingNumber": "121042882",
       "accountNumber": "0000000000",
+      "bankAccountType": "CHECKING",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Alice Example",


### PR DESCRIPTION
bankAccountType was optional on USD_ACCOUNT external account creation and
omitted values were treated as checking. Grid then sent ACH transaction code 22
instead of 32 for savings accounts, and the receiving bank returned a C05
notification of change. In the month to 2026-08-10, 13 of 18 notifications of
change corrected the account type, all on accounts created without the field.

- Add bankAccountType to the required list on UsdExternalAccountCreateInfo, so
  it is required on POST /customers/external-accounts,
  POST /platform/external-accounts, and POST /agents/me/external-accounts. The
  read and payment-instruction schemas keep it optional.
- Inline the CHECKING/SAVINGS enum on the create and base schemas instead of a
  shared UsdBankAccountType component: the required-property lint rule only
  recognizes a property defined in the same branch as the required list, and a
  named component would rename the enum the SDK generators emit.
- Update the CLI (grid accounts external create --bank-account-type), samples,
  wallet demos, skill references, and the external accounts docs; add a
  changelog entry.
- Regenerate the wallet demo bank fields and add a CI step that verifies they
  stay in sync with the spec. This surfaced a pre-existing drift, so also add
  the crypto-only PLASMA_WALLET to the wallet demos' excluded account types.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>