### PR TITLE
Declare the Idempotency-Key header on POST /cards

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8554,6 +8554,8 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
+        Card issuance is fee-bearing and cannot be reversed, so an `Idempotency-Key` header is required. Retries must carry the same key.
+
         Optional `maxSpendPerTransaction`, `maxSpendPerDay`, and `maxTransactionsPerDay` values set the card-specific caps on one transaction, on spend during one UTC calendar day, and on the number of transactions during one UTC calendar day. The limits are enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. If the platform config sets the corresponding `cardConfigs` value, Grid enforces the lower of the card and platform caps. Amounts use the smallest unit of the card's currency.
 
         If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
@@ -8566,6 +8568,16 @@ paths:
         - Cards
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          description: |
+            A unique identifier for the request, up to 255 characters. A retry carrying the same key returns the card created by the first request; reusing a key for a materially different card request is rejected with `409`.
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:
@@ -8592,7 +8604,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
+          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `INVALID_INPUT` when the `Idempotency-Key` header is missing or exceeds 255 characters, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8554,6 +8554,8 @@ paths:
       description: |
         Issue a new card for a cardholder. Every card must be bound to at least one funding source at create time. The cardholder must have KYC status `APPROVED` before a card can be issued; otherwise the request is rejected with `CARDHOLDER_KYC_NOT_APPROVED`.
 
+        Card issuance is fee-bearing and cannot be reversed, so an `Idempotency-Key` header is required. Retries must carry the same key.
+
         Optional `maxSpendPerTransaction`, `maxSpendPerDay`, and `maxTransactionsPerDay` values set the card-specific caps on one transaction, on spend during one UTC calendar day, and on the number of transactions during one UTC calendar day. The limits are enforced by Grid for card programs where Grid makes the authorization decision, whether the card is funded by an Embedded Wallet account or custodial fiat. If the platform config sets the corresponding `cardConfigs` value, Grid enforces the lower of the card and platform caps. Amounts use the smallest unit of the card's currency.
 
         If any funding source is an Embedded Wallet internal account, the cardholder must authorize Grid to sign Spark token transactions for that card funding source by completing the delegated-key creation flow with `POST /auth/delegated-keys`. Until an active delegated key exists for that funding source, Authorization Decisioning cannot use it to fund card transactions.
@@ -8566,6 +8568,16 @@ paths:
         - Cards
       security:
         - BasicAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          description: |
+            A unique identifier for the request, up to 255 characters. A retry carrying the same key returns the card created by the first request; reusing a key for a materially different card request is rejected with `409`.
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+            example: 550e8400-e29b-41d4-a716-446655440000
       requestBody:
         required: true
         content:
@@ -8592,7 +8604,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
+          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `INVALID_INPUT` when the `Idempotency-Key` header is missing or exceeds 255 characters, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
           content:
             application/json:
               schema:

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -630,6 +630,7 @@ We follow the [IETF Idempotency-Key HTTP Header Field](https://datatracker.ietf.
 | `POST /quotes/{quoteId}/execute` | Executes a previously created quote |
 | `POST /transfer-in` | Initiates an inbound transfer |
 | `POST /transfer-out` | Initiates an outbound transfer |
+| `POST /cards` | Issues a new card for a cardholder |
 
 ### How It Works
 

--- a/openapi/paths/cards/cards.yaml
+++ b/openapi/paths/cards/cards.yaml
@@ -7,6 +7,10 @@ post:
     with `CARDHOLDER_KYC_NOT_APPROVED`.
 
 
+    Card issuance is fee-bearing and cannot be reversed, so an
+    `Idempotency-Key` header is required. Retries must carry the same key.
+
+
     Optional `maxSpendPerTransaction`, `maxSpendPerDay`, and
     `maxTransactionsPerDay` values set the card-specific caps on one
     transaction, on spend during one UTC calendar day, and on the number of
@@ -41,6 +45,19 @@ post:
     - Cards
   security:
     - BasicAuth: []
+  parameters:
+    - name: Idempotency-Key
+      in: header
+      description: >
+        A unique identifier for the request, up to 255 characters. A retry
+        carrying the same key returns the card created by the first request;
+        reusing a key for a materially different card request is rejected with
+        `409`.
+      required: true
+      schema:
+        type: string
+        maxLength: 255
+        example: 550e8400-e29b-41d4-a716-446655440000
   requestBody:
     required: true
     content:
@@ -73,7 +90,8 @@ post:
     '400':
       description: >-
         Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the
-        cardholder's KYC status is not `APPROVED`, with
+        cardholder's KYC status is not `APPROVED`, with `INVALID_INPUT` when
+        the `Idempotency-Key` header is missing or exceeds 255 characters, with
         `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does
         not belong to the cardholder or is not denominated in a
         card-eligible currency, and for general invalid parameters.


### PR DESCRIPTION
## Why

`POST /cards` declares no `parameters:` block at all. The `Idempotency-Key` header appears nowhere in the operation except inside the prose of the 409 response.

For card programs where the card issuer decides authorizations, that header is **mandatory**: `create_card.py` reads it, strips it, and rejects the request with `INVALID_INPUT` and "Idempotency-Key header is required for card issuance on this platform." There is no fallback on that path.

So a client written strictly against this spec cannot issue a card on those programs at all. That is not a nuance a careful reader could infer; it is an undocumented required input.

## What changed

- Declares `Idempotency-Key` as a **required** header parameter on `createCard`, following the `createInternalAccount` precedent, which requires the same header for the same reason: the operation mints something that cannot be reversed.
- States the retry semantics in the operation description.
- Names the missing-or-oversized key in the `400` description.
- Adds the row to the idempotency table in `openapi/README.md`.

## Why the guidance carries no condition

The first draft of this PR marked the parameter `required: false` and put the conditionality in the description: required for programs where the issuer decides authorizations, optional otherwise.

That was wrong, and the reason is worth recording. **Nothing in the API tells an integrator which card program they are on.** There is no field on `Card`, none on any platform resource, and no error that names it up front. A rule keyed on that distinction is one a caller cannot act on, and the failure mode is that they cannot construct a valid issuance request at all.

The spec does lean on the same distinction elsewhere ("Supported only for card programs whose authorization decisions are made by Grid"), but always for **optional** features, where a caller discovers the answer by getting a 400 on something they chose to send. For a required input it is a different class of problem.

Every caller should always send an idempotency key when issuing a card. That instruction is correct on both programs and is the only guidance an integrator can follow, so the parameter is simply required.

## What this deliberately accepts

Marking it required is a source-breaking change for generated SDKs: callers on the program where Grid derives a fallback key from the request body omit the header today, and their next SDK upgrade will demand it.

That is accepted deliberately. The API itself keeps accepting an omitted header on that program, so nothing deployed breaks at runtime. `info.version` is not bumped, since the wire contract has not changed.

## Notes for review

- Deliberately untouched: `cardholderId`, `fundingSources`, the request examples, and the `maxSpendPerTransaction` description. A separate workstream has pending renames in exactly those fields.
- This edits the same `400` description as the companion PR retiring `FUNDING_SOURCE_INELIGIBLE`, so those two conflict on whichever lands second. Trivial to resolve.
