### PR TITLE
docs(spec): railSelectionMode is an optional enum, not a nullable one

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -23534,10 +23534,8 @@ components:
                 - type: 'null'
               description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null when no external rail is used (e.g. instant or intra-network transfers, or non-direct-destination transactions) or before a rail is resolved.
             railSelectionMode:
-              anyOf:
-                - $ref: '#/components/schemas/RailSelectionMode'
-                - type: 'null'
-              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it. Null when no rail is resolved.
+              $ref: '#/components/schemas/RailSelectionMode'
+              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it.
             expectedSettlementAt:
               type:
                 - string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23534,10 +23534,8 @@ components:
                 - type: 'null'
               description: The payment rail used to settle this transaction (e.g. ACH, WIRE, NEFT, FASTER_PAYMENTS). Uses the same values as the PaymentRail sent on quote requests. Null when no external rail is used (e.g. instant or intra-network transfers, or non-direct-destination transactions) or before a rail is resolved.
             railSelectionMode:
-              anyOf:
-                - $ref: '#/components/schemas/RailSelectionMode'
-                - type: 'null'
-              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it. Null when no rail is resolved.
+              $ref: '#/components/schemas/RailSelectionMode'
+              description: How the rail was chosen — MANUAL when the platform specified a paymentRail on the destination, AUTO when Lightspark selects it.
             expectedSettlementAt:
               type:
                 - string

--- a/openapi/components/schemas/transactions/OutgoingTransaction.yaml
+++ b/openapi/components/schemas/transactions/OutgoingTransaction.yaml
@@ -82,13 +82,10 @@ allOf:
           or intra-network transfers, or non-direct-destination transactions)
           or before a rail is resolved.
       railSelectionMode:
-        anyOf:
-          - $ref: ../common/RailSelectionMode.yaml
-          - type: 'null'
+        $ref: ../common/RailSelectionMode.yaml
         description: >-
           How the rail was chosen — MANUAL when the platform specified a
-          paymentRail on the destination, AUTO when Lightspark selects it. Null
-          when no rail is resolved.
+          paymentRail on the destination, AUTO when Lightspark selects it.
       expectedSettlementAt:
         type:
           - string


### PR DESCRIPTION
## Reason

Two problems with `OutgoingTransaction.railSelectionMode` — one in the prose, one in the schema.

**The description was wrong.** It said:

> …AUTO when Lightspark selects it. **Null when no rail is resolved.**

That is not how the value is chosen. `MANUAL` means the caller specified a `paymentRail` on the destination and `AUTO` means Lightspark selects one, and that is settled when the payment is quoted — before any rail has been resolved. So an auto-routed payment reports `AUTO` while `paymentRail` is still null, which is exactly the combination the sentence said would not occur.

**The field was nullable for no reason.** It was `anyOf: [RailSelectionMode, 'null']` while also absent from `required`, making it both optional and nullable. Nothing needs the null: absent and null carry the same meaning for this field.

## Overview

**Optional and nullable are independent**, which is the whole of the change:

| | key absent | key present as `null` |
|---|---|---|
| optional, not nullable | ✅ | ❌ |
| optional **and** nullable | ✅ | ✅ |

The field stays optional. Only the nullability goes, and the stale sentence goes with it:

```yaml
railSelectionMode:
  $ref: ../common/RailSelectionMode.yaml
  description: >-
    How the rail was chosen — MANUAL when the platform specified a
    paymentRail on the destination, AUTO when Lightspark selects it.
```

A bare `$ref` alongside a `description` is valid in OpenAPI 3.1, and `reconciliationInstructions` in this same schema already uses that form — this follows an existing pattern rather than introducing one.

### What changes for consumers

**The key is omitted rather than sent as `null`.**

Generators that emit an explicit `null` for a field that is both nullable and set will drop it from that list once the field is no longer nullable, so an unresolved rail produces no `railSelectionMode` key at all. Anything reading the field by direct index rather than a safe accessor should move to the latter.

**The generated type does not change.** An optional `$ref` and an optional nullable `$ref` both produce an optional enum — verified by comparing against `reconciliationInstructions`, which is already a bare `$ref`.

## Test Plan

`openapi/components/schemas/transactions/OutgoingTransaction.yaml` is the authored source; `openapi.yaml` and `mintlify/openapi.yaml` are build outputs, regenerated rather than hand-edited.

- **`npm run build:openapi`** — the rebuild touches only this property in each bundle. No incidental churn, which also confirms the checked-in bundles were in sync with their sources beforehand.
- **`npx @redocly/cli lint openapi.yaml`** — *"Your API description is valid."* 55 warnings, all pre-existing.
- **`npx @stoplight/spectral-cli lint openapi.yaml --fail-severity=error`** — **0 errors** (179 warnings, 722 infos, all pre-existing across the spec). Filtering the output for `railSelectionMode` returns nothing, so this introduces no new finding on the field.
- The serialization behaviour described above was measured against a generated client rather than assumed — both construction paths (field passed as null, field never passed) and the resulting payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)