### PR TITLE
docs(config): document platform-name defaults for card tokenization 2FA copy

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12294,7 +12294,7 @@ components:
         fromName:
           type: string
           maxLength: 255
-          description: Sender display name.
+          description: Sender display name. Defaults to `displayName`.
           example: Acme Cards
         replyToAddress:
           type: string
@@ -12305,7 +12305,9 @@ components:
         subject:
           type: string
           maxLength: 255
-          description: Subject for the authentication email.
+          description: |
+            Subject for the authentication email. Defaults to
+            "Your {displayName} verification code".
           example: Your Acme card verification code
         bodyText:
           type: string
@@ -12313,7 +12315,8 @@ components:
           description: |
             Plain-text message content. Lightspark inserts the authentication code into
             a controlled text and HTML template; arbitrary HTML and template variables
-            are not supported.
+            are not supported. Defaults to "Use this code to finish adding your
+            {displayName} card to your wallet."
           example: Use this code to finish adding your Acme card to your digital wallet.
     CardTokenization2FASmsConfig:
       type: object
@@ -12331,7 +12334,8 @@ components:
           maxLength: 480
           description: |
             Plain-text fallback message used when Twilio Verify is unavailable for the
-            authentication code. Lightspark appends the code to this text.
+            authentication code. Lightspark appends the code to this text. Defaults to
+            "Your {displayName} verification code is:".
           example: Use this code to finish adding your Acme card to your digital wallet.
     CardTokenization2FAConfig:
       type: object
@@ -12340,7 +12344,9 @@ components:
         displayName:
           type: string
           maxLength: 255
-          description: Platform name displayed in authentication messages.
+          description: |
+            Name shown in authentication messages and used to build the default
+            subject, body, and sender name. Defaults to the platform's name.
           example: Acme
         logoUrl:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12294,7 +12294,7 @@ components:
         fromName:
           type: string
           maxLength: 255
-          description: Sender display name.
+          description: Sender display name. Defaults to `displayName`.
           example: Acme Cards
         replyToAddress:
           type: string
@@ -12305,7 +12305,9 @@ components:
         subject:
           type: string
           maxLength: 255
-          description: Subject for the authentication email.
+          description: |
+            Subject for the authentication email. Defaults to
+            "Your {displayName} verification code".
           example: Your Acme card verification code
         bodyText:
           type: string
@@ -12313,7 +12315,8 @@ components:
           description: |
             Plain-text message content. Lightspark inserts the authentication code into
             a controlled text and HTML template; arbitrary HTML and template variables
-            are not supported.
+            are not supported. Defaults to "Use this code to finish adding your
+            {displayName} card to your wallet."
           example: Use this code to finish adding your Acme card to your digital wallet.
     CardTokenization2FASmsConfig:
       type: object
@@ -12331,7 +12334,8 @@ components:
           maxLength: 480
           description: |
             Plain-text fallback message used when Twilio Verify is unavailable for the
-            authentication code. Lightspark appends the code to this text.
+            authentication code. Lightspark appends the code to this text. Defaults to
+            "Your {displayName} verification code is:".
           example: Use this code to finish adding your Acme card to your digital wallet.
     CardTokenization2FAConfig:
       type: object
@@ -12340,7 +12344,9 @@ components:
         displayName:
           type: string
           maxLength: 255
-          description: Platform name displayed in authentication messages.
+          description: |
+            Name shown in authentication messages and used to build the default
+            subject, body, and sender name. Defaults to the platform's name.
           example: Acme
         logoUrl:
           type: string

--- a/openapi/components/schemas/config/CardTokenization2FAConfig.yaml
+++ b/openapi/components/schemas/config/CardTokenization2FAConfig.yaml
@@ -7,7 +7,9 @@ properties:
   displayName:
     type: string
     maxLength: 255
-    description: Platform name displayed in authentication messages.
+    description: |
+      Name shown in authentication messages and used to build the default
+      subject, body, and sender name. Defaults to the platform's name.
     example: Acme
   logoUrl:
     type: string

--- a/openapi/components/schemas/config/CardTokenization2FAEmailConfig.yaml
+++ b/openapi/components/schemas/config/CardTokenization2FAEmailConfig.yaml
@@ -12,7 +12,7 @@ properties:
   fromName:
     type: string
     maxLength: 255
-    description: Sender display name.
+    description: Sender display name. Defaults to `displayName`.
     example: Acme Cards
   replyToAddress:
     type: string
@@ -23,7 +23,9 @@ properties:
   subject:
     type: string
     maxLength: 255
-    description: Subject for the authentication email.
+    description: |
+      Subject for the authentication email. Defaults to
+      "Your {displayName} verification code".
     example: Your Acme card verification code
   bodyText:
     type: string
@@ -31,5 +33,6 @@ properties:
     description: |
       Plain-text message content. Lightspark inserts the authentication code into
       a controlled text and HTML template; arbitrary HTML and template variables
-      are not supported.
+      are not supported. Defaults to "Use this code to finish adding your
+      {displayName} card to your wallet."
     example: Use this code to finish adding your Acme card to your digital wallet.

--- a/openapi/components/schemas/config/CardTokenization2FASmsConfig.yaml
+++ b/openapi/components/schemas/config/CardTokenization2FASmsConfig.yaml
@@ -15,5 +15,6 @@ properties:
     maxLength: 480
     description: |
       Plain-text fallback message used when Twilio Verify is unavailable for the
-      authentication code. Lightspark appends the code to this text.
+      authentication code. Lightspark appends the code to this text. Defaults to
+      "Your {displayName} verification code is:".
     example: Use this code to finish adding your Acme card to your digital wallet.


### PR DESCRIPTION
## Reason

With lightsparkdev/webdev#34633, card-tokenization verification messages default to the platform's name instead of "wallet" and "Lightspark" when a platform has not set `cardTokenization2faConfig` fields. Integrators reading the spec should know what they get without overriding anything.

## Overview

Description-only changes on `CardTokenization2FAConfig`, `CardTokenization2FAEmailConfig`, and `CardTokenization2FASmsConfig`: `displayName` defaults to the platform's name and drives the default sender name, subject, email body, and SMS fallback body. Each of those fields now states its default. No schema shape changes.

## Test Plan

- `make build` and `make lint` pass. Lint output shows only pre-existing informational and warning findings on unrelated schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dU4iNZ2goV3EnNZHso67R
