### PR TITLE
docs: correct the ownership challenge behavior and list its account statuses

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -2580,12 +2580,16 @@ paths:
           asynchronously. The outcome is delivered via
           `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-        Calling this endpoint again abandons any in-flight challenge and issues a
-        new one with the requested method — use it to retry after a failed
-        attempt, to replace an expired challenge, or to switch methods. An
-        `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-        new challenge is issued.
+        While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+        again returns that same challenge, with the same `messageToSign` and
+        `expiresAt`. Reloading a signing page therefore does not invalidate the
+        message the user is about to sign. You get a new challenge once the
+        outstanding one expires or its attempt fails.
 
+        Requesting `LIVENESS` always starts a liveness attempt, even while a
+        signature challenge is outstanding.
+
+        An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
         Completing ownership verification moves the account to `ACTIVE`.
       operationId: createExternalAccountOwnershipChallenge
       tags:
@@ -2932,12 +2936,16 @@ paths:
           asynchronously. The outcome is delivered via
           `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-        Calling this endpoint again abandons any in-flight challenge and issues a
-        new one with the requested method — use it to retry after a failed
-        attempt, to replace an expired challenge, or to switch methods. An
-        `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-        new challenge is issued.
+        While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+        again returns that same challenge, with the same `messageToSign` and
+        `expiresAt`. Reloading a signing page therefore does not invalidate the
+        message the user is about to sign. You get a new challenge once the
+        outstanding one expires or its attempt fails.
 
+        Requesting `LIVENESS` always starts a liveness attempt, even while a
+        signature challenge is outstanding.
+
+        An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
         Completing ownership verification moves the account to `ACTIVE`.
       operationId: createPlatformExternalAccountOwnershipChallenge
       tags:

--- a/mintlify/platform-overview/core-concepts/account-model.mdx
+++ b/mintlify/platform-overview/core-concepts/account-model.mdx
@@ -209,8 +209,12 @@ PENDING → ACTIVE
 
 - **PENDING**: Created, undergoing verification/screening
 - **ACTIVE**: Verified, ready for transactions
+- **PENDING_OWNERSHIP_VERIFICATION**: The customer must prove they control this self-custody wallet
+- **UNVERIFIED**: The last ownership attempt failed. Start a new challenge to retry
 - **INACTIVE**: Disabled (can be reactivated)
 - **UNDER_REVIEW**: Additional review required
+
+A self-custody wallet registered with `ownershipType` set to `FIRST_PARTY` starts at `PENDING_OWNERSHIP_VERIFICATION` in regions that require the owner to prove they control it (e.g. the EU). Transfers below the regulatory threshold go through while it is pending, so the status is not a block. Clear it by starting a challenge on the account and completing it with either a wallet signature or a liveness check.
 
 You'll receive `INTERNAL_ACCOUNT.BALANCE_UPDATED` webhooks as balance changes, and `INTERNAL_ACCOUNT.STATUS_UPDATED` webhooks when account status changes (e.g., ACTIVE to FROZEN).
 

--- a/mintlify/platform-overview/core-concepts/account-model.mdx
+++ b/mintlify/platform-overview/core-concepts/account-model.mdx
@@ -214,9 +214,57 @@ PENDING → ACTIVE
 - **INACTIVE**: Disabled (can be reactivated)
 - **UNDER_REVIEW**: Additional review required
 
-A self-custody wallet registered with `ownershipType` set to `FIRST_PARTY` starts at `PENDING_OWNERSHIP_VERIFICATION` in regions that require the owner to prove they control it (e.g. the EU). Transfers below the regulatory threshold go through while it is pending, so the status is not a block. Clear it by starting a challenge on the account and completing it with either a wallet signature or a liveness check.
-
 You'll receive `INTERNAL_ACCOUNT.BALANCE_UPDATED` webhooks as balance changes, and `INTERNAL_ACCOUNT.STATUS_UPDATED` webhooks when account status changes (e.g., ACTIVE to FROZEN).
