### PR TITLE
feat(spec): add stablecoin Grid enablement request endpoint

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9694,6 +9694,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /stablecoins/{stablecoinId}/request-grid-enablement:
+    parameters:
+      - name: stablecoinId
+        in: path
+        description: System-generated stablecoin identifier
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Request Grid enablement for a stablecoin
+      description: |
+        Ask Lightspark to approve a registered stablecoin as a Grid settlement currency. Grid enablement is a reviewed workflow rather than a self-service switch, so this endpoint only records the request: it moves `gridOperationsStatus` from `NOT_ENABLED` to `PENDING_APPROVAL` and returns the updated stablecoin. Lightspark drives the remaining `ENABLING` and `ENABLED` steps.
+
+        The request is idempotent. Repeating it while the stablecoin is already `PENDING_APPROVAL` succeeds and changes nothing. A stablecoin in any other Grid operations status cannot be requested, and returns `409`.
+      operationId: requestStablecoinGridEnablement
+      tags:
+        - Stablecoins
+      security:
+        - BasicAuth: []
+      responses:
+        '200':
+          description: Grid enablement requested
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stablecoin'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden. The caller may not request Grid enablement for this stablecoin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Stablecoin not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: The stablecoin is not in a Grid operations status that can be requested for enablement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /stablecoins/{stablecoinId}/mints:
     parameters:
       - name: stablecoinId
@@ -13722,6 +13778,7 @@ components:
             | INVALID_STATE_TRANSITION | The requested card `state` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
             | CARD_ALREADY_CLOSED | `state: CLOSED` was requested for a card that is already `CLOSED` |
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
+            | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -13735,6 +13792,7 @@ components:
             - INVALID_STATE_TRANSITION
             - CARD_ALREADY_CLOSED
             - CARD_NOT_MUTABLE
+            - STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE
             - CONFLICT
         message:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9694,6 +9694,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /stablecoins/{stablecoinId}/request-grid-enablement:
+    parameters:
+      - name: stablecoinId
+        in: path
+        description: System-generated stablecoin identifier
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Request Grid enablement for a stablecoin
+      description: |
+        Ask Lightspark to approve a registered stablecoin as a Grid settlement currency. Grid enablement is a reviewed workflow rather than a self-service switch, so this endpoint only records the request: it moves `gridOperationsStatus` from `NOT_ENABLED` to `PENDING_APPROVAL` and returns the updated stablecoin. Lightspark drives the remaining `ENABLING` and `ENABLED` steps.
+
+        The request is idempotent. Repeating it while the stablecoin is already `PENDING_APPROVAL` succeeds and changes nothing. A stablecoin in any other Grid operations status cannot be requested, and returns `409`.
+      operationId: requestStablecoinGridEnablement
+      tags:
+        - Stablecoins
+      security:
+        - BasicAuth: []
+      responses:
+        '200':
+          description: Grid enablement requested
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stablecoin'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden. The caller may not request Grid enablement for this stablecoin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Stablecoin not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '409':
+          description: The stablecoin is not in a Grid operations status that can be requested for enablement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /stablecoins/{stablecoinId}/mints:
     parameters:
       - name: stablecoinId
@@ -13722,6 +13778,7 @@ components:
             | INVALID_STATE_TRANSITION | The requested card `state` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
             | CARD_ALREADY_CLOSED | `state: CLOSED` was requested for a card that is already `CLOSED` |
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
+            | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -13735,6 +13792,7 @@ components:
             - INVALID_STATE_TRANSITION
             - CARD_ALREADY_CLOSED
             - CARD_NOT_MUTABLE
+            - STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE
             - CONFLICT
         message:
           type: string

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -25,6 +25,7 @@ properties:
       | INVALID_STATE_TRANSITION | The requested card `state` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
       | CARD_ALREADY_CLOSED | `state: CLOSED` was requested for a card that is already `CLOSED` |
       | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
+      | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -38,6 +39,7 @@ properties:
       - INVALID_STATE_TRANSITION
       - CARD_ALREADY_CLOSED
       - CARD_NOT_MUTABLE
+      - STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE
       - CONFLICT
   message:
     type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -370,6 +370,8 @@ paths:
     $ref: paths/stablecoins/stablecoins.yaml
   /stablecoins/{stablecoinId}:
     $ref: paths/stablecoins/stablecoins_{stablecoinId}.yaml
