### PR TITLE
feat(cards): report why a card authorization was declined

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -8799,7 +8799,7 @@ paths:
         This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
         Effects:
-        - `state: FROZEN`: Authorization Decisioning declines new auths with `CARD_PAUSED`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
+        - `state: FROZEN`: Authorization Decisioning declines new auths with `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
         - `state: ACTIVE`: normal authorization behavior resumes.
         - `state: CLOSED`: terminal close. The card transitions to `state: "CLOSED"` with `stateReason: "CLOSED_BY_PLATFORM"` and stays in the system for audit and reconciliation. All pending auths reconcile to a terminal state via the existing reconcile primitive. Inbound clearings received after close follow the standard force-post / late-presentment path — Lightspark absorbs the loss if a post-hoc pull on the now-unbound source fails. Funding-source bindings are detached. Refunds already in flight still complete because Lightspark holds the card-reserve keys.
 
@@ -8969,7 +8969,7 @@ paths:
 
         The decisioning outcome is controlled by the last three characters of `merchant.descriptor`:
 
-        | Suffix | Outcome | | ------ | ------- | | `002`  | Decline — `INSUFFICIENT_FUNDS` (the pull on the funding source fails) | | `003`  | Decline — `CARD_PAUSED` (intended to verify a frozen card refuses auths) | | `005`  | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path | | `006`  | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert | | any other | Approved |
+        | Suffix | Outcome | | ------ | ------- | | `002`  | The authorization is approved, then the pull on the funding source fails: `EXCEPTION` | | `003`  | Decline: `DECLINED`, `cardDeclinedReason: CARD_NOT_ACTIVE` (verifies a frozen card refuses auths) | | `005`  | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path | | `006`  | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert | | any other | Approved |
 
         Production returns `404` on this path.
       operationId: sandboxSimulateCardAuthorization
@@ -9002,8 +9002,8 @@ paths:
                     descriptor: BLUE BOTTLE COFFEE SF
                     mcc: '5814'
                     country: US
-              declinedInsufficientFunds:
-                summary: Declined — insufficient funds (descriptor suffix `002`)
+              insufficientFundsPullFailure:
+                summary: Approved, then the funding-source pull fails (descriptor suffix `002`)
                 value:
                   amount: 50000
                   currency:
@@ -12018,7 +12018,7 @@ webhooks:
                     createdAt: '2026-05-10T09:15:00Z'
                     updatedAt: '2026-05-10T09:15:00Z'
               declined:
-                summary: Authorization declined
+                summary: Authorization declined for insufficient funds
                 value:
                   id: Webhook:019542f5-b3e7-1d02-0000-000000000044
                   type: CARD_TRANSACTION.DECLINED
@@ -12031,6 +12031,7 @@ webhooks:
                     platformCustomerId: 18d3e5f7b4a9c2
                     issuerTransactionToken: lithic_txn_d41a7f02
                     status: DECLINED
+                    cardDeclinedReason: INSUFFICIENT_FUNDS
                     direction: DEBIT
                     merchant:
                       descriptor: UBER EATS
@@ -23909,6 +23910,28 @@ components:
         | `SETTLED` | All clearings for the auth have posted and the transaction is closed against the funding source. A `RETURN` received afterwards keeps the purchase `SETTLED`; the return appears as its own `CREDIT` transaction. |
         | `DECLINED` | The authorization was declined before any money moved. Declines carry no settlement and must be excluded from cardholder statements. |
         | `EXCEPTION` | The transaction settled to the card network but the corresponding pull from the funding source failed (e.g. balance no longer covers the post-hoc clearing). Surfaces high-urgency alerts and is the dashboard query for stuck reconciliations. |
+    CardDeclinedReason:
+      type: string
+      enum:
+        - CARD_NOT_ACTIVE
+        - SPEND_LIMIT_EXCEEDED
+        - INSUFFICIENT_FUNDS
+        - NO_ELIGIBLE_FUNDING_SOURCE
+        - BLOCKED
+        - UNSUPPORTED_NETWORK
+        - OTHER
+      description: |
+        Reason a card authorization was declined.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `CARD_NOT_ACTIVE` | The card is not `ACTIVE`. |
+        | `SPEND_LIMIT_EXCEEDED` | The authorization exceeds `maxSpendPerTransaction`, `maxSpendPerDay`, `maxTransactionsPerDay`, or the matching platform cap. |
+        | `INSUFFICIENT_FUNDS` | The funding source balance does not cover the authorization. |
+        | `NO_ELIGIBLE_FUNDING_SOURCE` | The card has no usable funding source, for example an Embedded Wallet source with no active delegated key. |
+        | `BLOCKED` | The merchant category or the transaction is blocked by program rules. |
+        | `UNSUPPORTED_NETWORK` | The network or transaction type is not supported. |
+        | `OTHER` | Any other reason. |
     CardMerchant:
       type: object
       required:
@@ -23979,6 +24002,10 @@ components:
           example: lithic_txn_b81c2a4f
         status:
           $ref: '#/components/schemas/CardTransactionStatus'
+        cardDeclinedReason:
+          $ref: '#/components/schemas/CardDeclinedReason'
+          description: Present only when `status` is `DECLINED`.
+          example: INSUFFICIENT_FUNDS
         direction:
           $ref: '#/components/schemas/TransactionDirection'
           description: A purchase is a `DEBIT`. A merchant refund is a `CREDIT` with the credited value in `settledAmount`; when the refund returns against a known purchase, `originalTransactionId` identifies it.
@@ -24002,7 +24029,7 @@ components:
         authorizedAt:
           type: string
           format: date-time
-          description: When the auth was approved.
+          description: When the authorization was approved or declined.
           example: '2026-05-08T14:30:00Z'
         createdAt:
           type: string
@@ -26171,7 +26198,7 @@ components:
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
-        | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
+        | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing settlements and refunds continue to reconcile. |
         | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |
     CardStateReason:
       type: string

--- a/mintlify/snippets/cards/cardholder-setup.mdx
+++ b/mintlify/snippets/cards/cardholder-setup.mdx
@@ -39,9 +39,11 @@ curl -X GET "$GRID_BASE_URL/customers/internal-accounts?customerId=Customer:0195
 
 ## Pre-fund before authorizations arrive
 
-Cards decline at auth time if the bound funding source can't cover the
-transaction. The decline code surfaces as `INSUFFICIENT_FUNDS` and is
-visible on the resulting `CardTransaction`. Fund the source the same
+Grid does not check the funding source balance when it decides an
+authorization. An authorization against an underfunded source is approved to
+the card network, and the pull against the funding source fails afterwards. The
+transaction resolves as `EXCEPTION` for you to reconcile, and it carries no
+`cardDeclinedReason`, because nothing was declined. Fund the source the same
 way you would for any other internal account — via the funding
 payment instructions or, in Sandbox, with
 `/sandbox/internal-accounts/{id}/fund`.

--- a/mintlify/snippets/cards/freezing-and-closing.mdx
+++ b/mintlify/snippets/cards/freezing-and-closing.mdx
@@ -40,7 +40,7 @@ The response is `200 OK` with the updated `Card` and a
 Setting a card to `FROZEN`:
 
 - Causes Authorization Decisioning to decline new auths with
-  `CARD_PAUSED`.
+  `cardDeclinedReason: CARD_NOT_ACTIVE`.
 - Does **not** pause the lifecycle of authorizations that already
   passed. Pulls, clearings, and refunds against existing transactions
   continue to reconcile normally.

--- a/mintlify/snippets/cards/sandbox-testing.mdx
+++ b/mintlify/snippets/cards/sandbox-testing.mdx
@@ -46,8 +46,8 @@ Outcomes are controlled by the last three characters of
 
 | Suffix | Outcome |
 |--------|---------|
-| `002` | Decline — `INSUFFICIENT_FUNDS` (the pull on the funding source fails) |
-| `003` | Decline — `CARD_PAUSED` (use against a `FROZEN` card to verify) |
+| `002` | The authorization is approved, then the pull on the funding source fails: `EXCEPTION` |
+| `003` | Decline: `DECLINED`, `cardDeclinedReason: CARD_NOT_ACTIVE` (verifies a frozen card refuses auths) |
 | `005` | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path |
 | `006` | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert |
 | any other | Approved |

--- a/mintlify/snippets/cards/terminology.mdx
+++ b/mintlify/snippets/cards/terminology.mdx
@@ -24,7 +24,8 @@ multi-source decisioning.
 The real-time request from the card network ("can this card spend
 $12.50 at Blue Bottle Coffee?"). {` `}Grid runs Authorization Decisioning
 against the funding source and either approves the auth (placing a hold)
-or declines it (`INSUFFICIENT_FUNDS`, `CARD_PAUSED`, etc.).
+or creates a terminal card transaction with `status: "DECLINED"` and a
+`cardDeclinedReason`.
 
 ## Pull
 

--- a/mintlify/snippets/cards/webhooks.mdx
+++ b/mintlify/snippets/cards/webhooks.mdx
@@ -1,4 +1,4 @@
-Cards add five webhook event types on top of Grid's existing webhook
+Cards add six webhook event types on top of Grid's existing webhook
 infrastructure. Signature verification (`X-Grid-Signature`) and
 retry behavior are identical to the rest of Grid — see
 [Authentication](/api-reference/authentication) and
@@ -15,7 +15,7 @@ lifecycle.
 | `CARD_TRANSACTION.AUTHORIZED` | An authorization is approved and a hold is placed on the funding source. |
 | `CARD_TRANSACTION.PARTIALLY_SETTLED` | A clearing posted, but more are still expected. |
 | `CARD_TRANSACTION.SETTLED` | All clearings have posted. Also fires for a merchant return, which posts as its own `CREDIT` row linked via `originalTransactionId`. |
-| `CARD_TRANSACTION.DECLINED` | The authorization was declined before any money moved. |
+| `CARD_TRANSACTION.DECLINED` | The authorization was declined before any money moved. The payload carries `cardDeclinedReason`. |
 | `CARD_TRANSACTION.EXCEPTION` | The transaction settled to the network but the pull from the funding source failed. |
 
 All of them carry the standard envelope:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8799,7 +8799,7 @@ paths:
         This endpoint is authenticated by the platform credential alone and returns `200` directly. It deliberately does not use Grid's 202 → signed-retry pattern: that pattern signs with the session key of a credential on the owning internal account, so it models actions taken *by* the end user on their own credentials or funds. Freezing or closing a card is routinely an action taken *about* a user and without them present - fraud response, offboarding, an ops-driven freeze - and requiring the cardholder's signature would make exactly those cases impossible. Operations that expose sensitive card data (`POST /cards/{id}/reveal`, 3DS password retrieval) are SCA-railed instead, because there the cardholder is the party being served.
 
         Effects:
-        - `state: FROZEN`: Authorization Decisioning declines new auths with `CARD_PAUSED`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
+        - `state: FROZEN`: Authorization Decisioning declines new auths with `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing pulls and in-flight reconciliation continue — freezing does not pause the lifecycle of authorizations that already passed.
         - `state: ACTIVE`: normal authorization behavior resumes.
         - `state: CLOSED`: terminal close. The card transitions to `state: "CLOSED"` with `stateReason: "CLOSED_BY_PLATFORM"` and stays in the system for audit and reconciliation. All pending auths reconcile to a terminal state via the existing reconcile primitive. Inbound clearings received after close follow the standard force-post / late-presentment path — Lightspark absorbs the loss if a post-hoc pull on the now-unbound source fails. Funding-source bindings are detached. Refunds already in flight still complete because Lightspark holds the card-reserve keys.
 