+
+### Ownership Verification
+
+Some regions require the owner of a self-custody wallet to prove they control it (e.g. the EU). Register the wallet with `ownershipType` set to `FIRST_PARTY` and it starts at `PENDING_OWNERSHIP_VERIFICATION`.
+
+The status is not a block: transfers below the regulatory threshold go through while a wallet is pending. Larger transfers need verification to be complete first.
+
+Start a challenge on the account, choosing how the owner will prove control:
+
+```bash
+curl -X POST https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:abc123/challenge \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"method": "WALLET_SIGNATURE"}'
+```
+
+**`WALLET_SIGNATURE`** returns a message for the wallet to sign:
+
+```json
+{
+  "method": "WALLET_SIGNATURE",
+  "messageToSign": "I am verifying ownership of the wallet address 7Ub1FK9aE5MsQBYfEdxSXorWeCGq9xPgPygL9XjA3KZz as a361e175-69b4-4bfb-9ceb-acb6ea672cf0. This message was signed on 04/09/2026 to confirm my control over this wallet.",
+  "expiresAt": "2026-09-06T00:00:00Z"
+}
+```
+
+Submit the signature to complete verification synchronously. The response is the external account, with `status` set to `ACTIVE` on success:
+
+```bash
+curl -X POST https://api.lightspark.com/grid/2025-10-13/customers/external-accounts/ExternalAccount:abc123/verify \
+  -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"signature": "5tCtPdm7CnT3YyYChEdiiEH5..."}'
+```
+
+<Warning>
+  Sign `messageToSign` exactly as returned. It is matched character for character, and the date it carries is only accepted for yesterday, today, and tomorrow in UTC. Never rebuild the message yourself.
+</Warning>
+
+**`LIVENESS`** returns a hosted `verificationLink` (and an embed `token` where supported). The owner completes a biometric flow and verification finishes asynchronously, so watch for `EXTERNAL_ACCOUNT.STATUS_UPDATED` or poll the account.
+
+<Note>
+  Calling the challenge endpoint again while a signature challenge is outstanding returns that same challenge, so reloading a signing page does not invalidate the message the owner is about to sign. A refused signature moves the account to `UNVERIFIED`, where it stays until a retry succeeds.
+</Note>
+
+Verification applies only to first-party self-custody wallets. A wallet held at an exchange is declared by setting `vaspName` inside `accountInfo`, and skips verification because the keys belong to the exchange. `THIRD_PARTY` wallets skip it too.
+
+<Warning>
+  `vaspName` belongs inside `accountInfo`. At the top level it is ignored, and the wallet is treated as self-custody.
+</Warning>
 
 ### Using External Accounts
 

--- a/mintlify/ramps/accounts/external-accounts.mdx
+++ b/mintlify/ramps/accounts/external-accounts.mdx
@@ -172,17 +172,29 @@ curl -X GET 'https://api.lightspark.com/grid/2025-10-13/customers/external-accou
 
 External accounts move through verification states:
 
-| Status     | Description              | Can Use for Conversions |
-| ---------- | ------------------------ | ----------------------- |
-| `PENDING`       | Verification in progress    | ❌                      |
-| `ACTIVE`        | Verified and ready          | ✅                      |
-| `UNDER_REVIEW`  | Additional review required  | ❌                      |
-| `INACTIVE`      | Manually disabled           | ❌                      |
+| Status                           | Description                                                       | Can use for conversions        |
+| -------------------------------- | ----------------------------------------------------------------- | ------------------------------ |
+| `PENDING`                        | Verification in progress                                          | No                             |
+| `ACTIVE`                         | Verified and ready                                                | Yes                            |
+| `PENDING_OWNERSHIP_VERIFICATION` | The customer must prove they control this self-custody wallet     | Below the regulatory threshold |
+| `UNVERIFIED`                     | The last ownership attempt failed. Start a new challenge to retry  | Below the regulatory threshold |
+| `UNDER_REVIEW`                   | Additional review required                                        | No                             |
+| `INACTIVE`                       | Manually disabled                                                 | No                             |
 
 <Info>
   Spark wallet accounts are immediately `ACTIVE`. Bank accounts may require
   verification (typically instant to a few hours).
 </Info>
