### PR TITLE
use the Transaction: prefix in card transaction id examples

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -9043,12 +9043,12 @@ paths:
               tipOnTopClearing:
                 summary: Clearing larger than auth — exercises post-hoc pull
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
               authorizationExpiry:
                 summary: Clearing of 0 — exercises authorization expiry
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 0
       responses:
         '202':
@@ -9117,7 +9117,7 @@ paths:
               fullRefund:
                 summary: Full refund of a $15.00 settled transaction
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
       responses:
         '202':
@@ -9485,7 +9485,7 @@ paths:
               resizeUp:
                 summary: Re-size an open auth up to a new total of $20.00
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 2000
       responses:
         '202':
@@ -9630,7 +9630,7 @@ paths:
               returnReversal:
                 summary: Reverse a settled return on a transaction with a posted return
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
       responses:
         '202':
           description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
@@ -9700,11 +9700,11 @@ paths:
               fullReversal:
                 summary: Reverse the whole open authorization
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               partialReversal:
                 summary: Reverse part of it and leave the rest authorized
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 500
       responses:
         '202':
@@ -9775,7 +9775,7 @@ paths:
               expiry:
                 summary: Expire an open authorization
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
       responses:
         '202':
           description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
@@ -11792,7 +11792,7 @@ webhooks:
                   timestamp: '2026-05-09T10:00:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11832,7 +11832,7 @@ webhooks:
                   timestamp: '2026-05-09T15:42:11Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11880,7 +11880,7 @@ webhooks:
                   timestamp: '2026-05-10T09:15:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11935,7 +11935,7 @@ webhooks:
                   timestamp: '2026-05-09T16:05:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000101
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000101
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -23804,7 +23804,7 @@ components:
           type: string
           description: System-generated unique card transaction identifier
           readOnly: true
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         cardId:
           type: string
           description: The id of the `Card` this transaction was made on.
@@ -26319,7 +26319,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to clear against. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26336,7 +26336,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to refund against. Must have at least one settled clearing.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26361,7 +26361,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` the advice re-sizes. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26377,7 +26377,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to act against.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
     SandboxCardReversalRequest:
       type: object
       required:
@@ -26387,7 +26387,7 @@ components:
         cardTransactionId:
           type: string
           description: The authorization to reverse. It must still be fully open, with nothing settled against it yet.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64

--- a/mintlify/snippets/cards/quickstart.mdx
+++ b/mintlify/snippets/cards/quickstart.mdx
@@ -124,7 +124,7 @@ curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:019542f5-b3e7-1d02-0000-00000000
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "cardTransactionId": "CardTransaction:019542f5-b3e7-1d02-0000-000000000100",
+    "cardTransactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000100",
     "amount": 1500
   }'
 ```

--- a/mintlify/snippets/cards/sandbox-testing.mdx
+++ b/mintlify/snippets/cards/sandbox-testing.mdx
@@ -73,7 +73,7 @@ curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:019542f5-b3e7-1d02-0000-00000000
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "cardTransactionId": "CardTransaction:019542f5-b3e7-1d02-0000-000000000100",
+    "cardTransactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000100",
     "amount": 1500
   }'
 ```
@@ -95,7 +95,7 @@ curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:019542f5-b3e7-1d02-0000-00000000
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-    "cardTransactionId": "CardTransaction:019542f5-b3e7-1d02-0000-000000000100",
+    "cardTransactionId": "Transaction:019542f5-b3e7-1d02-0000-000000000100",
     "amount": 1500
   }'
 ```
@@ -130,13 +130,13 @@ curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:.../simulate/authorization" \
 curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:.../simulate/clearing" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -d '{ "cardTransactionId": "CardTransaction:...", "amount": 1500 }'
+  -d '{ "cardTransactionId": "Transaction:...", "amount": 1500 }'
 
 # 4. Refund the cleared transaction
 curl -X POST "$GRID_BASE_URL/sandbox/cards/Card:.../simulate/return" \
   -u "$GRID_CLIENT_ID:$GRID_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
