### PR TITLE
docs(discoveries): show banks the endpoint actually returns

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -332,12 +332,12 @@ paths:
                   summary: Payment rails for Philippines (PHP)
                   value:
                     data:
-                      - bankName: BDO Unibank
-                        displayName: BDO Unibank
+                      - bankName: Bank of the Philippine Islands (BPI)
+                        displayName: Bank of the Philippine Islands (BPI)
                         country: PH
                         currency: PHP
-                      - bankName: BPI
-                        displayName: Bank of the Philippine Islands
+                      - bankName: BDO Network Bank
+                        displayName: BDO Network Bank / One Network Bank
                         country: PH
                         currency: PHP
         '400':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -332,12 +332,12 @@ paths:
                   summary: Payment rails for Philippines (PHP)
                   value:
                     data:
-                      - bankName: BDO Unibank
-                        displayName: BDO Unibank
+                      - bankName: Bank of the Philippine Islands (BPI)
+                        displayName: Bank of the Philippine Islands (BPI)
                         country: PH
                         currency: PHP
-                      - bankName: BPI
-                        displayName: Bank of the Philippine Islands
+                      - bankName: BDO Network Bank
+                        displayName: BDO Network Bank / One Network Bank
                         country: PH
                         currency: PHP
         '400':

--- a/openapi/paths/discoveries/discoveries.yaml
+++ b/openapi/paths/discoveries/discoveries.yaml
@@ -39,12 +39,12 @@ get:
               summary: Payment rails for Philippines (PHP)
               value:
                 data:
-                  - bankName: BDO Unibank
-                    displayName: BDO Unibank
+                  - bankName: Bank of the Philippine Islands (BPI)
+                    displayName: Bank of the Philippine Islands (BPI)
                     country: PH
                     currency: PHP
-                  - bankName: BPI
-                    displayName: Bank of the Philippine Islands
+                  - bankName: BDO Network Bank
+                    displayName: BDO Network Bank / One Network Bank
                     country: PH
                     currency: PHP
     "400":


### PR DESCRIPTION
The `GET /discoveries` example listed `BDO Unibank` and `BPI`, which the endpoint does not return for PH/PHP. Both rows now use values it does return.

`bankName` on a Philippine external account must match a returned value exactly, so the example should be one.
