### PR TITLE
fix(docs): build class names without whitespace inside template literals

### DIFF
--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -27,7 +27,7 @@ export const ProductTiles = ({ categories }) => {
               setActiveCategory(cat.id);
               setActiveItem(cat.items[0]?.id);
             }}
-            className={`product-tiles-tab ${activeCategory === cat.id ? 'active' : ''}`}
+            className={['product-tiles-tab', activeCategory === cat.id && 'active'].filter(Boolean).join(' ')}
           >
             {cat.label}
           </button>
@@ -45,7 +45,7 @@ export const ProductTiles = ({ categories }) => {
                 }
               }}
               onMouseEnter={() => setActiveItem(item.id)}
-              className={`product-tiles-item ${activeItem === item.id ? 'active' : ''}`}
+              className={['product-tiles-item', activeItem === item.id && 'active'].filter(Boolean).join(' ')}
             >
               <img src={item.icon} alt="" className="product-tiles-icon" />
               <div className="product-tiles-item-content">
@@ -64,7 +64,7 @@ export const ProductTiles = ({ categories }) => {
               key={item.id} 
               src={item.image} 
               alt={item.title} 
-              className={`product-tiles-preview-img ${activeItem === item.id ? 'active' : ''}`}
+              className={['product-tiles-preview-img', activeItem === item.id && 'active'].filter(Boolean).join(' ')}
             />
           ))}
         </div>

--- a/mintlify/snippets/feature-card.mdx
+++ b/mintlify/snippets/feature-card.mdx
@@ -3,12 +3,20 @@ export const FeatureCard = ({ icon, title, children, href, linkHref, linkText, c
   const isFlat = variant === 'flat';
   const isLargeIcon = iconSize === 'lg';
   const isInlineTag = tagPosition === 'inline';
+  const className = [
+    'feature-card',
+    href && 'feature-card-link',
+    !icon && 'feature-card-no-icon',
+    isHorizontal && 'feature-card-horizontal',
+    isFlat && 'feature-card-flat',
+    isLargeIcon && 'feature-card-icon-lg',
+  ].filter(Boolean).join(' ');
   const card = (
-    <div className={`feature-card ${href ? 'feature-card-link' : ''} ${!icon ? 'feature-card-no-icon' : ''} ${isHorizontal ? 'feature-card-horizontal' : ''} ${isFlat ? 'feature-card-flat' : ''} ${isLargeIcon ? 'feature-card-icon-lg' : ''}`}>
+    <div className={className}>
       {icon && (
         <div className="feature-card-icon-wrapper">
           {color ? (
-            <div 
+            <div
               className="feature-card-icon"
               style={{
                 WebkitMaskImage: `url(${icon})`,
@@ -76,8 +84,9 @@ export const FeatureCardContainer = ({ children }) => (
 );
 
 export const ImageCard = ({ img, title, children, href }) => {
+  const className = ['image-card', href && 'image-card-link'].filter(Boolean).join(' ');
   const card = (
-    <div className={`image-card ${href ? 'image-card-link' : ''}`}>
+    <div className={className}>
       <div className="image-card-img-wrapper">
         <img src={img} alt={title} className="image-card-img" />
       </div>


### PR DESCRIPTION
## What broke

On [Currencies & Payment Rails](https://docs.lightspark.com/platform-overview/core-concepts/currencies-and-rails), the Supported Currencies cards lost their horizontal layout: the icon stacks above the title instead of sitting to its left.

On that page, Mintlify's compiler drops whitespace that sits next to a `${}` interpolation inside a template literal. Interior whitespace survives. The compiled payload shows it:

```js
// production, currencies-and-rails
className:`feature-card${href?`feature-card-link`:``}${isHorizontal?`feature-card-horizontal`:``}...`

// production, same snippet, unaffected page (configuration, rewards, assessing-fees)
className:`feature-card ${href?`feature-card-link`:``} ${isHorizontal?`feature-card-horizontal`:``}...`

// same broken page, interior whitespace untouched
className:`not-prose feature-cards-grid feature-cards-cols-${cols}`
```

The browser then receives one unusable class token, `feature-cardfeature-card-horizontalfeature-card-flat`, so `.feature-card-horizontal` never matches and the card falls back to `flex-direction: column`.

## Blast radius

Confirmed broken in production: `currencies-and-rails` and `payment-flow/send-payment`. Confirmed correct: `configuration`, `rewards`, `global-p2p`, `postman-collection`, `list-transactions`, `self-custody-wallets`, `assessing-fees`, `use-cases`, and the homepage. The same snippet source compiles differently per page, and I have not identified what triggers the stripping on the two broken pages. It is not simply "recently rebuilt": `assessing-fees` is a new page and compiles correctly.

Three components use the affected pattern. All three are changed here so none of them depends on whitespace next to an interpolation, regardless of which pages trigger the behavior:

- `FeatureCard` (used on about 20 pages)
- `ImageCard` (use cases page)
- the homepage product tiles (tab, item, and preview image active states)

## The fix

Build the class list from an array joined with a standalone `' '` string. That separator is a plain string literal rather than a template literal chunk. Whitespace-only string literals survive on the broken page (the markdown table cells between code spans compile to `` ` ` ``), so the separator is expected to survive too.

## Test plan

- `mint dev` renders `class="feature-card feature-card-horizontal feature-card-flat"` and `class="image-card image-card-link"`, with the three-row card, hairline dividers, and icon-left layout intact.
- Homepage product tiles compile to the array form and the page builds without errors.
- `markdownlint` reports no new findings (`index.mdx` keeps its 18 pre-existing warnings; `feature-card.mdx` is clean).
- `mint openapi-check openapi.yaml` passes.
- The local dev compiler does not reproduce the stripping, so confirm the fix on the Mintlify preview build for this PR, on `/platform-overview/core-concepts/currencies-and-rails`, before merging.