-  -d '{ "cardTransactionId": "CardTransaction:...", "amount": 1500 }'
+  -d '{ "cardTransactionId": "Transaction:...", "amount": 1500 }'
 ```
 
 At each step you'll see `CARD.STATE_CHANGE` webhooks plus transaction

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9043,12 +9043,12 @@ paths:
               tipOnTopClearing:
                 summary: Clearing larger than auth — exercises post-hoc pull
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
               authorizationExpiry:
                 summary: Clearing of 0 — exercises authorization expiry
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 0
       responses:
         '202':
@@ -9117,7 +9117,7 @@ paths:
               fullRefund:
                 summary: Full refund of a $15.00 settled transaction
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 1500
       responses:
         '202':
@@ -9485,7 +9485,7 @@ paths:
               resizeUp:
                 summary: Re-size an open auth up to a new total of $20.00
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 2000
       responses:
         '202':
@@ -9630,7 +9630,7 @@ paths:
               returnReversal:
                 summary: Reverse a settled return on a transaction with a posted return
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
       responses:
         '202':
           description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
@@ -9700,11 +9700,11 @@ paths:
               fullReversal:
                 summary: Reverse the whole open authorization
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               partialReversal:
                 summary: Reverse part of it and leave the rest authorized
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
                   amount: 500
       responses:
         '202':
@@ -9775,7 +9775,7 @@ paths:
               expiry:
                 summary: Expire an open authorization
                 value:
-                  cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                  cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
       responses:
         '202':
           description: Simulation accepted. The resulting card operation is delivered asynchronously via the issuer's events webhook. Returns the issuer transaction token that correlates the simulated event.
@@ -11792,7 +11792,7 @@ webhooks:
                   timestamp: '2026-05-09T10:00:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11832,7 +11832,7 @@ webhooks:
                   timestamp: '2026-05-09T15:42:11Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11880,7 +11880,7 @@ webhooks:
                   timestamp: '2026-05-10T09:15:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -11935,7 +11935,7 @@ webhooks:
                   timestamp: '2026-05-09T16:05:00Z'
                   data:
                     type: CARD
-                    id: CardTransaction:019542f5-b3e7-1d02-0000-000000000101
+                    id: Transaction:019542f5-b3e7-1d02-0000-000000000101
                     cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                     customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCustomerId: 18d3e5f7b4a9c2
@@ -23804,7 +23804,7 @@ components:
           type: string
           description: System-generated unique card transaction identifier
           readOnly: true
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         cardId:
           type: string
           description: The id of the `Card` this transaction was made on.
@@ -26319,7 +26319,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to clear against. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26336,7 +26336,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to refund against. Must have at least one settled clearing.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26361,7 +26361,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` the advice re-sizes. Must be in `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64
@@ -26377,7 +26377,7 @@ components:
         cardTransactionId:
           type: string
           description: The id of the `CardTransaction` to act against.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
     SandboxCardReversalRequest:
       type: object
       required:
@@ -26387,7 +26387,7 @@ components:
         cardTransactionId:
           type: string
           description: The authorization to reverse. It must still be fully open, with nothing settled against it yet.
-          example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+          example: Transaction:019542f5-b3e7-1d02-0000-000000000100
         amount:
           type: integer
           format: int64

--- a/openapi/components/schemas/cards/CardTransaction.yaml
+++ b/openapi/components/schemas/cards/CardTransaction.yaml
@@ -30,7 +30,7 @@ properties:
     type: string
     description: System-generated unique card transaction identifier
     readOnly: true
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100
   cardId:
     type: string
     description: The id of the `Card` this transaction was made on.

--- a/openapi/components/schemas/cards/SandboxCardAuthorizationAdviceRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardAuthorizationAdviceRequest.yaml
@@ -11,7 +11,7 @@ properties:
     description: >-
       The id of the `CardTransaction` the advice re-sizes. Must be in
       `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100
   amount:
     type: integer
     format: int64

--- a/openapi/components/schemas/cards/SandboxCardClearingRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardClearingRequest.yaml
@@ -15,7 +15,7 @@ properties:
     description: >-
       The id of the `CardTransaction` to clear against. Must be in
       `AUTHORIZED` or `PARTIALLY_SETTLED` state.
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100
   amount:
     type: integer
     format: int64

--- a/openapi/components/schemas/cards/SandboxCardReturnRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardReturnRequest.yaml
@@ -13,7 +13,7 @@ properties:
     description: >-
       The id of the `CardTransaction` to refund against. Must have at least
       one settled clearing.
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100
   amount:
     type: integer
     format: int64

