### PR TITLE
Retire four card-API features nothing implements

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8559,7 +8559,7 @@ paths:
 
         A platform may be limited to a maximum number of live cards. Once that limit is reached, further issuance is rejected with `CARD_LIMIT_REACHED` until a card is closed or Lightspark raises the limit. Cards in `CLOSED` state do not count toward the limit.
 
-        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE`.
       operationId: createCard
       tags:
         - Cards
@@ -8590,7 +8590,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
+          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, and with `INVALID_INPUT` when a supplied funding source does not belong to the cardholder, is not denominated in a card-eligible currency, or for other invalid parameters.
           content:
             application/json:
               schema:
@@ -8649,7 +8649,7 @@ paths:
             type: string
         - name: state
           in: query
-          description: Filter by card state.
+          description: Filter by card state. Accepted values are `PROCESSING`, `ACTIVE`, `FROZEN`, and `CLOSED`. `PENDING_KYC` is reserved and is rejected as an invalid filter.
           required: false
           schema:
             $ref: '#/components/schemas/CardState'
@@ -8828,7 +8828,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a supplied funding source does not belong to the cardholder or is not denominated in the card's currency, and for general invalid parameters.
+          description: Bad request. Returned with `INVALID_INPUT` when a supplied funding source does not belong to the cardholder, is not denominated in the card's currency, or for other invalid parameters.
           content:
             application/json:
               schema:
@@ -11636,7 +11636,7 @@ webhooks:
     post:
       summary: Card state change
       description: |
-        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
+        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE` and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
 
         This endpoint should be implemented by clients of the Grid API.
 
@@ -11674,7 +11674,6 @@ webhooks:
                     platformCardId: card-emp-aary-001
                     state: ACTIVE
                     stateReason: null
-                    brand: VISA
                     form: VIRTUAL
                     last4: '4242'
                     expMonth: 12
@@ -11688,25 +11687,6 @@ webhooks:
                     issuerRef: lead_card_7a1b9c3d
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:11:00Z'
-              issuerRejected:
-                summary: Card rejected by issuer during provisioning
-                value:
-                  id: Webhook:019542f5-b3e7-1d02-0000-000000000021
-                  type: CARD.STATE_CHANGE
-                  timestamp: '2026-05-08T14:12:00Z'
-                  data:
-                    id: Card:019542f5-b3e7-1d02-0000-000000000011
-                    cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
-                    state: CLOSED
-                    stateReason: ISSUER_REJECTED
-                    form: VIRTUAL
-                    fundingSources:
-                      - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-                    maxSpendPerTransaction: null
-                    maxSpendPerDay: null
-                    currency: USD
-                    createdAt: '2026-05-08T14:10:00Z'
-                    updatedAt: '2026-05-08T14:12:00Z'
               frozen:
                 summary: Card frozen by the platform
                 value:
@@ -11718,7 +11698,6 @@ webhooks:
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     state: FROZEN
                     stateReason: null
-                    brand: VISA
                     form: VIRTUAL
                     last4: '4242'
                     expMonth: 12
@@ -26023,7 +26002,7 @@ components:
 
         | State | Description |
         |-------|-------------|
-        | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
+        | `PENDING_KYC` | Reserved for generated SDK compatibility. Grid does not return this state, and `GET /cards` rejects it as a `state` filter. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
@@ -26035,23 +26014,13 @@ components:
         - CLOSED_BY_PLATFORM
         - CLOSED_BY_GRID
       description: |
-        Reason a card reached a terminal or non-active state. Present on
-        `CLOSED` cards, and on cards that fail provisioning before reaching
-        `ACTIVE`.
+        Reason a card reached `CLOSED`.
 
         | Reason | Description |
         |--------|-------------|
-        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
+        | `ISSUER_REJECTED` | Reserved for generated SDK compatibility. Grid does not currently return this reason. |
         | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
         | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |
-    CardBrand:
-      type: string
-      enum:
-        - VISA
-        - MASTERCARD
-      description: |
-        Card network brand. Read-only — determined by Grid when the card is
-        provisioned with the issuer.
     CardForm:
       type: string
       enum:
@@ -26091,9 +26060,7 @@ components:
           anyOf:
             - $ref: '#/components/schemas/CardStateReason'
             - type: 'null'
