### PR TITLE
add the sandbox authorization reversal and expiry simulators to the spec

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -179,7 +179,7 @@ rules:
       field: "@key"
       function: pattern
       functionOptions:
-        match: "^((\\/([a-z0-9]+(-[a-z0-9]+)*|\\{[a-zA-Z0-9]+\\}))+|\\/sandbox\\/cards\\/\\{id\\}\\/simulate\\/(balance_inquiry|credit_authorization|financial_authorization|financial_credit_authorization|authorization_advice|credit_authorization_advice|return_reversal))$"
+        match: "^((\\/([a-z0-9]+(-[a-z0-9]+)*|\\{[a-zA-Z0-9]+\\}))+|\\/sandbox\\/cards\\/\\{id\\}\\/simulate\\/(balance_inquiry|credit_authorization|financial_authorization|financial_credit_authorization|authorization_advice|credit_authorization_advice|return_reversal|authorization_reversal|authorization_expiry))$"
 
 # Per-property exemptions from the naming rules above.
 overrides:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9606,8 +9606,6 @@ paths:
       description: |
         Simulate a `RETURN_REVERSAL` against an existing card transaction in the sandbox environment — reversing a previously settled return. The parent transaction must have a posted return (non-zero `refundedAmount`). The resulting card operation is delivered asynchronously via the issuer's events webhook.
 
-        Note: authorization reversal / void has no dedicated card-issuer simulate path (the void simulator emits a distinct `VOID` event), so — like authorization expiry — it is not exposed here.
-
         Production returns `404` on this path.
       operationId: sandboxSimulateCardReturnReversal
       tags:
@@ -9642,6 +9640,151 @@ paths:
                 $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_reversal:
+    post:
+      summary: Simulate a card authorization reversal
+      description: |
+        Simulate a merchant cancelling a card authorization before it settles — a hotel releasing a hold, or a store voiding a purchase that never went through. Use it to see how your integration handles an authorization that disappears without ever clearing.
+        Send `amount` to reverse only part of the authorization, or leave it out to reverse all of it. The transaction must still be fully open: once any part of it has settled, it can no longer be reversed.
+        Grid processes the reversal in the background and sends a card transaction webhook once it lands, the same as the other simulators.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationReversal
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the reversal applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardReversalRequest'
+            examples:
+              fullReversal:
+                summary: Reverse the whole open authorization
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              partialReversal:
+                summary: Reverse part of it and leave the rest authorized
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  amount: 500
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters, or the transaction is not an open authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_expiry:
+    post:
+      summary: Simulate a card authorization expiry
+      description: |
+        Simulate an authorization the merchant never followed through on, so the card network lets it lapse and releases the held funds. Use it to see how your integration handles a hold that quietly goes away instead of settling.
+        The transaction must still be fully open: once any part of it has settled, it can no longer expire.
+        Grid processes the expiry in the background and sends a card transaction webhook once it lands, the same as the other simulators.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationExpiry
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the expiry applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardTransactionRefRequest'
+            examples:
+              expiry:
+                summary: Expire an open authorization
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters, or the transaction is not an open authorization
           content:
             application/json:
               schema:
@@ -26289,12 +26432,28 @@ components:
       type: object
       required:
         - cardTransactionId
-      description: Sandbox-only request body for simulate endpoints keyed only by an existing card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+      description: 'Sandbox-only request body for simulate endpoints keyed only by an existing card transaction: `POST /sandbox/cards/{id}/simulate/return_reversal` and `POST /sandbox/cards/{id}/simulate/authorization_expiry`.'
       properties:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to act against.
           example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    SandboxCardReversalRequest:
+      type: object
+      required:
+        - cardTransactionId
+      description: 'Request body for `POST /sandbox/cards/{id}/simulate/authorization_reversal`: which authorization to reverse, and optionally how much of it.'
+      properties:
+        cardTransactionId:
+          type: string
+          description: The authorization to reverse. It must still be fully open, with nothing settled against it yet.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+        amount:
+          type: integer
+          format: int64
+          description: How much to reverse, in the smallest unit of the transaction's currency (cents for USD). Leave it out to reverse the whole authorization. Send an amount to reverse only that much and leave the rest on hold.
+          exclusiveMinimum: 0
+          example: 1250
     StablecoinIssuanceStatus:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9606,8 +9606,6 @@ paths:
       description: |
         Simulate a `RETURN_REVERSAL` against an existing card transaction in the sandbox environment — reversing a previously settled return. The parent transaction must have a posted return (non-zero `refundedAmount`). The resulting card operation is delivered asynchronously via the issuer's events webhook.
 
-        Note: authorization reversal / void has no dedicated card-issuer simulate path (the void simulator emits a distinct `VOID` event), so — like authorization expiry — it is not exposed here.
-
         Production returns `404` on this path.
       operationId: sandboxSimulateCardReturnReversal
       tags:
@@ -9642,6 +9640,151 @@ paths:
                 $ref: '#/components/schemas/SandboxCardSimulationResponse'
         '400':
           description: Bad request - Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_reversal:
+    post:
+      summary: Simulate a card authorization reversal
+      description: |
+        Simulate a merchant cancelling a card authorization before it settles — a hotel releasing a hold, or a store voiding a purchase that never went through. Use it to see how your integration handles an authorization that disappears without ever clearing.
+        Send `amount` to reverse only part of the authorization, or leave it out to reverse all of it. The transaction must still be fully open: once any part of it has settled, it can no longer be reversed.
+        Grid processes the reversal in the background and sends a card transaction webhook once it lands, the same as the other simulators.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationReversal
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the reversal applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardReversalRequest'
+            examples:
+              fullReversal:
+                summary: Reverse the whole open authorization
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              partialReversal:
+                summary: Reverse part of it and leave the rest authorized
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  amount: 500
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters, or the transaction is not an open authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '403':
+          description: Forbidden - request was made with a production platform token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        '404':
+          description: Card or card transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /sandbox/cards/{id}/simulate/authorization_expiry:
+    post:
+      summary: Simulate a card authorization expiry
+      description: |
+        Simulate an authorization the merchant never followed through on, so the card network lets it lapse and releases the held funds. Use it to see how your integration handles a hold that quietly goes away instead of settling.
+        The transaction must still be fully open: once any part of it has settled, it can no longer expire.
+        Grid processes the expiry in the background and sends a card transaction webhook once it lands, the same as the other simulators.
+
+        Production returns `404` on this path.
+      operationId: sandboxSimulateCardAuthorizationExpiry
+      tags:
+        - Sandbox
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the card the expiry applies to.
+          schema:
+            type: string
+          example: Card:019542f5-b3e7-1d02-0000-000000000010
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SandboxCardTransactionRefRequest'
+            examples:
+              expiry:
+                summary: Expire an open authorization
+                value:
+                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+      responses:
+        '202':
+          description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxCardSimulationResponse'
+        '400':
+          description: Bad request - Invalid parameters, or the transaction is not an open authorization
           content:
             application/json:
               schema:
@@ -26289,12 +26432,28 @@ components:
       type: object
       required:
         - cardTransactionId
-      description: Sandbox-only request body for simulate endpoints keyed only by an existing card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+      description: 'Sandbox-only request body for simulate endpoints keyed only by an existing card transaction: `POST /sandbox/cards/{id}/simulate/return_reversal` and `POST /sandbox/cards/{id}/simulate/authorization_expiry`.'
       properties:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to act against.
           example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    SandboxCardReversalRequest:
+      type: object
+      required:
+        - cardTransactionId
+      description: 'Request body for `POST /sandbox/cards/{id}/simulate/authorization_reversal`: which authorization to reverse, and optionally how much of it.'
+      properties:
+        cardTransactionId:
+          type: string
+          description: The authorization to reverse. It must still be fully open, with nothing settled against it yet.
+          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+        amount:
+          type: integer
+          format: int64
+          description: How much to reverse, in the smallest unit of the transaction's currency (cents for USD). Leave it out to reverse the whole authorization. Send an amount to reverse only that much and leave the rest on hold.
+          exclusiveMinimum: 0
+          example: 1250
     StablecoinIssuanceStatus:
       type: string
       enum:

--- a/openapi/components/schemas/cards/SandboxCardReversalRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardReversalRequest.yaml
@@ -1,0 +1,23 @@
+type: object
+required:
+  - cardTransactionId
+description: >-
+  Request body for `POST /sandbox/cards/{id}/simulate/authorization_reversal`:
+  which authorization to reverse, and optionally how much of it.
+properties:
+  cardTransactionId:
+    type: string
+    description: >-
+      The authorization to reverse. It must still be fully open, with
+      nothing settled against it yet.
+    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+  amount:
+    type: integer
+    format: int64
+    description: >-
+      How much to reverse, in the smallest unit of the transaction's
+      currency (cents for USD). Leave it out to reverse the whole
+      authorization. Send an amount to reverse only that much and leave the
+      rest on hold.
+    exclusiveMinimum: 0
+    example: 1250

--- a/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
@@ -3,7 +3,8 @@ required:
   - cardTransactionId
 description: >-
   Sandbox-only request body for simulate endpoints keyed only by an existing
-  card transaction — currently `POST /sandbox/cards/{id}/simulate/return_reversal`.
+  card transaction: `POST /sandbox/cards/{id}/simulate/return_reversal` and
+  `POST /sandbox/cards/{id}/simulate/authorization_expiry`.
 properties:
   cardTransactionId:
     type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -368,6 +368,10 @@ paths:
     $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
   /sandbox/cards/{id}/simulate/return_reversal:
     $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
+  /sandbox/cards/{id}/simulate/authorization_reversal:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
+  /sandbox/cards/{id}/simulate/authorization_expiry:
+    $ref: paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
   /stablecoins:
     $ref: paths/stablecoins/stablecoins.yaml
   /stablecoins/{stablecoinId}:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
@@ -1,15 +1,20 @@
 post:
-  summary: Simulate a card return reversal
+  summary: Simulate a card authorization expiry
   description: >
-    Simulate a `RETURN_REVERSAL` against an existing card transaction in the
-    sandbox environment — reversing a previously settled return. The parent
-    transaction must have a posted return (non-zero `refundedAmount`). The
-    resulting card operation is delivered asynchronously via the issuer's
-    events webhook.
+    Simulate an authorization the merchant never followed through on, so the
+    card network lets it lapse and releases the held funds. Use it to see how
+    your integration handles a hold that quietly goes away instead of
+    settling.
+
+    The transaction must still be fully open: once any part of it has
+    settled, it can no longer expire.
+
+    Grid processes the expiry in the background and sends a card transaction
+    webhook once it lands, the same as the other simulators.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturnReversal
+  operationId: sandboxSimulateCardAuthorizationExpiry
   tags:
     - Sandbox
   security:
@@ -18,7 +23,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return reversal applies to.
+      description: The id of the card the expiry applies to.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -29,8 +34,8 @@ post:
         schema:
           $ref: ../../../components/schemas/cards/SandboxCardTransactionRefRequest.yaml
         examples:
-          returnReversal:
-            summary: Reverse a settled return on a transaction with a posted return
+          expiry:
+            summary: Expire an open authorization
             value:
               cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
   responses:
@@ -44,7 +49,9 @@ post:
           schema:
             $ref: ../../../components/schemas/cards/SandboxCardSimulationResponse.yaml
     '400':
-      description: Bad request - Invalid parameters
+      description: >-
+        Bad request - Invalid parameters, or the transaction is not an open
+        authorization
       content:
         application/json:
           schema:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
@@ -1,15 +1,21 @@
 post:
-  summary: Simulate a card return reversal
+  summary: Simulate a card authorization reversal
   description: >
-    Simulate a `RETURN_REVERSAL` against an existing card transaction in the
-    sandbox environment — reversing a previously settled return. The parent
-    transaction must have a posted return (non-zero `refundedAmount`). The
-    resulting card operation is delivered asynchronously via the issuer's
-    events webhook.
+    Simulate a merchant cancelling a card authorization before it settles —
+    a hotel releasing a hold, or a store voiding a purchase that never went
+    through. Use it to see how your integration handles an authorization
+    that disappears without ever clearing.
+
+    Send `amount` to reverse only part of the authorization, or leave it out
+    to reverse all of it. The transaction must still be fully open: once any
+    part of it has settled, it can no longer be reversed.
+
+    Grid processes the reversal in the background and sends a card
+    transaction webhook once it lands, the same as the other simulators.
 
 
     Production returns `404` on this path.
