### PR TITLE
add CARD to TransactionType

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12223,7 +12223,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransactionType'
-          description: Payment types that are enabled for this currency. Card transactions are enabled through the card program, not through this list.
+          description: List of transaction types that are enabled for this currency.
           example:
             - OUTGOING
             - INCOMING

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12169,7 +12169,7 @@ components:
         - INCOMING
         - OUTGOING
         - CARD
-      description: Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a card transaction, listed alongside payments in `GET /transactions`.
+      description: Type of transaction
     PlatformCurrencyConfig:
       type: object
       properties:

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -12168,7 +12168,8 @@ components:
       enum:
         - INCOMING
         - OUTGOING
-      description: Type of transaction (incoming payment or outgoing payment)
+        - CARD
+      description: Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a card transaction, listed alongside payments in `GET /transactions`.
     PlatformCurrencyConfig:
       type: object
       properties:
@@ -12222,7 +12223,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransactionType'
-          description: List of transaction types that are enabled for this currency.
+          description: Payment types that are enabled for this currency. Card transactions are enabled through the card program, not through this list.
           example:
             - OUTGOING
             - INCOMING

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12223,7 +12223,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransactionType'
-          description: Payment types that are enabled for this currency. Card transactions are enabled through the card program, not through this list.
+          description: List of transaction types that are enabled for this currency.
           example:
             - OUTGOING
             - INCOMING

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12169,7 +12169,7 @@ components:
         - INCOMING
         - OUTGOING
         - CARD
-      description: Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a card transaction, listed alongside payments in `GET /transactions`.
+      description: Type of transaction
     PlatformCurrencyConfig:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12168,7 +12168,8 @@ components:
       enum:
         - INCOMING
         - OUTGOING
-      description: Type of transaction (incoming payment or outgoing payment)
+        - CARD
+      description: Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a card transaction, listed alongside payments in `GET /transactions`.
     PlatformCurrencyConfig:
       type: object
       properties:
@@ -12222,7 +12223,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransactionType'
-          description: List of transaction types that are enabled for this currency.
+          description: Payment types that are enabled for this currency. Card transactions are enabled through the card program, not through this list.
           example:
             - OUTGOING
             - INCOMING

--- a/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
+++ b/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
@@ -61,7 +61,9 @@ properties:
     type: array
     items:
       $ref: ../transactions/TransactionType.yaml
-    description: List of transaction types that are enabled for this currency.
+    description: >-
+      Payment types that are enabled for this currency. Card transactions are
+      enabled through the card program, not through this list.
     example:
       - OUTGOING
       - INCOMING

--- a/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
+++ b/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
@@ -61,9 +61,7 @@ properties:
     type: array
     items:
       $ref: ../transactions/TransactionType.yaml
-    description: >-
-      Payment types that are enabled for this currency. Card transactions are
-      enabled through the card program, not through this list.
+    description: List of transaction types that are enabled for this currency.
     example:
       - OUTGOING
       - INCOMING

--- a/openapi/components/schemas/transactions/TransactionType.yaml
+++ b/openapi/components/schemas/transactions/TransactionType.yaml
@@ -3,6 +3,4 @@ enum:
   - INCOMING
   - OUTGOING
   - CARD
-description: >-
-  Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a
-  card transaction, listed alongside payments in `GET /transactions`.
+description: Type of transaction

--- a/openapi/components/schemas/transactions/TransactionType.yaml
+++ b/openapi/components/schemas/transactions/TransactionType.yaml
@@ -2,4 +2,7 @@ type: string
 enum:
   - INCOMING
   - OUTGOING
-description: Type of transaction (incoming payment or outgoing payment)
+  - CARD
+description: >-
+  Type of transaction. `INCOMING` and `OUTGOING` are payments; `CARD` is a
+  card transaction, listed alongside payments in `GET /transactions`.


### PR DESCRIPTION
## Summary

`GET /transactions` returns card transactions next to payments, and the `TransactionOneOf` discriminator already maps `CARD` to `CardTransaction`. But the `TransactionType` enum only knew `INCOMING` and `OUTGOING`, so the `type` query filter could not ask for cards, and generated clients had no enum member for a value the API already emits.

## What changes

- `TransactionType` gains `CARD`. The description is now just "Type of transaction".

`CardTransaction.type` keeps its inline single-value enum so the discriminator stays narrow. `PlatformCurrencyConfig.enabledTransactionTypes`, which reuses this enum, is unchanged.

## Follow-up

Servers that back the `type` filter need to map `CARD` to card transactions once they pick up this version of the spec.

## Test plan

- `npm run lint:openapi` passes. Redocly warnings and Spectral results are unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)