-          description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.
-        brand:
-          $ref: '#/components/schemas/CardBrand'
+          description: Reason associated with the current `state`. Populated when the card is `CLOSED`; otherwise null.
         form:
           $ref: '#/components/schemas/CardForm'
         last4:
@@ -26206,7 +26173,7 @@ components:
           $ref: '#/components/schemas/CardForm'
         fundingSources:
           type: array
-          description: Internal account ids to bind as funding sources, in priority order. The first entry is tried first by Authorization Decisioning. Every card must be bound to at least one source, and every source must belong to the cardholder and be denominated in a card-eligible currency; otherwise the request is rejected with `FUNDING_SOURCE_INELIGIBLE`.
+          description: Internal account ids to bind as funding sources, in priority order. The first entry is tried first by Authorization Decisioning. Every card must be bound to at least one source, and every source must belong to the cardholder and be denominated in a card-eligible currency; otherwise the request is rejected with `INVALID_INPUT`.
           minItems: 1
           items:
             type: string

--- a/mintlify/snippets/cards/cardholder-setup.mdx
+++ b/mintlify/snippets/cards/cardholder-setup.mdx
@@ -26,7 +26,7 @@ time. The account must:
 
 - Belong to the cardholder (no cross-customer funding in v1).
 - Be denominated in a card-eligible currency. In v1 this is USDB; the
-  request is rejected with `400 FUNDING_SOURCE_INELIGIBLE` otherwise.
+  request is rejected with `400 INVALID_INPUT` otherwise.
 
 If the cardholder doesn't have an internal account yet, internal
 accounts are created automatically when the customer is created based

--- a/mintlify/snippets/cards/funding-sources.mdx
+++ b/mintlify/snippets/cards/funding-sources.mdx
@@ -29,7 +29,7 @@ Each source must:
   one currency.
 
 If any source fails these checks, the request is rejected with
-`400 FUNDING_SOURCE_INELIGIBLE`.
+`400 INVALID_INPUT`.
 
 ## Replacing the binding
 
@@ -59,9 +59,8 @@ together.
 
 | Status | Code | What it means |
 |--------|------|---------------|
-| 400 | `FUNDING_SOURCE_INELIGIBLE` | A supplied account doesn't belong to the cardholder or isn't denominated in the card's currency. |
+| 400 | `INVALID_INPUT` | A supplied account doesn't belong to the cardholder, isn't denominated in the card's currency, or the `fundingSources` array is empty. |
 | 409 | `CARD_NOT_MUTABLE` | The card is `CLOSED`. |
-| 400 | `INVALID_INPUT` | The `fundingSources` array is empty (a card must have at least one source). |
 
 <Warning>
 `fundingSources` is a full replacement, not a delta. Always send the

--- a/mintlify/snippets/cards/intro.mdx
+++ b/mintlify/snippets/cards/intro.mdx
@@ -20,11 +20,10 @@ the same ledger you already use for payouts.
 
 ## Card lifecycle at a glance
 
-A card moves through five states:
+A card moves through four states:
 
 | State | Meaning |
 |-------|---------|
-| `PENDING_KYC` | Cardholder has not finished KYC; the card cannot transact yet. |
 | `PROCESSING` | Card has been requested and is being provisioned with the issuer. |
 | `ACTIVE` | Card is live and can authorize transactions. |
 | `FROZEN` | Card is temporarily disabled. New authorizations are declined; in-flight settlements continue. |

--- a/mintlify/snippets/cards/issuing-cards.mdx
+++ b/mintlify/snippets/cards/issuing-cards.mdx
@@ -37,10 +37,8 @@ one currency.
 
 ```text
 PROCESSING    ──► ACTIVE ──► FROZEN ──► ACTIVE ──► CLOSED
-       │             │                              ▲
-       │             └──────────────────────────────┘
-       │
-       └─► CLOSED (stateReason: ISSUER_REJECTED)
+                     │                              ▲
+                     └──────────────────────────────┘
 ```
 
 | State | When you see it |
@@ -48,10 +46,7 @@ PROCESSING    ──► ACTIVE ──► FROZEN ──► ACTIVE ──► CLOSE
 | `PROCESSING` | Returned synchronously from `POST /cards`. The card cannot transact yet. |
 | `ACTIVE` | Issuer provisioned the card. Reached via `CARD.STATE_CHANGE` webhook. |
 | `FROZEN` | You called `PATCH /cards/{id}` with `state: "FROZEN"`. |