@@ -8969,7 +8969,7 @@ paths:
 
         The decisioning outcome is controlled by the last three characters of `merchant.descriptor`:
 
-        | Suffix | Outcome | | ------ | ------- | | `002`  | Decline — `INSUFFICIENT_FUNDS` (the pull on the funding source fails) | | `003`  | Decline — `CARD_PAUSED` (intended to verify a frozen card refuses auths) | | `005`  | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path | | `006`  | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert | | any other | Approved |
+        | Suffix | Outcome | | ------ | ------- | | `002`  | The authorization is approved, then the pull on the funding source fails: `EXCEPTION` | | `003`  | Decline: `DECLINED`, `cardDeclinedReason: CARD_NOT_ACTIVE` (verifies a frozen card refuses auths) | | `005`  | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path | | `006`  | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert | | any other | Approved |
 
         Production returns `404` on this path.
       operationId: sandboxSimulateCardAuthorization
@@ -9002,8 +9002,8 @@ paths:
                     descriptor: BLUE BOTTLE COFFEE SF
                     mcc: '5814'
                     country: US
-              declinedInsufficientFunds:
-                summary: Declined — insufficient funds (descriptor suffix `002`)
+              insufficientFundsPullFailure:
+                summary: Approved, then the funding-source pull fails (descriptor suffix `002`)
                 value:
                   amount: 50000
                   currency:
@@ -12018,7 +12018,7 @@ webhooks:
                     createdAt: '2026-05-10T09:15:00Z'
                     updatedAt: '2026-05-10T09:15:00Z'
               declined:
-                summary: Authorization declined
+                summary: Authorization declined for insufficient funds
                 value:
                   id: Webhook:019542f5-b3e7-1d02-0000-000000000044
                   type: CARD_TRANSACTION.DECLINED
@@ -12031,6 +12031,7 @@ webhooks:
                     platformCustomerId: 18d3e5f7b4a9c2
                     issuerTransactionToken: lithic_txn_d41a7f02
                     status: DECLINED
+                    cardDeclinedReason: INSUFFICIENT_FUNDS
                     direction: DEBIT
                     merchant:
                       descriptor: UBER EATS
@@ -23909,6 +23910,28 @@ components:
         | `SETTLED` | All clearings for the auth have posted and the transaction is closed against the funding source. A `RETURN` received afterwards keeps the purchase `SETTLED`; the return appears as its own `CREDIT` transaction. |
         | `DECLINED` | The authorization was declined before any money moved. Declines carry no settlement and must be excluded from cardholder statements. |
         | `EXCEPTION` | The transaction settled to the card network but the corresponding pull from the funding source failed (e.g. balance no longer covers the post-hoc clearing). Surfaces high-urgency alerts and is the dashboard query for stuck reconciliations. |