+
+<Note>
+  A self-custody wallet registered with `ownershipType` set to `FIRST_PARTY` in a
+  region that applies the EU Travel Rule starts at
+  `PENDING_OWNERSHIP_VERIFICATION`. It is not blocked: conversions below the
+  regulatory threshold go through while the wallet is pending. To clear the
+  status, start a challenge with
+  `POST /customers/external-accounts/{externalAccountId}/challenge` and complete
+  it with either a wallet signature or a liveness check.
+</Note>
 
 ## Best practices for ramps
 

--- a/mintlify/ramps/accounts/external-accounts.mdx
+++ b/mintlify/ramps/accounts/external-accounts.mdx
@@ -187,9 +187,9 @@ External accounts move through verification states:
 </Info>
 
 <Note>
-  A self-custody wallet registered with `ownershipType` set to `FIRST_PARTY` in a
-  region that applies the EU Travel Rule starts at
-  `PENDING_OWNERSHIP_VERIFICATION`. It is not blocked: conversions below the
+  A self-custody wallet registered with `ownershipType` set to `FIRST_PARTY`
+  starts at `PENDING_OWNERSHIP_VERIFICATION` in regions that require the owner to
+  prove they control it (e.g. the EU). It is not blocked: conversions below the
   regulatory threshold go through while the wallet is pending. To clear the
   status, start a challenge with
   `POST /customers/external-accounts/{externalAccountId}/challenge` and complete

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -1981,7 +1981,7 @@ Beneficiary data may be reviewed for risk and compliance. Only `ACTIVE` accounts
 | `UNDER_REVIEW`                   | Additional review required                                                        |
 | `INACTIVE`                       | Disabled, cannot be used                                                          |
 
-A wallet reaches `PENDING_OWNERSHIP_VERIFICATION` when you register it with `ownershipType` set to `FIRST_PARTY` in a region that applies the EU Travel Rule. To clear it, start a challenge with `POST /customers/external-accounts/{externalAccountId}/challenge` and complete it with either a wallet signature or a liveness check. Both statuses allow transfers below the regulatory threshold, so a pending wallet is not blocked outright.
+A wallet reaches `PENDING_OWNERSHIP_VERIFICATION` when you register it with `ownershipType` set to `FIRST_PARTY` in a region that requires the owner to prove they control it (e.g. the EU). To clear it, start a challenge with `POST /customers/external-accounts/{externalAccountId}/challenge` and complete it with either a wallet signature or a liveness check. Both statuses allow transfers below the regulatory threshold, so a pending wallet is not blocked outright.
 
 ## Listing external accounts
 

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -1970,14 +1970,18 @@ For business beneficiaries, the required fields vary by destination currency:
 </Info>
 
 ## Account status
-Beneficiary data may be reviewed for risk and compliance. Only `ACTIVE` accounts can receive payments. Updates to account data may trigger account re-review.
+Beneficiary data may be reviewed for risk and compliance. Only `ACTIVE` accounts can receive payments, except that a self-custody wallet still owed ownership verification can receive transfers below the regulatory threshold. Updates to account data may trigger account re-review.
 
