### PR TITLE
Allow internal accounts as stablecoin burn destinations

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -27146,30 +27146,75 @@ components:
           EXTERNAL_ACCOUNT: '#/components/schemas/StablecoinExternalAccountBurnSource'
           GRID_INTERNAL_ACCOUNT: '#/components/schemas/StablecoinGridInternalBurnSource'
           PROVIDER_INTERNAL_BALANCE: '#/components/schemas/StablecoinProviderBalanceBurnSource'
-    StablecoinBurnDestination:
+    StablecoinBurnDestinationRail:
+      type: string
+      enum:
+        - WIRE
+        - ACH_CREDIT
+        - SAME_DAY_ACH_CREDIT
+        - RTP_CREDIT
+      description: Fiat payout rail for the burn destination.
+    StablecoinBurnDestinationBase:
       type: object
       required:
         - type
-        - externalAccountId
         - rail
       properties:
         type:
           type: string
           enum:
             - EXTERNAL_ACCOUNT
-          description: Burn destination variant. V1 supports fiat Grid `ExternalAccount` destinations.
-        externalAccountId:
-          type: string
-          description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
-          example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205
+            - GRID_INTERNAL_ACCOUNT
+          description: Burn destination variant.
         rail:
-          type: string
-          enum:
-            - WIRE
-            - ACH_CREDIT
-            - SAME_DAY_ACH_CREDIT
-            - RTP_CREDIT
-          description: Fiat payout rail for the burn destination.
+          $ref: '#/components/schemas/StablecoinBurnDestinationRail'
+    StablecoinExternalAccountBurnDestination:
+      title: External Account
+      allOf:
+        - $ref: '#/components/schemas/StablecoinBurnDestinationBase'
+        - type: object
+          required:
+            - type
+            - externalAccountId
+          properties:
+            type:
+              type: string
+              enum:
+                - EXTERNAL_ACCOUNT
+              description: External account burn destination.
+              example: EXTERNAL_ACCOUNT
+            externalAccountId:
+              type: string
+              description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
+              example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205
+    StablecoinGridInternalBurnDestination:
+      title: Grid Internal Account
+      allOf:
+        - $ref: '#/components/schemas/StablecoinBurnDestinationBase'
+        - type: object
+          required:
+            - type
+            - accountId
+          properties:
+            type:
+              type: string
+              enum:
+                - GRID_INTERNAL_ACCOUNT
+              description: Grid internal account burn destination.
+              example: GRID_INTERNAL_ACCOUNT
+            accountId:
+              type: string
+              description: Grid `InternalAccount` receiving fiat redemption proceeds through its bank funding instructions.
+              example: InternalAccount:019542f5-b3e7-1d02-0000-000000000206
+    StablecoinBurnDestination:
+      oneOf:
+        - $ref: '#/components/schemas/StablecoinExternalAccountBurnDestination'
+        - $ref: '#/components/schemas/StablecoinGridInternalBurnDestination'
+      discriminator:
+        propertyName: type
+        mapping:
+          EXTERNAL_ACCOUNT: '#/components/schemas/StablecoinExternalAccountBurnDestination'
+          GRID_INTERNAL_ACCOUNT: '#/components/schemas/StablecoinGridInternalBurnDestination'
     StablecoinBurnRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27146,30 +27146,75 @@ components:
           EXTERNAL_ACCOUNT: '#/components/schemas/StablecoinExternalAccountBurnSource'
           GRID_INTERNAL_ACCOUNT: '#/components/schemas/StablecoinGridInternalBurnSource'
           PROVIDER_INTERNAL_BALANCE: '#/components/schemas/StablecoinProviderBalanceBurnSource'
-    StablecoinBurnDestination:
+    StablecoinBurnDestinationRail:
+      type: string
+      enum:
+        - WIRE
+        - ACH_CREDIT
+        - SAME_DAY_ACH_CREDIT
+        - RTP_CREDIT
+      description: Fiat payout rail for the burn destination.
+    StablecoinBurnDestinationBase:
       type: object
       required:
         - type
-        - externalAccountId
         - rail
       properties:
         type:
           type: string
           enum:
             - EXTERNAL_ACCOUNT
-          description: Burn destination variant. V1 supports fiat Grid `ExternalAccount` destinations.
-        externalAccountId:
-          type: string
-          description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
-          example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205
+            - GRID_INTERNAL_ACCOUNT
+          description: Burn destination variant.
         rail:
-          type: string
-          enum:
-            - WIRE
-            - ACH_CREDIT
-            - SAME_DAY_ACH_CREDIT
-            - RTP_CREDIT
-          description: Fiat payout rail for the burn destination.
+          $ref: '#/components/schemas/StablecoinBurnDestinationRail'
+    StablecoinExternalAccountBurnDestination:
+      title: External Account
+      allOf:
+        - $ref: '#/components/schemas/StablecoinBurnDestinationBase'
+        - type: object
+          required:
+            - type
+            - externalAccountId
+          properties:
+            type:
+              type: string
+              enum:
+                - EXTERNAL_ACCOUNT
+              description: External account burn destination.
+              example: EXTERNAL_ACCOUNT
+            externalAccountId:
+              type: string
+              description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
+              example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205
+    StablecoinGridInternalBurnDestination:
+      title: Grid Internal Account
+      allOf:
+        - $ref: '#/components/schemas/StablecoinBurnDestinationBase'
+        - type: object
+          required:
+            - type
+            - accountId
+          properties:
+            type:
+              type: string
+              enum:
+                - GRID_INTERNAL_ACCOUNT
+              description: Grid internal account burn destination.
+              example: GRID_INTERNAL_ACCOUNT
+            accountId:
+              type: string
+              description: Grid `InternalAccount` receiving fiat redemption proceeds through its bank funding instructions.
+              example: InternalAccount:019542f5-b3e7-1d02-0000-000000000206
+    StablecoinBurnDestination:
+      oneOf:
+        - $ref: '#/components/schemas/StablecoinExternalAccountBurnDestination'
+        - $ref: '#/components/schemas/StablecoinGridInternalBurnDestination'
+      discriminator:
+        propertyName: type
+        mapping:
+          EXTERNAL_ACCOUNT: '#/components/schemas/StablecoinExternalAccountBurnDestination'
+          GRID_INTERNAL_ACCOUNT: '#/components/schemas/StablecoinGridInternalBurnDestination'
     StablecoinBurnRequest:
       type: object
       required:

--- a/openapi/components/schemas/stablecoins/StablecoinBurnDestination.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinBurnDestination.yaml
@@ -1,23 +1,8 @@
-type: object
-required:
-  - type
-  - externalAccountId
-  - rail
-properties:
-  type:
-    type: string
-    enum:
-      - EXTERNAL_ACCOUNT
-    description: Burn destination variant. V1 supports fiat Grid `ExternalAccount` destinations.
-  externalAccountId:
-    type: string
-    description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
-    example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205
-  rail:
-    type: string
-    enum:
-      - WIRE
-      - ACH_CREDIT
-      - SAME_DAY_ACH_CREDIT
-      - RTP_CREDIT
-    description: Fiat payout rail for the burn destination.
+oneOf:
+  - $ref: ./StablecoinExternalAccountBurnDestination.yaml
+  - $ref: ./StablecoinGridInternalBurnDestination.yaml
+discriminator:
+  propertyName: type
+  mapping:
+    EXTERNAL_ACCOUNT: ./StablecoinExternalAccountBurnDestination.yaml
+    GRID_INTERNAL_ACCOUNT: ./StablecoinGridInternalBurnDestination.yaml

--- a/openapi/components/schemas/stablecoins/StablecoinBurnDestinationBase.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinBurnDestinationBase.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - type
+  - rail
+properties:
+  type:
+    type: string
+    enum:
+      - EXTERNAL_ACCOUNT
+      - GRID_INTERNAL_ACCOUNT
+    description: Burn destination variant.
+  rail:
+    $ref: ./StablecoinBurnDestinationRail.yaml

--- a/openapi/components/schemas/stablecoins/StablecoinBurnDestinationRail.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinBurnDestinationRail.yaml
@@ -1,0 +1,3 @@
+type: string
+enum: [WIRE, ACH_CREDIT, SAME_DAY_ACH_CREDIT, RTP_CREDIT]
+description: Fiat payout rail for the burn destination.

--- a/openapi/components/schemas/stablecoins/StablecoinExternalAccountBurnDestination.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinExternalAccountBurnDestination.yaml
@@ -1,0 +1,18 @@
+title: External Account
+allOf:
+  - $ref: ./StablecoinBurnDestinationBase.yaml
+  - type: object
+    required:
+      - type
+      - externalAccountId
+    properties:
+      type:
+        type: string
+        enum:
+          - EXTERNAL_ACCOUNT
+        description: External account burn destination.
+        example: EXTERNAL_ACCOUNT
+      externalAccountId:
+        type: string
+        description: Grid bank `ExternalAccount` receiving fiat redemption proceeds.
+        example: ExternalAccount:019542f5-b3e7-1d02-0000-000000000205

--- a/openapi/components/schemas/stablecoins/StablecoinGridInternalBurnDestination.yaml
+++ b/openapi/components/schemas/stablecoins/StablecoinGridInternalBurnDestination.yaml
@@ -1,0 +1,18 @@
+title: Grid Internal Account
+allOf:
+  - $ref: ./StablecoinBurnDestinationBase.yaml
+  - type: object
+    required:
+      - type
+      - accountId
+    properties:
+      type:
+        type: string
+        enum:
+          - GRID_INTERNAL_ACCOUNT
+        description: Grid internal account burn destination.
+        example: GRID_INTERNAL_ACCOUNT
+      accountId:
+        type: string
+        description: Grid `InternalAccount` receiving fiat redemption proceeds through its bank funding instructions.
+        example: InternalAccount:019542f5-b3e7-1d02-0000-000000000206


### PR DESCRIPTION
## What this does

Stablecoin burns can currently pay only external bank accounts. This adds a Grid internal-account destination variant so clients can direct redemption proceeds to an internal account through its bank funding instructions.

## API shape

- `StablecoinBurnDestination` is a discriminated `oneOf` union so generated SDKs preserve variant-specific required fields.
- `EXTERNAL_ACCOUNT` keeps `externalAccountId` and `rail`.
- `GRID_INTERNAL_ACCOUNT` uses `accountId` and `rail`.
- Both variants share the same supported payout rails.

## Validation

- `make build`
- `make lint`
- `git diff --check`
- Adversarial review found no P0/P1 issues.

Requested by @peterrojs

Original PR: https://github.com/lightsparkdev/grid-api/pull/965
