### PR TITLE
make Card.stateReason optional rather than nullable

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11678,7 +11678,6 @@ webhooks:
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCardId: card-emp-aary-001
                     state: ACTIVE
-                    stateReason: null
                     brand: VISA
                     form: VIRTUAL
                     last4: '4242'
@@ -11724,7 +11723,6 @@ webhooks:
                     id: Card:019542f5-b3e7-1d02-0000-000000000010
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     state: FROZEN
-                    stateReason: null
                     brand: VISA
                     form: VIRTUAL
                     last4: '4242'
@@ -26112,10 +26110,8 @@ components:
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
-          anyOf:
-            - $ref: '#/components/schemas/CardStateReason'
-            - type: 'null'
-          description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.
+          $ref: '#/components/schemas/CardStateReason'
+          description: Reason associated with the current `state`. Present when the card is `CLOSED` or when provisioning was rejected; absent otherwise.
         brand:
           $ref: '#/components/schemas/CardBrand'
         form:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11678,7 +11678,6 @@ webhooks:
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     platformCardId: card-emp-aary-001
                     state: ACTIVE
-                    stateReason: null
                     brand: VISA
                     form: VIRTUAL
                     last4: '4242'
@@ -11724,7 +11723,6 @@ webhooks:
                     id: Card:019542f5-b3e7-1d02-0000-000000000010
                     cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                     state: FROZEN
-                    stateReason: null
                     brand: VISA
                     form: VIRTUAL
                     last4: '4242'
@@ -26112,10 +26110,8 @@ components:
         state:
           $ref: '#/components/schemas/CardState'
         stateReason:
-          anyOf:
-            - $ref: '#/components/schemas/CardStateReason'
-            - type: 'null'
-          description: Reason associated with the current `state`. Populated when the card is `CLOSED` or when provisioning was rejected; otherwise null.
+          $ref: '#/components/schemas/CardStateReason'
+          description: Reason associated with the current `state`. Present when the card is `CLOSED` or when provisioning was rejected; absent otherwise.
         brand:
           $ref: '#/components/schemas/CardBrand'
         form:

--- a/openapi/components/schemas/cards/Card.yaml
+++ b/openapi/components/schemas/cards/Card.yaml
@@ -28,12 +28,10 @@ properties:
   state:
     $ref: ./CardState.yaml
   stateReason:
-    anyOf:
-      - $ref: ./CardStateReason.yaml
-      - type: 'null'
+    $ref: ./CardStateReason.yaml
     description: >-
-      Reason associated with the current `state`. Populated when the card is
-      `CLOSED` or when provisioning was rejected; otherwise null.
+      Reason associated with the current `state`. Present when the card is
+      `CLOSED` or when provisioning was rejected; absent otherwise.
   brand:
     $ref: ./CardBrand.yaml
   form:

--- a/openapi/webhooks/card-state-change.yaml
+++ b/openapi/webhooks/card-state-change.yaml
@@ -52,7 +52,6 @@ post:
                 cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 platformCardId: card-emp-aary-001
                 state: ACTIVE
-                stateReason: null
                 brand: VISA
                 form: VIRTUAL
                 last4: '4242'
@@ -98,7 +97,6 @@ post:
                 id: Card:019542f5-b3e7-1d02-0000-000000000010
                 cardholderId: Customer:019542f5-b3e7-1d02-0000-000000000001
                 state: FROZEN
-                stateReason: null
                 brand: VISA
                 form: VIRTUAL
                 last4: '4242'


### PR DESCRIPTION
## Summary

`Card.stateReason` was `anyOf: [CardStateReason, 'null']` and also absent from `required`, so it was both optional and nullable. Absent and null carry the same meaning here, so the null branch was redundant and rendered as a confusing "one of: … / null" in the docs.

## What changes

- `Card.stateReason` is a plain `$ref` to `CardStateReason`. Still optional. The description now says the field is present when the card is `CLOSED` or provisioning was rejected, and absent otherwise.
- The two card-state-change webhook examples that showed `stateReason: null` now omit the field.

Same shape as the earlier `OutgoingTransaction.railSelectionMode` fix: an optional `$ref` and an optional nullable `$ref` generate the same client type, so only serialization moves. A server that emits the field as `null` today should omit it instead.

## Test plan

- `npm run lint:openapi` passes. Redocly warnings are unchanged from `main`; Spectral has 0 errors.
- Spectral reports one new info-level item, `schema-properties-have-examples` on `stateReason`. It is the same pre-existing info `Transaction.pendingReason` carries: the rule fires on any `$ref` to a string enum once the `anyOf` wrapper no longer hides it, and adding a sibling `example` does not satisfy it. Left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)