### PR TITLE
refactor(cli): send customerId on the card commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -310,14 +310,14 @@ grid receiver lookup-account <accountId>
 
 ```bash
 # List cards
-grid cards list [--cardholder-id <id>] [--status ACTIVE]
+grid cards list [--customer-id <id>] [--status ACTIVE]
 
 # Get a card
 grid cards get <cardId>
 
 # Issue a virtual card
 grid cards create \
-  --cardholder-id <customerId> \
+  --customer-id <customerId> \
   --funding-source "InternalAccount:1" \
   --max-spend-per-transaction 5000
 

--- a/cli/src/commands/cards.ts
+++ b/cli/src/commands/cards.ts
@@ -6,7 +6,7 @@ import { addSignedOptions, signedHeaders, validateSignedOptions } from "../signe
 
 interface Card {
   id: string;
-  cardholderId: string;
+  customerId: string;
   platformCardId?: string;
   status: "PENDING_KYC" | "PROCESSING" | "ACTIVE" | "FROZEN" | "CLOSED";
   form: "VIRTUAL";
@@ -57,7 +57,7 @@ export function registerCardsCommand(
   cardsCmd
     .command("list")
     .description("List cards")
-    .option("--cardholder-id <id>", "Filter by cardholder (customer) ID")
+    .option("--customer-id <id>", "Filter by customer ID")
     .option("--account-id <id>", "Filter by a bound funding-source account ID")
     .option("--platform-card-id <id>", "Filter by platform card ID")
     .option("--status <status>", "Filter by status (PENDING_KYC, PROCESSING, ACTIVE, FROZEN, CLOSED)")
@@ -77,7 +77,7 @@ export function registerCardsCommand(
       }
 
       const params: Record<string, string | number | undefined> = {
-        cardholderId: options.cardholderId,
+        customerId: options.customerId,
         accountId: options.accountId,
         platformCardId: options.platformCardId,
         status: options.status,
@@ -105,7 +105,7 @@ export function registerCardsCommand(
   cardsCmd
     .command("create")
     .description("Issue a card")
-    .requiredOption("--cardholder-id <id>", "Cardholder (customer) ID")
+    .requiredOption("--customer-id <id>", "Customer ID")
     .requiredOption(
       "--funding-source <id>",
       "Internal account ID that funds the card",
@@ -124,7 +124,7 @@ export function registerCardsCommand(
       if (!client) return;
 
       const body: Record<string, unknown> = {
-        cardholderId: options.cardholderId,
+        customerId: options.customerId,
         form: options.form,
         fundingSource: options.fundingSource,
       };

--- a/cli/test/cards.test.ts
+++ b/cli/test/cards.test.ts
@@ -6,7 +6,7 @@ describe("cards list", () => {
     const { request } = await runCli([
       "cards",
       "list",
-      "--cardholder-id",
+      "--customer-id",
       "Customer:abc",
       "--status",
       "ACTIVE",
@@ -14,7 +14,7 @@ describe("cards list", () => {
 
     expect(request?.path).toBe("/grid/v1/cards");
     expect(request?.query).toMatchObject({
-      cardholderId: "Customer:abc",
+      customerId: "Customer:abc",
       status: "ACTIVE",
     });
   });
@@ -25,7 +25,7 @@ describe("cards create", () => {
     const { request } = await runCli([
       "cards",
       "create",
-      "--cardholder-id",
+      "--customer-id",
       "Customer:abc",
       "--funding-source",
       "InternalAccount:1",
@@ -34,7 +34,7 @@ describe("cards create", () => {
     expect(request?.method).toBe("POST");
     expect(request?.path).toBe("/grid/v1/cards");
     expect(request?.body).toMatchObject({
-      cardholderId: "Customer:abc",
+      customerId: "Customer:abc",
       form: "VIRTUAL",
       fundingSource: "InternalAccount:1",
     });
@@ -44,7 +44,7 @@ describe("cards create", () => {
     const { request } = await runCli([
       "cards",
       "create",
-      "--cardholder-id",
+      "--customer-id",
       "Customer:abc",
       "--funding-source",
       "InternalAccount:1",
@@ -60,7 +60,7 @@ describe("cards create", () => {
       runCli([
         "cards",
         "create",
-        "--cardholder-id",
+        "--customer-id",
         "Customer:abc",
         "--funding-source",
         "",
@@ -72,7 +72,7 @@ describe("cards create", () => {
     const { request } = await runCli([
       "cards",
       "create",
-      "--cardholder-id",
+      "--customer-id",
       "Customer:abc",
       "--funding-source",
       "  InternalAccount:1  ",
@@ -88,7 +88,7 @@ describe("cards create", () => {
       runCli([
         "cards",
         "create",
-        "--cardholder-id",
+        "--customer-id",
         "Customer:abc",
         "--funding-source",
         "InternalAccount:1",


### PR DESCRIPTION
Jira: [ENG-11658](https://lightspark.atlassian.net/browse/ENG-11658) under [ENG-11645](https://lightspark.atlassian.net/browse/ENG-11645)

## What this does

The card endpoints used to call the cardholder `cardholderId`. #937 renamed that to `customerId` across the spec and the docs.

The Grid CLI was not part of that change. It still sends `cardholderId` and still spells the flag `--cardholder-id`, so the one executable client in this repo speaks a field name the spec no longer documents.

This PR brings the CLI in line.

## How it works

- `grid cards list --cardholder-id` becomes `grid cards list --customer-id`.
- `grid cards create --cardholder-id` becomes `grid cards create --customer-id`.
- The `Card` interface and both request bodies send `customerId`.
- The README examples use the new flag.

Breaking for anyone scripting the CLI. There is no alias, which matches how #937 handled the API itself.

## Sequencing

The server has not caught up. `GridListCardsRequestArgs` in `list_cards.py` declares `cardholder_id` and sets `extra="forbid"`, so `GET /cards?customerId=` returns a 400 until the server change lands. `POST /cards` is the same: the generated `CardCreateRequest` still requires `cardholderId`.

So this should merge with the webdev server change, not ahead of it. Holding it as its own PR keeps that decision separate from the funding-source work.

## Tests

`cd cli && npm test` passes 82 tests, and `npx tsc --noEmit` is clean.

## Why it is its own PR

It was sitting inside #934, which is titled "bind one funding source per card". A breaking flag rename that belongs to a different ticket should not ride along inside that diff, so it was split out.

#934 has since merged, and this branch is rebased on top of it. The two changes touched the same lines of `cards.ts` and the README, so the rebase took #934's singular `--funding-source` and this PR's `--customer-id` rename together. Two `--cardholder-id` uses that #934 added to `cards.test.ts` are renamed here as well.

#964 then renamed the card lifecycle field from `state` to `status` and touched the same `cards list` line in the README and the same `cards.test.ts` assertion. This branch is rebased on that too, so the list example now reads `grid cards list [--customer-id <id>] [--status ACTIVE]` and the test asserts both `customerId` and `status`.


[ENG-11658]: https://lightspark.atlassian.net/browse/ENG-11658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-11645]: https://lightspark.atlassian.net/browse/ENG-11645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

