### PR TITLE
docs(spec): note that exchangeRate is fee-exclusive

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12626,7 +12626,7 @@ components:
           example: 1650000
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: it covers the currency conversion only, and Grid charges `fees` separately rather than pricing them into the rate.'
           exclusiveMinimum: 0
           example: 0.012121
         fees:
@@ -22714,7 +22714,7 @@ components:
           description: Amount sent in the sender's currency
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: Grid deducts fees from the sending amount before converting at this rate.'
           exclusiveMinimum: 0
           example: 1.08
         quoteId:
@@ -23680,7 +23680,7 @@ components:
           example: 1000
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: Grid deducts `feesIncluded` from `totalSendingAmount` first, then converts the remainder at this rate to reach `totalReceivingAmount`.'
           exclusiveMinimum: 0
         feesIncluded:
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12626,7 +12626,7 @@ components:
           example: 1650000
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: it covers the currency conversion only, and Grid charges `fees` separately rather than pricing them into the rate.'
           exclusiveMinimum: 0
           example: 0.012121
         fees:
@@ -22714,7 +22714,7 @@ components:
           description: Amount sent in the sender's currency
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: Grid deducts fees from the sending amount before converting at this rate.'
           exclusiveMinimum: 0
           example: 1.08
         quoteId:
@@ -23680,7 +23680,7 @@ components:
           example: 1000
         exchangeRate:
           type: number
-          description: Number of sending currency units per receiving currency unit.
+          description: 'Number of sending currency units per receiving currency unit. The rate is fee-exclusive: Grid deducts `feesIncluded` from `totalSendingAmount` first, then converts the remainder at this rate to reach `totalReceivingAmount`.'
           exclusiveMinimum: 0
         feesIncluded:
           type: integer

--- a/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
+++ b/openapi/components/schemas/exchange_rates/ExchangeRate.yaml
@@ -47,7 +47,10 @@ properties:
     example: 1650000
   exchangeRate:
     type: number
-    description: Number of sending currency units per receiving currency unit.
+    description: >-
+      Number of sending currency units per receiving currency unit. The rate is
+      fee-exclusive: it covers the currency conversion only, and Grid charges
+      `fees` separately rather than pricing them into the rate.
     exclusiveMinimum: 0
     example: 0.012121
   fees:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -80,7 +80,11 @@ properties:
     example: 1000
   exchangeRate:
     type: number
-    description: Number of sending currency units per receiving currency unit.
+    description: >-
+      Number of sending currency units per receiving currency unit. The rate is
+      fee-exclusive: Grid deducts `feesIncluded` from `totalSendingAmount`
+      first, then converts the remainder at this rate to reach
+      `totalReceivingAmount`.
     exclusiveMinimum: 0
   feesIncluded:
     type: integer

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -71,7 +71,10 @@ properties:
     description: Amount sent in the sender's currency
   exchangeRate:
     type: number
-    description: Number of sending currency units per receiving currency unit.
+    description: >-
+      Number of sending currency units per receiving currency unit. The rate is
+      fee-exclusive: Grid deducts fees from the sending amount before converting
+      at this rate.
     exclusiveMinimum: 0
     example: 1.08
   quoteId:


### PR DESCRIPTION
## Summary

Documents that `exchangeRate` is fee-exclusive, on all three schemas that expose it: `Quote`, `Transaction`, and `ExchangeRate`.

The previous description was `Number of sending currency units per receiving currency unit.` That is silent on where fees sit relative to the rate, so an integrator converting a sending amount at the quoted rate computes a receiving amount that is too high by the fee.

## Verification

The rate is computed in `grid/objects/quote.py`:

```python
Decimal(sending_amount - total_fees)
* Decimal(10**receiving_currency.decimals)
/ (Decimal(receiving_amount) * Decimal(10**sending_currency.decimals))
```

Fees are deducted before the conversion. Checked against the published examples whose rates are precise enough to be unambiguous:

| Example | send | fee | recv | published rate | computed |
|---|---|---|---|---|---|
| `quote-system.mdx` USD→EUR | 100000 | 500 | 91540 | 1.08695652 | **1.08695652** |
| `currencies-and-rails.mdx` USD→MXN | 100000 | 500 | 1716375 | 0.05797101 | **0.05797101** |
| `quote-system.mdx` USD→BTC | 100000 | 500 | 828835 | 120048.01920768 | **120048.01920768** |

## Wording

Each description is written for the fields available on its own object:

- `Quote` names `feesIncluded` and `totalSendingAmount` directly.
- `Transaction` states the property without naming fields. The object carries no fee field to reference.
- `ExchangeRate` points at the sibling `fees` object.

Each states the fee ordering and stops there, leaving the arithmetic to the reader.

## Test plan

- [x] `make build` rebundled `openapi.yaml` and `mintlify/openapi.yaml`. The bundle diff is exactly the three description lines.
- [x] `@redocly/cli@1.34.5 lint openapi.yaml`: valid.
- [x] `spectral lint --fail-severity=error`: 0 errors. Remaining warnings and infos are pre-existing across the spec.

## Follow-ups, not addressed here

Two pre-existing issues surfaced while verifying this change. Both are worth fixing, and neither belongs in a description-only PR.

**1. The rate's unit basis is undocumented.** The amount fields are in the smallest unit of their currency, but the rate is not: each side is scaled by its currency's `decimals` first. For USD→BTC, dividing the wire integers (99500 cents / 828835 sats) gives `0.12004802`, off by 10^6 from the published `120048.01920768`; scaling each side first (995.00 / 0.00828835) reproduces it exactly. Same-decimal corridors hide this, so it only bites on pairs like USD→BTC. Wording that explains this clearly, without leaning on "major/minor unit" (terms absent from this spec) or on named denominations (BTC's smallest unit is the satoshi), needs its own pass.

**2. Most quote examples in the repo contradict this field.** 16 of the 18 quote examples do not satisfy the documented relationship between `exchangeRate`, the amounts, and the fee. Most publish the rate inverted, receiving-per-sending rather than sending-per-receiving. `openapi/paths/quotes/quotes.yaml` shows `exchangeRate: 0.92` for a USD→EUR send where sending-per-receiving is about 1.087, so `10000 x 0.92 = 9200` reconciles only because the rate direction and the operation are both flipped and the errors cancel. Only `quote-system.mdx` and `currencies-and-rails.mdx` are correct today.

A reader who checks this description against a nearby example will find they disagree, so fixing the examples is the higher-value follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
