### PR TITLE
docs(cards): diagram the card transaction status transitions

### DIFF
--- a/mintlify/snippets/cards/reconciliation.mdx
+++ b/mintlify/snippets/cards/reconciliation.mdx
@@ -1,7 +1,7 @@
 A card transaction is not a single event — it's a parent row plus a
 stream of child events from the card network. This page covers the
 event model, the status transitions, and how to handle the
-`EXCEPTION` path.
+`EXCEPTION` path, including what a reversal and an expiry do to the status.
 
 ## The event model
 
@@ -22,15 +22,31 @@ Clearings are reconciled against the purchase and rolled up into its
 
 ## Status transitions
 
-```text
-AUTHORIZED ──► PARTIALLY_SETTLED ──► SETTLED
-    │
-    ├──► DECLINED   (auth declined, no money moved)
-    └──► EXCEPTION  (pull failed after settlement)
+```mermaid
+stateDiagram-v2
+    [*] --> AUTHORIZED : Authorization approved
+    [*] --> DECLINED : Authorization declined
+    AUTHORIZED --> PARTIALLY_SETTLED : A clearing posts, more expected
+    PARTIALLY_SETTLED --> SETTLED : Final clearing posts
+    AUTHORIZED --> SETTLED : Resolved, nothing left outstanding
+    AUTHORIZED --> EXCEPTION : Funding-source pull failed
+    PARTIALLY_SETTLED --> EXCEPTION : Funding-source pull failed
+    SETTLED --> EXCEPTION : Funding-source pull failed
+    EXCEPTION --> SETTLED : The outstanding amount posts
 ```
+
+The status is not stored. Grid re-derives it from the events recorded so far
+every time you read the transaction, so a status can change in either
+direction as later events arrive. `DECLINED` is the one exception: nothing was
+pulled, and no further event follows.
 
 A merchant `RETURN` does not move the purchase's status. The purchase stays
 `SETTLED`; the return posts as its own `CREDIT` transaction.
+
+A partial authorization reversal releases part of the hold and lowers
+`authorizedAmount`. The transaction stays `AUTHORIZED`. A full reversal or an
+expiry releases the whole hold, which leaves nothing outstanding, so the
+transaction resolves as `SETTLED` with a `settledAmount` of zero.
 
 | Status | Meaning |
 |--------|---------|


### PR DESCRIPTION
Jira: [ENG-11670](https://lightspark.atlassian.net/browse/ENG-11670) under [ENG-11645](https://lightspark.atlassian.net/browse/ENG-11645)

## What this does

The reconciliation page explains how a card transaction moves between statuses. It draws those transitions as an ASCII block.

The block has fallen behind the model. It shows no path out of `PARTIALLY_SETTLED` into `EXCEPTION`, even though a pull can fail at any point after the authorization, and no path out of `EXCEPTION` at all. It also says nothing about reversals or expiries, which is the question integrators actually ask.

This PR replaces it with a state diagram and writes down the two rules the old block left out.

## How it works

- The ASCII block becomes a mermaid `stateDiagram-v2`, matching the one on the transaction lifecycle page.
- The diagram shows both entry points, every clearing path, the three ways a transaction reaches `EXCEPTION`, and the way back out of it.
- New prose says the status is not stored. Grid re-derives it from the events recorded so far on every read, so it can move in either direction as later events arrive. That is why `EXCEPTION` is drawn with a way out.
- New prose says what a reversal does. A partial reversal releases part of the hold, lowers `authorizedAmount`, and leaves the transaction `AUTHORIZED`. A full reversal or an expiry releases the whole hold, so the transaction resolves as `SETTLED` with a `settledAmount` of zero.

Every claim is read off `_gen_derive_current_status` in `ent_grid_card_transaction_schema.py`, not inferred from the old docs. `EXCEPTION` to `SETTLED` is the credit path: a credit whose authorization was refused derives `EXCEPTION`, and once the return posts it derives `SETTLED`.

## Tests

Docs only. No spec change, so no rebundle. `make lint` is unaffected.

## History

This is the last piece of #935, which was merged into #934's branch by mistake instead of into `main`. The `DECLINED` status from that PR shipped separately in #957, and the decline reason is in #960.

[ENG-11670]: https://lightspark.atlassian.net/browse/ENG-11670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-11645]: https://lightspark.atlassian.net/browse/ENG-11645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