-| Status         | Description                         |
-| -------------- | ----------------------------------- |
-| `PENDING`      | Created, awaiting verification      |
-| `ACTIVE`       | Verified and ready for transactions |
-| `UNDER_REVIEW` | Additional review required          |
-| `INACTIVE`     | Disabled, cannot be used            |
+| Status                           | Description                                                                       |
+| -------------------------------- | --------------------------------------------------------------------------------- |
+| `PENDING`                        | Created, awaiting verification                                                    |
+| `ACTIVE`                         | Verified and ready for transactions                                               |
+| `PENDING_OWNERSHIP_VERIFICATION` | The customer must prove they control this self-custody wallet                     |
+| `UNVERIFIED`                     | The last ownership attempt failed. Start a new challenge to retry                  |
+| `UNDER_REVIEW`                   | Additional review required                                                        |
+| `INACTIVE`                       | Disabled, cannot be used                                                          |
+
+A wallet reaches `PENDING_OWNERSHIP_VERIFICATION` when you register it with `ownershipType` set to `FIRST_PARTY` in a region that applies the EU Travel Rule. To clear it, start a challenge with `POST /customers/external-accounts/{externalAccountId}/challenge` and complete it with either a wallet signature or a liveness check. Both statuses allow transfers below the regulatory threshold, so a pending wallet is not blocked outright.
 
 ## Listing external accounts
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2580,12 +2580,16 @@ paths:
           asynchronously. The outcome is delivered via
           `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-        Calling this endpoint again abandons any in-flight challenge and issues a
-        new one with the requested method — use it to retry after a failed
-        attempt, to replace an expired challenge, or to switch methods. An
-        `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-        new challenge is issued.
+        While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+        again returns that same challenge, with the same `messageToSign` and
+        `expiresAt`. Reloading a signing page therefore does not invalidate the
+        message the user is about to sign. You get a new challenge once the
+        outstanding one expires or its attempt fails.
 
+        Requesting `LIVENESS` always starts a liveness attempt, even while a
+        signature challenge is outstanding.
+
+        An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
         Completing ownership verification moves the account to `ACTIVE`.
       operationId: createExternalAccountOwnershipChallenge
       tags:
@@ -2932,12 +2936,16 @@ paths:
           asynchronously. The outcome is delivered via
           `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-        Calling this endpoint again abandons any in-flight challenge and issues a
-        new one with the requested method — use it to retry after a failed
-        attempt, to replace an expired challenge, or to switch methods. An
-        `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-        new challenge is issued.
+        While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+        again returns that same challenge, with the same `messageToSign` and
+        `expiresAt`. Reloading a signing page therefore does not invalidate the
+        message the user is about to sign. You get a new challenge once the
+        outstanding one expires or its attempt fails.
 
+        Requesting `LIVENESS` always starts a liveness attempt, even while a
+        signature challenge is outstanding.
+
+        An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
         Completing ownership verification moves the account to `ACTIVE`.
       operationId: createPlatformExternalAccountOwnershipChallenge
       tags:

--- a/openapi/paths/customers/customers_external_accounts_{externalAccountId}_challenge.yaml
+++ b/openapi/paths/customers/customers_external_accounts_{externalAccountId}_challenge.yaml
@@ -14,12 +14,16 @@ post:
       asynchronously. The outcome is delivered via
       `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-    Calling this endpoint again abandons any in-flight challenge and issues a
-    new one with the requested method — use it to retry after a failed
-    attempt, to replace an expired challenge, or to switch methods. An
-    `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-    new challenge is issued.
+    While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+    again returns that same challenge, with the same `messageToSign` and
+    `expiresAt`. Reloading a signing page therefore does not invalidate the
+    message the user is about to sign. You get a new challenge once the
+    outstanding one expires or its attempt fails.
 
+    Requesting `LIVENESS` always starts a liveness attempt, even while a
+    signature challenge is outstanding.
+
+    An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
     Completing ownership verification moves the account to `ACTIVE`.
   operationId: createExternalAccountOwnershipChallenge
   tags:

--- a/openapi/paths/platform/platform_external_accounts_{externalAccountId}_challenge.yaml
+++ b/openapi/paths/platform/platform_external_accounts_{externalAccountId}_challenge.yaml
@@ -14,12 +14,16 @@ post:
       asynchronously. The outcome is delivered via
       `EXTERNAL_ACCOUNT.STATUS_UPDATED` webhooks or by polling the account.
 
