### PR TITLE
docs(msa): add Section 3.8 Accessibility to Grid API MSA

### DIFF
--- a/mintlify/legal/msa.mdx
+++ b/mintlify/legal/msa.mdx
@@ -6,7 +6,7 @@ hidden: true
 mode: "wide"
 ---
 
-_Last updated Aug 6, 2026_
+_Last updated Sep 10, 2026_
 
 In consideration of the mutual covenants and agreements set forth herein and in the Order to which this Master Services Agreement is attached, the Parties agree as follows:
 
@@ -119,6 +119,8 @@ Lightspark may utilize third-party payment processors, banking partners, or othe
 - **(j) Suspension and Termination of ACH Services.** Lightspark may suspend or terminate Platform's access to ACH origination services immediately upon notice if: (i) Platform violates applicable law, the NACHA Operating Rules, or any provision of this Section; (ii) Platform engages in or is associated with fraudulent or illegal activity; (iii) Platform's Unauthorized Return Rate, Administrative Return Rate, or Overall Return Rate exceeds the applicable NACHA threshold; or (iv) Lightspark's ODFI terminates or suspends Lightspark's authority to transmit Entries on Platform's behalf. In addition to Lightspark's rights under this Section, Platform agrees that Lightspark's ODFI shall have the right to terminate or suspend this Agreement, or Platform's access to the ACH origination Services, for Platform's breach of the NACHA Operating Rules, in a manner that permits the ODFI to comply with the NACHA Operating Rules. Platform acknowledges and agrees that Lightspark may act upon the direction of its ODFI to effect any such suspension or termination, including immediately and without prior notice where required for the ODFI's compliance with the NACHA Operating Rules.
 - **(k) Compliance with U.S. Law.** Platform agrees that it shall not originate, submit, or instruct Lightspark to originate any Entry that violates the laws of the United States, including the economic sanctions programs administered by the U.S. Department of the Treasury's Office of Foreign Assets Control. Platform represents and warrants that each Entry it originates or submits in connection with the Services will comply with all applicable laws of the United States.
 - **(l) ODFI Beneficiary.** Lightspark's ODFI is an intended third-party beneficiary of Platform's obligations and Lightspark's rights under this Section 3.7, and may enforce the authorization, termination, suspension, and audit provisions of this Section directly against Platform to the extent necessary for the ODFI to comply with the NACHA Operating Rules.
+
+**3.8 Accessibility.** Platform represents and warrants that its website, applications, and any other interfaces through which end users access the Services (collectively, the "Customer Interfaces") conform in all material respects to the Web Content Accessibility Guidelines (WCAG) 2.1 Level AA and comply with the Americans with Disabilities Act and other applicable accessibility laws. Platform will promptly remediate any material non-conformity upon becoming aware of it, and will defend and indemnify Lightspark against third-party claims arising from the accessibility of the Customer Interfaces.
 
 ## 4. Fees; Payment
 


### PR DESCRIPTION
## Summary

- Adds a new Section 3.8 (Accessibility) to the MSA (`mintlify/legal/msa.mdx`), inserted after Section 3.7 (NACHA Compliance). The clause has Platform represent and warrant that its Customer Interfaces conform to WCAG 2.1 Level AA and comply with the ADA and other accessibility laws, remediate material non-conformities, and indemnify Lightspark against related third-party claims.
- Bumps the page's "Last updated" date to Sep 10, 2026.

## Notes

- Text is taken word for word from Legal's "Changes to Grid MSA" doc (Sep 10, 2026 entry), requested by Katherine Nakazono. The earlier entries in that doc (Jul 29: Usage Data definition, Section 2.10, Section 12.8) already shipped in #768.
- Formatting matches the surrounding sections (bold section number and title, single paragraph).
- Section 3.8 is not added to the Section 6.5 survival list because Legal's instructions did not call for it.

## Test plan

- Verified the inserted clause matches the docx text byte for byte with a script.
- Ran `markdownlint-cli2` on the file; the only findings are pre-existing (bare URLs and multiple H1s in the exhibits), none on the changed lines.

Made with [Cursor](https://cursor.com)