### PR TITLE
Add merchant field description to SandboxCardAuthorizationRequest

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -26345,6 +26345,7 @@ components:
           $ref: '#/components/schemas/Currency'
         merchant:
           $ref: '#/components/schemas/CardMerchant'
+          description: 'The simulated merchant. `descriptor` and `mcc` are passed to the issuer''s simulator and come back on the resulting transaction. `country` is ignored: the issuer resolves the merchant location from its own data.'
     SandboxCardSimulationResponse:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26345,6 +26345,7 @@ components:
           $ref: '#/components/schemas/Currency'
         merchant:
           $ref: '#/components/schemas/CardMerchant'
+          description: 'The simulated merchant. `descriptor` and `mcc` are passed to the issuer''s simulator and come back on the resulting transaction. `country` is ignored: the issuer resolves the merchant location from its own data.'
     SandboxCardSimulationResponse:
       type: object
       required:

--- a/openapi/components/schemas/cards/SandboxCardAuthorizationRequest.yaml
+++ b/openapi/components/schemas/cards/SandboxCardAuthorizationRequest.yaml
@@ -25,3 +25,7 @@ properties:
     $ref: ../common/Currency.yaml
   merchant:
     $ref: ./CardMerchant.yaml
+    description: >-
+      The simulated merchant. `descriptor` and `mcc` are passed to the issuer's
+      simulator and come back on the resulting transaction. `country` is
+      ignored: the issuer resolves the merchant location from its own data.


### PR DESCRIPTION
## Summary
Added documentation to the `merchant` field in the `SandboxCardAuthorizationRequest` schema to clarify how merchant data is handled in the sandbox card authorization simulation.

## Changes
- Added description to the `merchant` property in `openapi/components/schemas/cards/SandboxCardAuthorizationRequest.yaml` explaining that:
  - `descriptor` and `mcc` are passed to the issuer's simulator and returned on the resulting transaction
  - `country` is ignored and the issuer resolves merchant location from its own data
- Regenerated bundled OpenAPI specs (`openapi.yaml` and `mintlify/openapi.yaml`) to include the new description

## Notes
- Changes follow the convention of editing the source OpenAPI spec in `openapi/` and regenerating the bundles
- Description clarifies sandbox-specific behavior for API users implementing card authorization simulations

https://claude.ai/code/session_01R2GGEEmr8Uj1jss3KGc2pW