-    Calling this endpoint again abandons any in-flight challenge and issues a
-    new one with the requested method — use it to retry after a failed
-    attempt, to replace an expired challenge, or to switch methods. An
-    `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a
-    new challenge is issued.
+    While a `WALLET_SIGNATURE` challenge is outstanding, calling this endpoint
+    again returns that same challenge, with the same `messageToSign` and
+    `expiresAt`. Reloading a signing page therefore does not invalidate the
+    message the user is about to sign. You get a new challenge once the
+    outstanding one expires or its attempt fails.
 
+    Requesting `LIVENESS` always starts a liveness attempt, even while a
+    signature challenge is outstanding.
+
+    An `UNVERIFIED` account stays `UNVERIFIED` until a retry succeeds.
     Completing ownership verification moves the account to `ACTIVE`.
   operationId: createPlatformExternalAccountOwnershipChallenge
   tags:


### PR DESCRIPTION
## Reason

Running the Travel Rule catalog against the dev Striga platform turned up two
endpoint descriptions that do not match what the API does, and two status tables
that omit the ownership statuses entirely.

**Two wrong claims**, present in both the customer and platform challenge files:

| Doc said | Observed |
| --- | --- |
| "Calling this endpoint again abandons any in-flight challenge" | Returns the outstanding challenge unchanged: same `messageToSign`, same `expiresAt` |
| "An `UNVERIFIED` account returns to `PENDING_OWNERSHIP_VERIFICATION` when a new challenge is issued" | Stays `UNVERIFIED` until a retry succeeds |

The implemented behavior is the better one in the first case: a user who reloads
a signing page gets the same message back rather than invalidating the one they
were about to sign. So the docs move, not the code.

**The status tables are incomplete and, in one place, misleading.** Neither
`snippets/external-accounts.mdx` nor `ramps/accounts/external-accounts.mdx`
listed `PENDING_OWNERSHIP_VERIFICATION` or `UNVERIFIED`. The ramps table has a
"Can Use for Conversions" column marking everything other than `ACTIVE` as `❌`,
but transfers below the regulatory threshold go through while a wallet is
pending. As written it tells integrators to build a block that Grid does not
impose.

## Overview

- Rewrites the "calling this endpoint again" paragraph in both challenge files to
  describe the real behavior, and adds that requesting `LIVENESS` starts a
  liveness attempt even while a signature challenge is outstanding.
- Adds `PENDING_OWNERSHIP_VERIFICATION` and `UNVERIFIED` to both status tables,
  with the ramps "can use" column reading "Below the regulatory threshold"
  instead of a yes/no that cannot express the real rule.
- Adds a short note to each explaining how a wallet reaches the status and how to
  clear it, naming both verification methods rather than only the signature.

No change to `ExternalAccountStatus.yaml`. Its `UNVERIFIED` description became
accurate once webdev #34316 landed: a refused signature now does move the account
there.

## Test Plan

`make build` then `make lint` — exits 0, zero errors, 55 warnings, which is the
same count as `main`. The two informational notices mentioning challenge and
ownership schemas (`ScaChallenge.factor`, `OwnershipVerifyRequest.signatureScheme`
missing examples) are pre-existing and on schemas this PR does not touch.

Behavior confirmed against the dev Striga platform
`019fe537-a313-b4db-0000-0f2ac35f082c` on 2026-09-04:

- Two consecutive challenge calls returned identical `messageToSign` and
  `expiresAt`.
- After a refused signature, a new challenge left the account `UNVERIFIED`; a
  correct signature then moved it to `ACTIVE`.
- A quote to a `PENDING_OWNERSHIP_VERIFICATION` destination was created
  successfully, confirming the status is not a block.
- A `LIVENESS` challenge was issued while a signature challenge was outstanding,
  and a later signature request still returned the original message.

## Follow-up

The feature still has no prose guide. `ownershipType`,
`PENDING_OWNERSHIP_VERIFICATION` and `vaspName` appear nowhere in the docs
outside the changelog and the generated spec, despite four endpoints and two
verification methods. Worth a snippet covering the declare, challenge, verify
flow, the UTC date window on the signed message, and the fact that `vaspName`
belongs inside `accountInfo` (at the top level it is silently dropped and the
wallet is treated as self-custody). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrRvhfq3vabYreWe8yvFD1
