### PR TITLE
Document the 409 that card reveal and the sandbox simulators return

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8874,7 +8874,9 @@ paths:
     post:
       summary: Reveal card details
       description: |-
-        Mint a signed, short-lived URL for the card processor's iframe that displays the card's full PAN, CVV, and expiry to the cardholder. This is the only way to obtain a reveal URL — the `Card` resource never carries one.
+        For card programs where Grid makes authorization decisions, mint a signed, short-lived URL for the card processor's iframe that displays the card's full PAN, CVV, and expiry to the cardholder. The `Card` resource never carries a reveal URL.
+
+        Cards in programs where the card issuer makes authorization decisions use the card issuer's challenge-based hosted reveal flow instead and cannot be revealed through this endpoint.
 
         Request the reveal right before rendering the iframe and render the returned `panEmbedUrl` immediately; it expires at `expiresAt` (within minutes). Never store, cache, or log the URL — it is a bearer secret for the full card details. The card data renders inside the processor's iframe and never crosses Grid's or your servers.
 
@@ -8909,6 +8911,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The card belongs to a program where the card issuer makes authorization decisions, so Grid cannot mint a PAN reveal URL for it. Use the card issuer's challenge-based hosted reveal flow instead. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9003,6 +9011,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9081,6 +9095,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9150,6 +9170,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9221,6 +9247,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9297,6 +9329,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9373,6 +9411,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9449,6 +9493,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9518,6 +9568,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9594,6 +9650,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9662,6 +9724,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9737,6 +9805,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9807,6 +9881,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:

--- a/mintlify/snippets/cards/issuing-cards.mdx
+++ b/mintlify/snippets/cards/issuing-cards.mdx
@@ -86,8 +86,11 @@ renders the full credentials directly to the cardholder. The full PAN
 and CVV never cross your servers or Grid's.
 
 <Note>