--- a/openapi/components/schemas/cards/SandboxCardReversalRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardReversalRequest.yaml
@@ -10,7 +10,7 @@ properties:
     description: >-
       The authorization to reverse. It must still be fully open, with
       nothing settled against it yet.
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100
   amount:
     type: integer
     format: int64

--- a/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardTransactionRefRequest.yaml
@@ -10,4 +10,4 @@ properties:
     type: string
     description: >-
       The id of the `CardTransaction` to act against.
-    example: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+    example: Transaction:019542f5-b3e7-1d02-0000-000000000100

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
@@ -33,7 +33,7 @@ post:
           resizeUp:
             summary: Re-size an open auth up to a new total of $20.00
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 2000
   responses:
     '202':

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
@@ -37,7 +37,7 @@ post:
           expiry:
             summary: Expire an open authorization
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
   responses:
     '202':
       description: >-

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
@@ -38,11 +38,11 @@ post:
           fullReversal:
             summary: Reverse the whole open authorization
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
           partialReversal:
             summary: Reverse part of it and leave the rest authorized
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 500
   responses:
     '202':

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
@@ -41,12 +41,12 @@ post:
           tipOnTopClearing:
             summary: Clearing larger than auth — exercises post-hoc pull
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 1500
           authorizationExpiry:
             summary: Clearing of 0 — exercises authorization expiry
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 0
   responses:
     '202':

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return.yaml
@@ -31,7 +31,7 @@ post:
           fullRefund:
             summary: Full refund of a $15.00 settled transaction
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
               amount: 1500
   responses:
     '202':

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
@@ -32,7 +32,7 @@ post:
           returnReversal:
             summary: Reverse a settled return on a transaction with a posted return
             value:
-              cardTransactionId: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+              cardTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
   responses:
     '202':
       description: >-

--- a/openapi/webhooks/card-transaction.yaml
+++ b/openapi/webhooks/card-transaction.yaml
@@ -59,7 +59,7 @@ post:
               timestamp: '2026-05-09T10:00:00Z'
               data:
                 type: CARD
-                id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                 cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                 customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 platformCustomerId: 18d3e5f7b4a9c2
@@ -99,7 +99,7 @@ post:
               timestamp: '2026-05-09T15:42:11Z'
               data:
                 type: CARD
-                id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                 cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                 customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 platformCustomerId: 18d3e5f7b4a9c2
@@ -147,7 +147,7 @@ post:
               timestamp: '2026-05-10T09:15:00Z'
               data:
                 type: CARD
-                id: CardTransaction:019542f5-b3e7-1d02-0000-000000000100
+                id: Transaction:019542f5-b3e7-1d02-0000-000000000100
                 cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                 customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 platformCustomerId: 18d3e5f7b4a9c2
@@ -202,7 +202,7 @@ post:
               timestamp: '2026-05-09T16:05:00Z'
               data:
                 type: CARD
-                id: CardTransaction:019542f5-b3e7-1d02-0000-000000000101
+                id: Transaction:019542f5-b3e7-1d02-0000-000000000101
                 cardId: Card:019542f5-b3e7-1d02-0000-000000000010
                 customerId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 platformCustomerId: 18d3e5f7b4a9c2


### PR DESCRIPTION
## Summary

Card transactions are listed and fetched through `/transactions`, and their ids carry the same `Transaction:` prefix as every other transaction. The examples said `CardTransaction:`, which is not an id Grid ever returns. An integrator copying an example into a sandbox simulate request, or matching webhook payloads against the documented shape, would be looking for a prefix that never appears.

## What changes

Every `CardTransaction:` example becomes `Transaction:`. No schema, field, or description changes.

- `CardTransaction.id` example.
- `cardTransactionId` examples on the sandbox simulate request schemas (authorization advice, clearing, return, reversal, and the shared transaction-ref request) and on the request examples of the six sandbox simulate paths.
- `id` in the four card-transaction webhook payload examples.
- The quickstart and sandbox-testing snippets.

The bundled `openapi.yaml` and the mintlify copy are rebuilt.

## Test plan

- `npm run lint:openapi` passes. Redocly warnings and Spectral results are unchanged from `main`.
- No `CardTransaction:` string remains anywhere in `openapi/` or `mintlify/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017bvbs2nhqaqCRn1BiZJU4G)_