-| `CLOSED` | You called `PATCH /cards/{id}` with `state: "CLOSED"` (or the issuer rejected provisioning). Terminal. |
-
-`PENDING_KYC` is also a valid state but you should not see it in v1 —
-issuance is gated on KYC up front.
+| `CLOSED` | You called `PATCH /cards/{id}` with `state: "CLOSED"`. Terminal. |
 
 ## After issuance
 
@@ -59,10 +54,6 @@ issuance is gated on KYC up front.
 issuer provisions the card asynchronously; on success a
 `CARD.STATE_CHANGE` webhook fires with the activated `Card` resource
 including the populated `last4`, `expMonth`, and `expYear`.
-
-If the issuer rejects provisioning, the same webhook fires with
-`state: "CLOSED"` and `stateReason: "ISSUER_REJECTED"`. That card is
-terminal — issue a new one with a fresh `platformCardId` to retry.
 
 ## Revealing the PAN
 
@@ -99,8 +90,7 @@ URL. Every reveal is audit-logged.
 | Status | Code | What it means |
 |--------|------|---------------|
 | 400 | `CARDHOLDER_KYC_NOT_APPROVED` | Cardholder is not `kycStatus: APPROVED`. Drive KYC to completion before retrying. |
-| 400 | `FUNDING_SOURCE_INELIGIBLE` | The supplied internal account doesn't belong to the cardholder or isn't denominated in a card-eligible currency. |
-| 400 | `INVALID_INPUT` | Validation failure on the request body. |
+| 400 | `INVALID_INPUT` | The supplied internal account doesn't belong to the cardholder, isn't denominated in a card-eligible currency, or another request-body validation failed. |
 
 ## Changing funding sources later
 

--- a/mintlify/snippets/cards/quickstart.mdx
+++ b/mintlify/snippets/cards/quickstart.mdx
@@ -65,7 +65,6 @@ for the full table. When activation completes, a
     "id": "Card:019542f5-b3e7-1d02-0000-000000000010",
     "cardholderId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
     "state": "ACTIVE",
-    "brand": "VISA",
     "form": "VIRTUAL",
     "last4": "4242",
     "expMonth": 12,