-`POST /cards/{id}/reveal` is the **only** way to obtain a reveal URL —
-the `Card` resource never carries one (not in responses, not in webhook
+For cards in programs where Grid makes authorization decisions,
+`POST /cards/{id}/reveal` is the **only** way to obtain a reveal URL;
+cards in programs where the card issuer makes authorization decisions use
+the card issuer's challenge-based hosted reveal flow instead. The `Card`
+resource never carries one (not in responses, not in webhook
 payloads). The URL expires at `expiresAt` (within minutes), so request a
 fresh reveal each time the cardholder asks for their details,
 immediately before rendering the iframe. Never store, cache, or log the
@@ -101,6 +104,7 @@ URL. Every reveal is audit-logged.
 | 400 | `CARDHOLDER_KYC_NOT_APPROVED` | Cardholder is not `kycStatus: APPROVED`. Drive KYC to completion before retrying. |
 | 400 | `FUNDING_SOURCE_INELIGIBLE` | The supplied internal account doesn't belong to the cardholder or isn't denominated in a card-eligible currency. |
 | 400 | `INVALID_INPUT` | Validation failure on the request body. |
+| 409 | `CONFLICT` | The card belongs to a program where the card issuer makes authorization decisions. Use the card issuer's challenge-based hosted reveal flow instead; retrying this endpoint will not help. |
 
 ## Changing funding sources later
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8874,7 +8874,9 @@ paths:
     post:
       summary: Reveal card details
       description: |-
-        Mint a signed, short-lived URL for the card processor's iframe that displays the card's full PAN, CVV, and expiry to the cardholder. This is the only way to obtain a reveal URL — the `Card` resource never carries one.
+        For card programs where Grid makes authorization decisions, mint a signed, short-lived URL for the card processor's iframe that displays the card's full PAN, CVV, and expiry to the cardholder. The `Card` resource never carries a reveal URL.
+
+        Cards in programs where the card issuer makes authorization decisions use the card issuer's challenge-based hosted reveal flow instead and cannot be revealed through this endpoint.
 
         Request the reveal right before rendering the iframe and render the returned `panEmbedUrl` immediately; it expires at `expiresAt` (within minutes). Never store, cache, or log the URL — it is a bearer secret for the full card details. The card data renders inside the processor's iframe and never crosses Grid's or your servers.
 
@@ -8909,6 +8911,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The card belongs to a program where the card issuer makes authorization decisions, so Grid cannot mint a PAN reveal URL for it. Use the card issuer's challenge-based hosted reveal flow instead. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9003,6 +9011,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9081,6 +9095,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9150,6 +9170,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9221,6 +9247,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9297,6 +9329,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9373,6 +9411,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9449,6 +9493,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9518,6 +9568,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9594,6 +9650,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9662,6 +9724,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9737,6 +9805,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:
@@ -9807,6 +9881,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. The simulation targets a card in a program where the card issuer makes authorization decisions. These sandbox simulators support only card programs where Grid makes authorization decisions. This is a property of the card's program, so retrying will not help.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '500':
           description: Internal service error
           content:

--- a/openapi/paths/cards/cards_{id}_reveal.yaml
+++ b/openapi/paths/cards/cards_{id}_reveal.yaml
@@ -8,10 +8,15 @@ parameters:
 post:
   summary: Reveal card details
   description: >-
-    Mint a signed, short-lived URL for the card processor's iframe that
-    displays the card's full PAN, CVV, and expiry to the cardholder. This is
-    the only way to obtain a reveal URL — the `Card` resource never carries
-    one.
+    For card programs where Grid makes authorization decisions, mint a signed,
+    short-lived URL for the card processor's iframe that displays the card's
+    full PAN, CVV, and expiry to the cardholder. The `Card` resource never
+    carries a reveal URL.
+
+
+    Cards in programs where the card issuer makes authorization decisions use
+    the card issuer's challenge-based hosted reveal flow instead and cannot be
+    revealed through this endpoint.
 
 
     Request the reveal right before rendering the iframe and render the
@@ -54,6 +59,16 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The card belongs to a program where the card issuer makes
+        authorization decisions, so Grid cannot mint a PAN reveal URL for it.
+        Use the card issuer's challenge-based hosted reveal flow instead. This
+        is a property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
@@ -96,6 +96,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_advice.yaml
@@ -69,6 +69,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_expiry.yaml
@@ -74,6 +74,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization_reversal.yaml
@@ -80,6 +80,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_balance_inquiry.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_balance_inquiry.yaml
@@ -70,6 +70,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_clearing.yaml
@@ -82,6 +82,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization.yaml
@@ -78,6 +78,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_credit_authorization_advice.yaml
@@ -79,6 +79,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_authorization.yaml
@@ -79,6 +79,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_credit_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_financial_credit_authorization.yaml
@@ -78,6 +78,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return.yaml
@@ -67,6 +67,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_return_reversal.yaml
@@ -67,6 +67,16 @@ post:
         application/json:
           schema:
             $ref: ../../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. The simulation targets a card in a program where the card
+        issuer makes authorization decisions. These sandbox simulators support
+        only card programs where Grid makes authorization decisions. This is a
+        property of the card's program, so retrying will not help.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/errors/Error409.yaml
     '500':
       description: Internal service error
       content:


### PR DESCRIPTION
## Why

Thirteen card operations return `409` in production for an entire class of card, and not one of them declared a `409` response.

- `POST /cards/{id}/reveal` declared 200, 401, 403, 404, 500, 501.
- All twelve `POST /sandbox/cards/{id}/simulate/*` operations declared 202, 400, 401, 403, 404, 500.

A generated SDK therefore has no typed branch for a status these operations really answer with, and a reader has no way to learn from the spec that a whole card program is excluded.

The reveal operation's description also implied every card can be revealed, which is what sends an integrator looking for a bug when they get the 409.

## What the code actually does

**Reveal** (`create_card_reveal.py`): the handler refuses on the card's provider kind alone, before any credential lookup, so the answer never depends on whether provider configuration happens to be present. Cards whose issuer decides authorizations have no Grid-minted PAN reveal at all; the reveal is the issuer's own challenge-based hosted flow. The already-declared `501` is a different condition: card issuance not enabled in the deployment.

**Sandbox** (`gen_require_lithic_simulable` in `sandbox_simulate_common.py`): simulated state on a provider-authoritative card would contradict the issuer's own ledger, so the guard refuses with `409`. It fires for all three ways a caller can name such a card: the canonical `Card:<uuid>`, the raw processor token `POST /cards` returns, and the issuer-side card id.

## What changed

A `409` on the reveal operation and on all twelve simulate operations, plus a corrected reveal description. Every simulate operation gets the identical description, because it is the identical condition.

Each description says it is a property of the card's program rather than a transient state, so a caller knows retrying will not help.

## Notes for review

- Twelve simulate operations, not ten. `authorization_expiry` and `authorization_reversal` are both already documented.
- The 409 descriptions deliberately do not claim that every non-simulable card gets a 409. A card belonging to **another platform** is answered as not-found instead, so that a raw provider id cannot be used to probe cross-tenant card existence. Wording that contradicted that would have been a leak in the docs.
- Response declarations only. No request schemas, examples, or descriptor-suffix outcome tables were touched.