+  /stablecoins/{stablecoinId}/request-grid-enablement:
+    $ref: paths/stablecoins/stablecoins_{stablecoinId}_request-grid-enablement.yaml
   /stablecoins/{stablecoinId}/mints:
     $ref: paths/stablecoins/stablecoins_{stablecoinId}_mints.yaml
   /stablecoins/{stablecoinId}/burns:

--- a/openapi/paths/stablecoins/stablecoins_{stablecoinId}_request-grid-enablement.yaml
+++ b/openapi/paths/stablecoins/stablecoins_{stablecoinId}_request-grid-enablement.yaml
@@ -1,0 +1,55 @@
+parameters:
+  - name: stablecoinId
+    in: path
+    description: System-generated stablecoin identifier
+    required: true
+    schema:
+      type: string
+post:
+  summary: Request Grid enablement for a stablecoin
+  description: |
+    Ask Lightspark to approve a registered stablecoin as a Grid settlement currency. Grid enablement is a reviewed workflow rather than a self-service switch, so this endpoint only records the request: it moves `gridOperationsStatus` from `NOT_ENABLED` to `PENDING_APPROVAL` and returns the updated stablecoin. Lightspark drives the remaining `ENABLING` and `ENABLED` steps.
+
+    The request is idempotent. Repeating it while the stablecoin is already `PENDING_APPROVAL` succeeds and changes nothing. A stablecoin in any other Grid operations status cannot be requested, and returns `409`.
+  operationId: requestStablecoinGridEnablement
+  tags:
+    - Stablecoins
+  security:
+    - BasicAuth: []
+  responses:
+    '200':
+      description: Grid enablement requested
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/stablecoins/Stablecoin.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error401.yaml
+    '403':
+      description: Forbidden. The caller may not request Grid enablement for this stablecoin.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error403.yaml
+    '404':
+      description: Stablecoin not found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: The stablecoin is not in a Grid operations status that can be requested for enablement.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
## MERGES LAST - keep this PR in draft

This spec change must NOT be merged until webdev PR #34100 has landed and the
feature is launch-ready. `grid-api` main feeds the nightly docs sync and the
Stainless public docs/SDKs, so merging early would publish an endpoint that
does not exist yet. Leave it as a draft until then.

## What

Adds `POST /stablecoins/{stablecoinId}/request-grid-enablement`, matching the
endpoint added in webdev #34100.

The endpoint is how a platform asks Lightspark to approve a registered
stablecoin as a Grid settlement currency. It records the request only: it moves
`gridOperationsStatus` from `NOT_ENABLED` to `PENDING_APPROVAL` and returns the
updated `Stablecoin`. Lightspark drives the remaining `ENABLING` and `ENABLED`
steps.

- No request body, and no `Idempotency-Key` header. The call carries no payload
  to disagree about, so a repeat request while the stablecoin is already
  `PENDING_APPROVAL` is an idempotent `200` that changes nothing.
- `ENABLING`, `ENABLED` and `DISABLED` belong to the Lightspark-driven
  workflow and are refused with `409`
  `STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE`, so a stale request cannot walk
  an in-flight or live token backwards.
- `403` when the caller does not own the stablecoin, `404` when it does not
  exist.

## Files

- `openapi/paths/stablecoins/stablecoins_{stablecoinId}_request-grid-enablement.yaml` (new)
- `openapi/openapi.yaml` - path entry
- `openapi/components/schemas/errors/Error409.yaml` - adds
  `STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE` to the code table and enum
- `openapi.yaml` / `mintlify/openapi.yaml` - regenerated bundles (`make build`)

## Difference from the vendored copy in webdev #34100

The path object here is identical to the vendored one. The one addition is the
`Error409` enum entry: the vendored copy documents the `409` response but never
adds `STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE` to the enumerated 409 codes,
and generated clients hard-reject an unknown error code. Worth mirroring back
into the webdev vendored spec.

## Verification

- `make build` regenerates the bundle cleanly.
- `make lint` passes (0 errors); no warning or info references the new path or
  operation.
- The regenerated canonical bundle's new path object compares equal to the
  vendored one in webdev #34100.