--- a/mintlify/snippets/cards/sandbox-testing.mdx
+++ b/mintlify/snippets/cards/sandbox-testing.mdx
@@ -21,7 +21,6 @@ The last three characters of `platformCardId` (or `cardholderId` when
 | Suffix | Behavior |
 |--------|----------|
 | `001` | Stays `PROCESSING` indefinitely (test the polling path) |
-| `002` | Issuer provisioning rejected → `state: CLOSED`, `stateReason: "ISSUER_REJECTED"` |
 | `005` | Delayed activation (~30s) before the `CARD.STATE_CHANGE` webhook fires |
 | any other | Instant activation → `state: ACTIVE`, `last4` deterministic from the suffix |
 
@@ -32,8 +31,8 @@ of `accountId`:
 
 | Suffix | Behavior |
 |--------|----------|
-| `002` | `FUNDING_SOURCE_INELIGIBLE` (insufficient balance check) |
-| `003` | `FUNDING_SOURCE_INELIGIBLE` (account closed) |
+| `002` | `INVALID_INPUT` (insufficient balance check) |
+| `003` | `INVALID_INPUT` (account closed) |
 | any other | Success |
 
 ## Authorization simulate

--- a/mintlify/snippets/cards/webhooks.mdx
+++ b/mintlify/snippets/cards/webhooks.mdx
@@ -11,7 +11,7 @@ lifecycle.
 
 | Type | Fires on |
 |------|----------|
-| `CARD.STATE_CHANGE` | `PROCESSING → ACTIVE`, `→ CLOSED (ISSUER_REJECTED)`, and every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition. |
+| `CARD.STATE_CHANGE` | `PROCESSING → ACTIVE` and every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition. |
 | `CARD_TRANSACTION.AUTHORIZED` | An authorization is approved and a hold is placed on the funding source. |
 | `CARD_TRANSACTION.PARTIALLY_SETTLED` | A clearing posted, but more are still expected. |
 | `CARD_TRANSACTION.SETTLED` | All clearings have posted. Re-fires when a merchant return lands, with the returned value in `refundedAmount`. |
@@ -44,7 +44,6 @@ activation after issuance:
     "id": "Card:019542f5-b3e7-1d02-0000-000000000010",
     "cardholderId": "Customer:019542f5-b3e7-1d02-0000-000000000001",
     "state": "ACTIVE",
-    "brand": "VISA",
     "form": "VIRTUAL",
     "last4": "4242",
     "expMonth": 12,
@@ -68,8 +67,6 @@ Common branches to handle in your consumer:
   `POST /cards/{id}/reveal` right before rendering its short-lived
   `panEmbedUrl` in an iframe — webhook payloads never carry a reveal
   URL.
-- `state: "CLOSED"`, `stateReason: "ISSUER_REJECTED"` — the issuer
-  rejected provisioning; offer to issue a new card.
 - `state: "FROZEN"` / `state: "ACTIVE"` — reflect the freeze toggle in
   your UI.
 - `state: "CLOSED"`, `stateReason: "CLOSED_BY_PLATFORM"` — close

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8559,7 +8559,7 @@ paths:
 
         A platform may be limited to a maximum number of live cards. Once that limit is reached, further issuance is rejected with `CARD_LIMIT_REACHED` until a card is closed or Lightspark raises the limit. Cards in `CLOSED` state do not count toward the limit.
 
-        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE` (or to `CLOSED` with `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+        New cards start in `state: "PROCESSING"` while the card issuer provisions the card. The `card.state_change` webhook fires on each state transition, including the transition to `ACTIVE`.
       operationId: createCard
       tags:
         - Cards
@@ -8590,7 +8590,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, with `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does not belong to the cardholder or is not denominated in a card-eligible currency, and for general invalid parameters.
+          description: Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the cardholder's KYC status is not `APPROVED`, and with `INVALID_INPUT` when a supplied funding source does not belong to the cardholder, is not denominated in a card-eligible currency, or for other invalid parameters.
           content:
             application/json:
               schema:
@@ -8649,7 +8649,7 @@ paths:
             type: string
         - name: state
           in: query
-          description: Filter by card state.
+          description: Filter by card state. Accepted values are `PROCESSING`, `ACTIVE`, `FROZEN`, and `CLOSED`. `PENDING_KYC` is reserved and is rejected as an invalid filter.
           required: false
           schema:
             $ref: '#/components/schemas/CardState'
@@ -8828,7 +8828,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Card'
         '400':
-          description: Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a supplied funding source does not belong to the cardholder or is not denominated in the card's currency, and for general invalid parameters.
+          description: Bad request. Returned with `INVALID_INPUT` when a supplied funding source does not belong to the cardholder, is not denominated in the card's currency, or for other invalid parameters.
           content:
             application/json:
               schema:
@@ -11636,7 +11636,7 @@ webhooks:
     post:
       summary: Card state change
       description: |
-        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)` when issuer provisioning fails, and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
+        Webhook that is called when a card's lifecycle state changes. Fires on `PROCESSING → ACTIVE` and on every subsequent `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
 
         This endpoint should be implemented by clients of the Grid API.
 
@@ -11674,7 +11674,6 @@ webhooks:
                     platformCardId: card-emp-aary-001
                     state: ACTIVE
                     stateReason: null
-                    brand: VISA
                     form: VIRTUAL
                     last4: '4242'
                     expMonth: 12
@@ -11688,25 +11687,6 @@ webhooks:
                     issuerRef: lead_card_7a1b9c3d
                     createdAt: '2026-05-08T14:10:00Z'
                     updatedAt: '2026-05-08T14:11:00Z'
-              issuerRejected:
-                summary: Card rejected by issuer during provisioning
-                value:
-                  id: Webhook:019542f5-b3e7-1d02-0000-000000000021
-                  type: CARD.STATE_CHANGE
-                  timestamp: '2026-05-08T14:12:00Z'
-                  data:
-                    id: Card:019542f5-b3e7-1d02-0000-000000000011
-                    cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
-                    state: CLOSED
-                    stateReason: ISSUER_REJECTED
-                    form: VIRTUAL
-                    fundingSources:
-                      - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-                    maxSpendPerTransaction: null
-                    maxSpendPerDay: null
-                    currency: USD
-                    createdAt: '2026-05-08T14:10:00Z'
-                    updatedAt: '2026-05-08T14:12:00Z'
               frozen:
                 summary: Card frozen by the platform
                 value:
@@ -11718,7 +11698,6 @@ webhooks:
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     state: FROZEN
                     stateReason: null
-                    brand: VISA
                     form: VIRTUAL
                     last4: '4242'
                     expMonth: 12
@@ -26023,7 +26002,7 @@ components:
 
         | State | Description |
         |-------|-------------|
-        | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
+        | `PENDING_KYC` | Reserved for generated SDK compatibility. Grid does not return this state, and `GET /cards` rejects it as a `state` filter. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
         | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
@@ -26035,23 +26014,13 @@ components:
         - CLOSED_BY_PLATFORM
         - CLOSED_BY_GRID
       description: |
-        Reason a card reached a terminal or non-active state. Present on
-        `CLOSED` cards, and on cards that fail provisioning before reaching
-        `ACTIVE`.
+        Reason a card reached `CLOSED`.
 
         | Reason | Description |
         |--------|-------------|
-        | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
+        | `ISSUER_REJECTED` | Reserved for generated SDK compatibility. Grid does not currently return this reason. |
         | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
         | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |
-    CardBrand:
-      type: string
-      enum:
-        - VISA
-        - MASTERCARD
-      description: |
-        Card network brand. Read-only — determined by Grid when the card is
-        provisioned with the issuer.
     CardForm:
       type: string
       enum:
@@ -26091,9 +26060,7 @@ components:
           anyOf:
             - $ref: '#/components/schemas/CardStateReason'
             - type: 'null'
-          description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.
-        brand:
-          $ref: '#/components/schemas/CardBrand'
+          description: Reason associated with the current `state`. Populated when the card is `CLOSED`; otherwise null.
         form:
           $ref: '#/components/schemas/CardForm'
         last4:
@@ -26206,7 +26173,7 @@ components:
           $ref: '#/components/schemas/CardForm'
         fundingSources:
           type: array
-          description: Internal account ids to bind as funding sources, in priority order. The first entry is tried first by Authorization Decisioning. Every card must be bound to at least one source, and every source must belong to the cardholder and be denominated in a card-eligible currency; otherwise the request is rejected with `FUNDING_SOURCE_INELIGIBLE`.
+          description: Internal account ids to bind as funding sources, in priority order. The first entry is tried first by Authorization Decisioning. Every card must be bound to at least one source, and every source must belong to the cardholder and be denominated in a card-eligible currency; otherwise the request is rejected with `INVALID_INPUT`.
           minItems: 1
           items:
             type: string

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -33,9 +33,7 @@ properties:
       - type: 'null'
     description: >-
       Reason associated with the current `state`. Populated when the card is
-      `CLOSED` or when provisioning was rejected; otherwise null.
-  brand:
-    $ref: ./CardBrand.yaml
+      `CLOSED`; otherwise null.
   form:
     $ref: ./CardForm.yaml
   last4:

--- a/openapi/components/schemas/cards/CardBrand.yaml
+++ b/openapi/components/schemas/cards/CardBrand.yaml
@@ -1,7 +1,0 @@
-type: string
-enum:
-  - VISA
-  - MASTERCARD
-description: |
-  Card network brand. Read-only — determined by Grid when the card is
-  provisioned with the issuer.

--- a/openapi/components/schemas/cards/CardCreateRequest.yaml
+++ b/openapi/components/schemas/cards/CardCreateRequest.yaml
@@ -37,7 +37,7 @@ properties:
       card must be bound to at least one source, and every source must
       belong to the cardholder and be denominated in a card-eligible
       currency; otherwise the request is rejected with
-      `FUNDING_SOURCE_INELIGIBLE`.
+      `INVALID_INPUT`.
     minItems: 1
     items:
       type: string

--- a/openapi/components/schemas/cards/CardState.yaml
+++ b/openapi/components/schemas/cards/CardState.yaml
@@ -10,7 +10,7 @@ description: |
 
   | State | Description |
   |-------|-------------|
-  | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
+  | `PENDING_KYC` | Reserved for generated SDK compatibility. Grid does not return this state, and `GET /cards` rejects it as a `state` filter. |
   | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
   | `ACTIVE` | The card is live and can authorize transactions. |
   | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |

--- a/openapi/components/schemas/cards/CardStateReason.yaml
+++ b/openapi/components/schemas/cards/CardStateReason.yaml
@@ -4,12 +4,10 @@ enum:
   - CLOSED_BY_PLATFORM
   - CLOSED_BY_GRID
 description: |
-  Reason a card reached a terminal or non-active state. Present on
-  `CLOSED` cards, and on cards that fail provisioning before reaching
-  `ACTIVE`.
+  Reason a card reached `CLOSED`.
 
   | Reason | Description |
   |--------|-------------|
-  | `ISSUER_REJECTED` | The card issuer rejected provisioning during `PROCESSING`. |
+  | `ISSUER_REJECTED` | Reserved for generated SDK compatibility. Grid does not currently return this reason. |
   | `CLOSED_BY_PLATFORM` | The card was closed via `PATCH /cards/{id}` (`state: CLOSED`) by the platform. |
   | `CLOSED_BY_GRID` | The card was closed by Grid (e.g. compliance or risk action). |

--- a/openapi/paths/cards/cards.yaml
+++ b/openapi/paths/cards/cards.yaml
@@ -32,8 +32,7 @@ post:
 
     New cards start in `state: "PROCESSING"` while the card issuer
     provisions the card. The `card.state_change` webhook fires on each state
-    transition, including the transition to `ACTIVE` (or to `CLOSED` with
-    `stateReason: "ISSUER_REJECTED"` if provisioning fails).
+    transition, including the transition to `ACTIVE`.
   operationId: createCard
   tags:
     - Cards
@@ -70,10 +69,10 @@ post:
     '400':
       description: >-
         Bad request. Returned with `CARDHOLDER_KYC_NOT_APPROVED` when the
-        cardholder's KYC status is not `APPROVED`, with
-        `FUNDING_SOURCE_INELIGIBLE` when the supplied funding source does
-        not belong to the cardholder or is not denominated in a
-        card-eligible currency, and for general invalid parameters.
+        cardholder's KYC status is not `APPROVED`, and with `INVALID_INPUT`
+        when a supplied funding source does not belong to the cardholder,
+        is not denominated in a card-eligible currency, or for other invalid
+        parameters.
       content:
         application/json:
           schema:
@@ -145,7 +144,10 @@ get:
         type: string
     - name: state
       in: query
-      description: Filter by card state.
+      description: >-
+        Filter by card state. Accepted values are `PROCESSING`, `ACTIVE`,
+        `FROZEN`, and `CLOSED`. `PENDING_KYC` is reserved and is rejected as
+        an invalid filter.
       required: false
       schema:
         $ref: ../../components/schemas/cards/CardState.yaml

--- a/openapi/paths/cards/cards_{id}.yaml
+++ b/openapi/paths/cards/cards_{id}.yaml
@@ -177,10 +177,9 @@ patch:
             $ref: ../../components/schemas/cards/Card.yaml
     '400':
       description: >-
-        Bad request. Returned with `FUNDING_SOURCE_INELIGIBLE` when a
-        supplied funding source does not belong to the cardholder or is
-        not denominated in the card's currency, and for general invalid
-        parameters.
+        Bad request. Returned with `INVALID_INPUT` when a supplied funding
+        source does not belong to the cardholder, is not denominated in the
+        card's currency, or for other invalid parameters.
       content:
         application/json:
           schema:

--- a/openapi/webhooks/card-state-change.yaml
+++ b/openapi/webhooks/card-state-change.yaml
@@ -2,9 +2,8 @@ post:
   summary: Card state change
   description: >
     Webhook that is called when a card's lifecycle state changes. Fires on
-    `PROCESSING → ACTIVE`, on `PROCESSING → CLOSED (ISSUER_REJECTED)`
-    when issuer provisioning fails, and on every subsequent
-    `ACTIVE ⇄ FROZEN` and `→ CLOSED` transition.
+    `PROCESSING → ACTIVE` and on every subsequent `ACTIVE ⇄ FROZEN` and
+    `→ CLOSED` transition.
 
 
     This endpoint should be implemented by clients of the Grid API.
@@ -53,7 +52,6 @@ post:
                 platformCardId: card-emp-aary-001
                 state: ACTIVE
                 stateReason: null
-                brand: VISA
                 form: VIRTUAL
                 last4: '4242'
                 expMonth: 12
@@ -67,25 +65,6 @@ post:
                 issuerRef: lead_card_7a1b9c3d
                 createdAt: '2026-05-08T14:10:00Z'
                 updatedAt: '2026-05-08T14:11:00Z'
-          issuerRejected:
-            summary: Card rejected by issuer during provisioning
-            value:
-              id: Webhook:019542f5-b3e7-1d02-0000-000000000021
-              type: CARD.STATE_CHANGE
-              timestamp: '2026-05-08T14:12:00Z'
-              data:
-                id: Card:019542f5-b3e7-1d02-0000-000000000011
-                cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
-                state: CLOSED
-                stateReason: ISSUER_REJECTED
-                form: VIRTUAL
-                fundingSources:
-                  - InternalAccount:019542f5-b3e7-1d02-0000-000000000002
-                maxSpendPerTransaction: null
-                maxSpendPerDay: null
-                currency: USD
-                createdAt: '2026-05-08T14:10:00Z'
-                updatedAt: '2026-05-08T14:12:00Z'
           frozen:
             summary: Card frozen by the platform
             value:
@@ -97,7 +76,6 @@ post:
                 cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 state: FROZEN
                 stateReason: null
-                brand: VISA
                 form: VIRTUAL
                 last4: '4242'
                 expMonth: 12


### PR DESCRIPTION
## Why

Four things in the card surface were documented, generated into the SDKs, and never produced by any code path. Each one gives an integrator dead handling: a branch they write, test against nothing, and carry forever.

Verified against `lightsparkdev/webdev` at `origin/main`.

| Item | Finding |
|---|---|
| `FUNDING_SOURCE_INELIGIBLE` | **Zero occurrences in the entire sparkcore tree.** Callers get the generic `INVALID_INPUT`. |
| `Card.brand` | No column behind it. The code's own docstring says so: "no card provider reports the network brand to us". Absent from every response, yet the webhook example showed `brand: VISA`. |
| `CardStateReason.ISSUER_REJECTED` | **Zero occurrences in sparkcore.** No path writes it. |
| `CardState.PENDING_KYC` | Maps to no internal status, so never emitted, and rejected as a `state` filter exactly like a nonsense value. A test parametrized over `["BOGUS", "PENDING_KYC"]` asserts both are refused. |

## Deleted versus kept, and the rule that decides it

**Deleted:** `FUNDING_SOURCE_INELIGIBLE`. It is an error code named only in prose, not a member of any published schema, so nothing generated references it and removing it breaks no consumer.

**Kept and marked as not populated:** `Card.brand` (with its `CardBrand` schema), `ISSUER_REJECTED`, and `PENDING_KYC`. Each of these is a member of a published schema, so removing it drops a property or an enum variant from the generated SDKs. That is source-breaking for a consumer who references `card.brand` or switches exhaustively on the enum, even though they have never received a value. The repo requires `info.version` and the `servers.url` path to advance for a breaking change, and none of this is worth an API version.

An earlier revision of this PR deleted `brand` while keeping the two enum variants on exactly that reasoning, which was inconsistent: referencing a property is more common in consumer code than exhaustive enum switching, not less. Greptile caught it. All three are now treated the same way.

## What actually carries the value

Every **misleading** artifact is gone, and none of that is breaking:

- The `brand: VISA` value in the `card-state-change` webhook example, and `"brand": "VISA"` in the Mintlify samples. A field Grid never populates must not appear populated in an example someone copies.
- The `issuerRejected` webhook example in full, because it demonstrated a state transition that does not occur.
- Every claim in prose that Grid emits these: the lifecycle diagram's `ISSUER_REJECTED` branch, "a card moves through five states", and the error tables listing `FUNDING_SOURCE_INELIGIBLE`.
- The `stateReason` description's claim that it is populated "when provisioning was rejected".

A deleted claim still described in a guide is the same defect one layer up, so the Mintlify sweep is in the same PR.

## Fenced off from the other workstream

Deliberately untouched, because a separate workstream has pending changes there:

- the nullability of `stateReason` (they are removing `null` from the response `oneOf`)
- `cardholderId`, `fundingSources`, and the `POST /cards` field names generally
- `CARD_LIMIT_REACHED`, which is real and has tests

The `cardholderId` and `fundingSources` lines that appear deleted in this diff are inside the `issuerRejected` example that was removed whole; no field name was renamed.

**`info.version` is not bumped, and after the revision above nothing in this PR requires it.**