+    CardDeclinedReason:
+      type: string
+      enum:
+        - CARD_NOT_ACTIVE
+        - SPEND_LIMIT_EXCEEDED
+        - INSUFFICIENT_FUNDS
+        - NO_ELIGIBLE_FUNDING_SOURCE
+        - BLOCKED
+        - UNSUPPORTED_NETWORK
+        - OTHER
+      description: |
+        Reason a card authorization was declined.
+
+        | Reason | Description |
+        |--------|-------------|
+        | `CARD_NOT_ACTIVE` | The card is not `ACTIVE`. |
+        | `SPEND_LIMIT_EXCEEDED` | The authorization exceeds `maxSpendPerTransaction`, `maxSpendPerDay`, `maxTransactionsPerDay`, or the matching platform cap. |
+        | `INSUFFICIENT_FUNDS` | The funding source balance does not cover the authorization. |
+        | `NO_ELIGIBLE_FUNDING_SOURCE` | The card has no usable funding source, for example an Embedded Wallet source with no active delegated key. |
+        | `BLOCKED` | The merchant category or the transaction is blocked by program rules. |
+        | `UNSUPPORTED_NETWORK` | The network or transaction type is not supported. |
+        | `OTHER` | Any other reason. |
     CardMerchant:
       type: object
       required:
@@ -23979,6 +24002,10 @@ components:
           example: lithic_txn_b81c2a4f
         status:
           $ref: '#/components/schemas/CardTransactionStatus'
+        cardDeclinedReason:
+          $ref: '#/components/schemas/CardDeclinedReason'
+          description: Present only when `status` is `DECLINED`.
+          example: INSUFFICIENT_FUNDS
         direction:
           $ref: '#/components/schemas/TransactionDirection'
           description: A purchase is a `DEBIT`. A merchant refund is a `CREDIT` with the credited value in `settledAmount`; when the refund returns against a known purchase, `originalTransactionId` identifies it.
@@ -24002,7 +24029,7 @@ components:
         authorizedAt:
           type: string
           format: date-time
-          description: When the auth was approved.
+          description: When the authorization was approved or declined.
           example: '2026-05-08T14:30:00Z'
         createdAt:
           type: string
@@ -26171,7 +26198,7 @@ components:
         | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
         | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
         | `ACTIVE` | The card is live and can authorize transactions. |
-        | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
+        | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing settlements and refunds continue to reconcile. |
         | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |
     CardStateReason:
       type: string

--- a/openapi/components/schemas/cards/CardDeclinedReason.yaml
+++ b/openapi/components/schemas/cards/CardDeclinedReason.yaml
@@ -1,0 +1,21 @@
+type: string
+enum:
+  - CARD_NOT_ACTIVE
+  - SPEND_LIMIT_EXCEEDED
+  - INSUFFICIENT_FUNDS
+  - NO_ELIGIBLE_FUNDING_SOURCE
+  - BLOCKED
+  - UNSUPPORTED_NETWORK
+  - OTHER
+description: |
+  Reason a card authorization was declined.
+
+  | Reason | Description |
+  |--------|-------------|
+  | `CARD_NOT_ACTIVE` | The card is not `ACTIVE`. |
+  | `SPEND_LIMIT_EXCEEDED` | The authorization exceeds `maxSpendPerTransaction`, `maxSpendPerDay`, `maxTransactionsPerDay`, or the matching platform cap. |
+  | `INSUFFICIENT_FUNDS` | The funding source balance does not cover the authorization. |
+  | `NO_ELIGIBLE_FUNDING_SOURCE` | The card has no usable funding source, for example an Embedded Wallet source with no active delegated key. |
+  | `BLOCKED` | The merchant category or the transaction is blocked by program rules. |
+  | `UNSUPPORTED_NETWORK` | The network or transaction type is not supported. |
+  | `OTHER` | Any other reason. |

