### PR TITLE
lint: don't let the runner's Chrome apt source fail the libsecret install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,12 @@ jobs:
           cache: 'npm'
       
       - name: Install libsecret
-        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+        run: |
+          # The runner image ships Google's Chrome apt source, which this job never
+          # uses and which intermittently serves mismatched indexes. Drop it so an
+          # unrelated mirror can't fail the update.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          sudo apt-get update && sudo apt-get install -y libsecret-1-dev
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

The `Lint Code & Documentation` job runs `sudo apt-get update && sudo apt-get install -y libsecret-1-dev` before anything else. `apt-get update` exits non-zero if *any* configured source fails a hash check — and the `ubuntu-latest` runner image ships Google's Chrome apt source, which this job never installs from.

When that mirror is mid-republish it serves a `Packages.gz` that doesn't match its own `Release` file, and the whole job dies in setup before `npm ci` or a single lint rule runs. That happened on #919 twice in a row today, ten minutes apart, with the identical hash mismatch both times:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
   Last modification reported: Wed, 09 Sep 2026 09:41:12 +0000
   Release file created at: Wed, 09 Sep 2026 17:16:59 +0000
##[error]Process completed with exit code 100.
```

Every check that actually exercises the spec on that PR — breaking-change detection, both OpenAPI builds, preview, Mintlify — was green. The lint job was red only because an unrelated third-party mirror had a veto over it.

## What changed

One step. The Chrome apt source list is removed before `apt-get update`:

```yaml
sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
sudo apt-get update && sudo apt-get install -y libsecret-1-dev
```

Nothing about what gets installed changes. `libsecret-1-dev` still installs from Ubuntu's own archive; a mirror this job doesn't use just loses the ability to fail it.

## Test plan

- The workflow YAML parses; the job still has six steps and the install step still references `libsecret-1-dev`.
- This is the standard mitigation for this runner-image behaviour, and it's purely subtractive — it can't make the install pull from anywhere it didn't already.
- Worth knowing for review: `.github/workflows/` is not in the Lint workflow's own `paths:` filter, so the real lint job won't run on this PR; `dummy.yml` reports the check instead. The actual validation is #919 going green once it's rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017bvbs2nhqaqCRn1BiZJU4G)_