-  operationId: sandboxSimulateCardReturnReversal
+  operationId: sandboxSimulateCardAuthorizationReversal
   tags:
     - Sandbox
   security:
@@ -18,7 +24,7 @@ post:
     - name: id
       in: path
       required: true
-      description: The id of the card the return reversal applies to.
+      description: The id of the card the reversal applies to.
       schema:
         type: string
       example: Card:019542f5-b3e7-1d02-0000-000000000010
@@ -27,12 +33,17 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../../../components/schemas/cards/SandboxCardTransactionRefRequest.yaml
+          $ref: ../../../components/schemas/cards/SandboxCardReversalRequest.yaml
         examples:
-          returnReversal:
-            summary: Reverse a settled return on a transaction with a posted return
+          fullReversal:
+            summary: Reverse the whole open authorization
             value:
               cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          partialReversal:
+            summary: Reverse part of it and leave the rest authorized
+            value:
+              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              amount: 500
   responses:
     '202':
       description: >-
@@ -44,7 +55,9 @@ post:
           schema:
             $ref: ../../../components/schemas/cards/SandboxCardSimulationResponse.yaml
     '400':
-      description: Bad request - Invalid parameters
+      description: >-
+        Bad request - Invalid parameters, or the transaction is not an open
+        authorization
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary

`POST /sandbox/cards/{id}/simulate/authorization_reversal` and `POST /sandbox/cards/{id}/simulate/authorization_expiry` have been live for some time but were never in the spec, so generated clients could not call them and integrators had no way to discover them.

The `return_reversal` endpoint's description went further and stated that neither existed:

> Note: authorization reversal / void has no dedicated card-issuer simulate path (the void simulator emits a distinct `VOID` event), so — like authorization expiry — it is not exposed here.

Both are documented now and that note is gone.

## What changed

**Two new paths**

- `simulate/authorization_reversal` — a merchant cancelling an authorization before it settles, in full or in part. Takes a new `SandboxCardReversalRequest`: the transaction plus an optional `amount`. Omit `amount` to reverse the whole authorization; send one to reverse only that much. The schema does not admit `0` — leaving the field out is the only way to express a full reversal, the same shape as the `return` simulator's `amount`. Same production-platform gating as `simulate/authorization`.
- `simulate/authorization_expiry` — the card network letting an authorization lapse because the merchant never followed through. Reuses `SandboxCardTransactionRefRequest`, whose description now names both of its callers. Sandbox-only, like `return_reversal`.

Both act on an authorization that is still fully open with nothing settled, since the issuer's void simulator rejects a partially-cleared one. Both return `202` with the issuer transaction token and land their result via the events webhook, matching the other simulators.

The descriptions are written for an integrator deciding whether to call the endpoint — what real-world event it stands in for and what to expect afterwards — rather than for someone who already knows the issuer's event names.

**Corrected prose** — the incorrect note in `return_reversal` is removed.

**Lint config** — the two paths join the kebab-case allowlist in `.spectral.yaml` for the same reason the other simulators are there: they mirror the issuer's routes verbatim and the SDK must call those exact URLs.

## Breaking-change check

Additive only: two new paths and one new request schema. No existing path, schema, or enum value changes. Nothing a client has already received is affected.

## Test plan

This is a spec + docs repo with no application code, so verification is the spec toolchain:

- `npm run lint:openapi` — Redocly validates clean at 55 warnings, one fewer than `main`. Spectral is 901 problems / 0 errors / 179 warnings, identical to `main` when both are linted in place.
- `npm run build:openapi` — rebundled `openapi.yaml` and `mintlify/openapi.yaml`; the two are identical, and the bundle diff contains exactly the source edits.
- Both new request bodies round-trip through the bundled schema: a reversal with and without `amount`, and an expiry with only `cardTransactionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)