--- a/openapi/components/schemas/cards/CardState.yaml
+++ b/openapi/components/schemas/cards/CardState.yaml
@@ -13,5 +13,5 @@ description: |
   | `PENDING_KYC` | The cardholder has not yet completed KYC. Cards in this state cannot transact. |
   | `PROCESSING` | The card has been requested and is being provisioned with the issuer. |
   | `ACTIVE` | The card is live and can authorize transactions. |
-  | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `CARD_PAUSED`. Existing settlements and refunds continue to reconcile. |
+  | `FROZEN` | The card is temporarily disabled by the platform. New authorizations are declined with `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing settlements and refunds continue to reconcile. |
   | `CLOSED` | The card is permanently closed. Terminal, irreversible state. |

--- a/openapi/components/schemas/cards/CardTransaction.yaml
+++ b/openapi/components/schemas/cards/CardTransaction.yaml
@@ -51,6 +51,10 @@ properties:
     example: lithic_txn_b81c2a4f
   status:
     $ref: ./CardTransactionStatus.yaml
+  cardDeclinedReason:
+    $ref: ./CardDeclinedReason.yaml
+    description: Present only when `status` is `DECLINED`.
+    example: INSUFFICIENT_FUNDS
   direction:
     $ref: ../transactions/TransactionDirection.yaml
     description: >-
@@ -82,7 +86,7 @@ properties:
   authorizedAt:
     type: string
     format: date-time
-    description: When the auth was approved.
+    description: When the authorization was approved or declined.
     example: '2026-05-08T14:30:00Z'
   createdAt:
     type: string

--- a/openapi/paths/cards/cards_{id}.yaml
+++ b/openapi/paths/cards/cards_{id}.yaml
@@ -117,7 +117,8 @@ patch:
     Effects:
 
     - `state: FROZEN`: Authorization Decisioning declines new auths with
-    `CARD_PAUSED`. Existing pulls and in-flight reconciliation continue —
+    `cardDeclinedReason: CARD_NOT_ACTIVE`. Existing pulls and in-flight
+    reconciliation continue —
     freezing does not pause the lifecycle of authorizations that already
     passed.
 

--- a/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
+++ b/openapi/paths/sandbox/cards/sandbox_cards_{id}_simulate_authorization.yaml
@@ -14,8 +14,8 @@ post:
 
     | Suffix | Outcome |
     | ------ | ------- |
-    | `002`  | Decline — `INSUFFICIENT_FUNDS` (the pull on the funding source fails) |
-    | `003`  | Decline — `CARD_PAUSED` (intended to verify a frozen card refuses auths) |
+    | `002`  | The authorization is approved, then the pull on the funding source fails: `EXCEPTION` |
+    | `003`  | Decline: `DECLINED`, `cardDeclinedReason: CARD_NOT_ACTIVE` (verifies a frozen card refuses auths) |
     | `005`  | Delayed pull (~30s) — exercises the `PENDING → CONFIRMED` path |
     | `006`  | Pull succeeds but the confirmation event reports `FAILED` — exercises the high-urgency `EXCEPTION` alert |
     | any other | Approved |
@@ -52,8 +52,8 @@ post:
                 descriptor: BLUE BOTTLE COFFEE SF
                 mcc: '5814'
                 country: US
-          declinedInsufficientFunds:
-            summary: Declined — insufficient funds (descriptor suffix `002`)
+          insufficientFundsPullFailure:
+            summary: Approved, then the funding-source pull fails (descriptor suffix `002`)
             value:
               amount: 50000
               currency:

--- a/openapi/webhooks/card-transaction.yaml
+++ b/openapi/webhooks/card-transaction.yaml
@@ -156,7 +156,7 @@ post:
                 createdAt: '2026-05-10T09:15:00Z'
                 updatedAt: '2026-05-10T09:15:00Z'
           declined:
-            summary: Authorization declined
+            summary: Authorization declined for insufficient funds
             value:
               id: Webhook:019542f5-b3e7-1d02-0000-000000000044
               type: CARD_TRANSACTION.DECLINED
@@ -169,6 +169,7 @@ post:
                 platformCustomerId: 18d3e5f7b4a9c2
                 issuerTransactionToken: lithic_txn_d41a7f02
                 status: DECLINED
+                cardDeclinedReason: INSUFFICIENT_FUNDS
                 direction: DEBIT
                 merchant:
                   descriptor: UBER EATS


### PR DESCRIPTION
Jira: [ENG-11677](https://lightspark.atlassian.net/browse/ENG-11677) under [ENG-11645](https://lightspark.atlassian.net/browse/ENG-11645)

## What this does

When a card authorization is declined, the card transaction reports `status: DECLINED`. #957 added that status.

A platform can now see that the authorization failed, but not why. A frozen card, a spend cap, and an empty funding source all look the same. Only some of those are something the platform can act on, and it cannot tell them apart.

This PR adds the reason.

## How it works

- New `CardDeclinedReason` enum: `CARD_NOT_ACTIVE`, `SPEND_LIMIT_EXCEEDED`, `INSUFFICIENT_FUNDS`, `NO_ELIGIBLE_FUNDING_SOURCE`, `BLOCKED`, `UNSUPPORTED_NETWORK`, `OTHER`.
- `CardTransaction` gains `cardDeclinedReason`. It is present only when `status` is `DECLINED`.
- The `CARD_TRANSACTION.DECLINED` webhook example carries the reason.
- Sandbox descriptor suffix `003` documents the reason it produces, which is `CARD_NOT_ACTIVE`.

It also retires a name that was never real. The docs told platforms a frozen card declines with `CARD_PAUSED`. No enum has ever had that member. The server's decision vocabulary calls it `CARD_NOT_ACTIVE`. Every page that said `CARD_PAUSED` now says `cardDeclinedReason: CARD_NOT_ACTIVE`.

## What has to land with this

The server does not expose the reason yet. It stores it on the decision row, `EntCardEventDecision.decline_reason`, and the public projection drops it. The webdev change that joins the decline decision to the transaction and emits the field merges in the same window.

## One thing to settle before this merges

`INSUFFICIENT_FUNDS` is in the enum, and nothing produces it.

Four of the seven reasons are real in production today. `NO_ELIGIBLE_FUNDING_SOURCE`, `SPEND_LIMIT_EXCEEDED`, `BLOCKED`, and `UNSUPPORTED_NETWORK` all come from the shared gates that run after `_gen_evaluate` in `decision/base.py`, so they apply on production platforms even though `ProductionCardDecisionEngine` itself approves everything.

`INSUFFICIENT_FUNDS` is not one of them. Grid never checks the funding source balance when it decides an authorization. The auth is approved to the card network, and the pull fails afterwards in `card_hold_action.py`, whose own comment says so: "The auth was already approved to the issuer; if only the pull fails (e.g. the wallet is short) the raw exception propagates as transient so the whole delivery rolls back and Lithic re-delivers." That path resolves as `EXCEPTION`, and it carries no decline reason.

So the docs in this PR now say that plainly, on the sandbox `002` row and on the pre-funding guide. What is left to decide is the enum itself. Keeping the member means committing to move the balance check to authorization time, which `production.py` already has a TODO for. Dropping it means adding it back later, which is breaking for strict clients on a response enum.

`CARD_NOT_ACTIVE` has a smaller version of the same question: only `SandboxDecisionEngine` checks card status, and no shared gate does, so on production platforms a frozen card is declined by the provider rather than by us.

## Tests

`make build` rebundles cleanly. `make lint` reports 0 errors. The one new finding is informational and is the known `$ref`-with-example shape that `direction` and `applicationFee` already report. `cd cli && npm test` passes 80 tests. No `CARD_PAUSED` remains anywhere under `openapi/` or `mintlify/snippets/`.

## History

This is the surviving half of #935. That PR was merged into #934's branch by mistake rather than into `main`, and #934 has since been rebuilt on `main` without it.

The other half of #935 was the `DECLINED` status itself, which #957 shipped independently. ENG-11676 is therefore already delivered and only the reason was left to land.

[ENG-11677]: https://lightspark.atlassian.net/browse/ENG-11677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-11645]: https://lightspark.atlassian.net/browse/ENG-11645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
