### PR TITLE
Clarify automatic BIC derivation for EUR accounts

### DIFF
--- a/.claude/skills/grid-api/references/account-types.md
+++ b/.claude/skills/grid-api/references/account-types.md
@@ -224,7 +224,6 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
     "accountInfo": {
       "accountType": "EUR_ACCOUNT",
       "iban": "DE89370400440532013000",
-      "swiftCode": "COBADEFFXXX",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
         "fullName": "Full Name",
@@ -246,8 +245,14 @@ curl -s -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
 Required fields:
 
 - `iban`: International Bank Account Number (15-34 characters)
-- `swiftCode`: SWIFT/BIC code (8 or 11 characters, pattern: `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`) — optional
 - Beneficiary: `countryOfResidence` is required (in addition to `fullName`)
+
+Optional field:
+
+- `swiftCode`: SWIFT/BIC code (8 or 11 characters, pattern:
+  `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`). When omitted, Grid derives
+  it from `iban` when possible. Provide it when automatic derivation is
+  unavailable.
 
 ### Denmark (DKK_ACCOUNT)
 

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -15349,7 +15349,7 @@ components:
           pattern: ^[A-Z]{2}[0-9]{2}[A-Za-z0-9]{11,30}$
         swiftCode:
           type: string
-          description: The SWIFT/BIC code of the bank
+          description: The SWIFT/BIC code of the bank. When omitted, Grid derives it from the IBAN when possible. Provide it when automatic derivation is unavailable.
           example: DEUTDEFF
           minLength: 8
           maxLength: 11
@@ -15357,7 +15357,6 @@ components:
       example:
         accountType: EUR_ACCOUNT
         iban: DE89370400440532013000
-        swiftCode: DEUTDEFF
     EurAccountInfo:
       allOf:
         - $ref: '#/components/schemas/EurAccountInfoBase'

--- a/mintlify/platform-overview/core-concepts/account-model.mdx
+++ b/mintlify/platform-overview/core-concepts/account-model.mdx
@@ -57,7 +57,6 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
       "accountType": "EUR_ACCOUNT",
       "currency": "EUR",
       "iban": "DE89370400440532013000",
-      "swiftCode": "DEUTDEFF",
       "bankName": "Deutsche Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -65,6 +64,9 @@ Grid uses two types of accounts: **internal accounts** (Grid-managed balances) a
       }
     }
     ```
+
+    When you omit `swiftCode`, Grid derives it from the IBAN when possible.
+    Provide it when automatic derivation is unavailable.
   </Tab>
 
   <Tab title="PIX (Brazil)">

--- a/mintlify/snippets/external-accounts.mdx
+++ b/mintlify/snippets/external-accounts.mdx
@@ -314,7 +314,6 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     "accountInfo": {
       "accountType": "EUR_ACCOUNT",
       "iban": "DE89370400440532013000",
-      "swiftCode": "DEUTDEFF",
       "bankName": "Deutsche Bank",
       "beneficiary": {
         "beneficiaryType": "INDIVIDUAL",
@@ -332,6 +331,9 @@ curl -X POST 'https://api.lightspark.com/grid/2025-10-13/customers/external-acco
     }
   }'
 ```
+
+When you omit `swiftCode`, Grid derives it from the IBAN when possible. Provide
+it when automatic derivation is unavailable.
 
 </Tab>
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15349,7 +15349,7 @@ components:
           pattern: ^[A-Z]{2}[0-9]{2}[A-Za-z0-9]{11,30}$
         swiftCode:
           type: string
-          description: The SWIFT/BIC code of the bank
+          description: The SWIFT/BIC code of the bank. When omitted, Grid derives it from the IBAN when possible. Provide it when automatic derivation is unavailable.
           example: DEUTDEFF
           minLength: 8
           maxLength: 11
@@ -15357,7 +15357,6 @@ components:
       example:
         accountType: EUR_ACCOUNT
         iban: DE89370400440532013000
-        swiftCode: DEUTDEFF
     EurAccountInfo:
       allOf:
         - $ref: '#/components/schemas/EurAccountInfoBase'

--- a/openapi/components/schemas/common/EurAccountInfoBase.yaml
+++ b/openapi/components/schemas/common/EurAccountInfoBase.yaml
@@ -16,7 +16,9 @@ properties:
     pattern: ^[A-Z]{2}[0-9]{2}[A-Za-z0-9]{11,30}$
   swiftCode:
     type: string
-    description: The SWIFT/BIC code of the bank
+    description: >-
+      The SWIFT/BIC code of the bank. When omitted, Grid derives it from the
+      IBAN when possible. Provide it when automatic derivation is unavailable.
     example: DEUTDEFF
     minLength: 8
     maxLength: 11
@@ -24,4 +26,3 @@ properties:
 example:
   accountType: EUR_ACCOUNT
   iban: DE89370400440532013000
-  swiftCode: DEUTDEFF


### PR DESCRIPTION
## Summary

- Remove `swiftCode` from EUR account request examples so they show the minimum required input.
- Explain that Grid derives the SWIFT/BIC from the IBAN when possible and that callers can provide it as a fallback.
- Preserve SWIFT/BIC in response-oriented examples where it may be returned.

## Testing

- `make lint`
- `cd mintlify && npx --no-install mint openapi-check openapi.yaml`
- `npx --no-install markdownlint .claude/skills/grid-api/references/account-types.md`

Requested by @peterrojs

Original PR: https://github.com/lightsparkdev/grid-api/pull/915