### PR TITLE
docs(errors): add BANK_ACCOUNT_VALIDATION_PENDING and declare 409 on quotes and transfer-out

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3949,6 +3949,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US bank account on the request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected, so retry once validation completes. An account that failed validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '429':
           description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when the requested amount would exceed the configured daily volume limit for the withdrawal currency.
           content:
@@ -4329,6 +4335,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error403'
+        '409':
+          description: Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US bank account on the request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected, so retry once validation completes. An account that failed validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '412':
           description: Counterparty doesn't support UMA version
           content:
@@ -14185,6 +14197,7 @@ components:
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
             | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
             | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
+            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -14195,6 +14208,7 @@ components:
             - PASSKEY_ALREADY_ENROLLED
             - SCA_SESSION_REQUIRED
             - BENEFICIARY_TRUSTED
+            - BANK_ACCOUNT_VALIDATION_PENDING
             - INVALID_STATE_TRANSITION
             - CARD_ALREADY_CLOSED
             - CARD_NOT_MUTABLE

--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -14192,12 +14192,12 @@ components:
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
             | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
             | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
+            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | INVALID_STATE_TRANSITION | The requested card `status` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
             | CARD_ALREADY_CLOSED | `status: CLOSED` was requested for a card that is already `CLOSED` |
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
             | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
             | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
-            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL

--- a/mintlify/snippets/error-handling.mdx
+++ b/mintlify/snippets/error-handling.mdx
@@ -15,7 +15,7 @@ Grid uses standard HTTP status codes to indicate the success or failure of reque
 | `401 Unauthorized`          | Authentication failed   | Invalid or missing API credentials                      |
 | `403 Forbidden`             | Permission denied       | Insufficient permissions or customer not ready          |
 | `404 Not Found`             | Resource not found      | Customer, transaction, or quote doesn't exist           |
-| `409 Conflict`              | Resource conflict       | Quote already executed, external account already exists |
+| `409 Conflict`              | Resource conflict       | Quote already executed, external account already exists, bank account still being validated |
 | `412 Precondition Failed`   | UMA version mismatch    | Counterparty doesn't support required UMA version       |
 | `429 Too Many Requests`     | Rate/volume limited     | Rate limit hit or daily volume limit exceeded           |
 | `422 Unprocessable Entity`  | Missing info            | Additional counterparty information required            |
@@ -99,6 +99,27 @@ async function safeSendPayment(accountId, amount) {
   }
 
   return await createQuote({ accountId, amount });
+}
+```
+
+</Accordion>
+
+<Accordion title="BANK_ACCOUNT_VALIDATION_PENDING">
+**Cause:** Grid is still validating the US bank account on this request
+
+**Solution:** Wait and retry. Grid validates a newly added ACH account by sending a micro-entry to the bank and waiting out the return window, which takes a few banking days. The account has not been rejected, so do not ask the customer to re-enter their details.
+
+```javascript
+async function createQuoteWhenAccountIsReady({ accountId, amount }) {
+  try {
+    return await createQuote({ accountId, amount });
+  } catch (error) {
+    if (error.code === "BANK_ACCOUNT_VALIDATION_PENDING") {
+      // Surface the wait to the customer; the account is fine.
+      return { status: "AWAITING_ACCOUNT_VALIDATION" };
+    }
+    throw error;
+  }
 }
 ```
 
@@ -443,6 +464,8 @@ function getUserFriendlyMessage(error) {
     INSUFFICIENT_BALANCE: "You don't have enough funds for this payment.",
     INVALID_BANK_ACCOUNT:
       "Bank account details are invalid. Please check and try again.",
+    BANK_ACCOUNT_VALIDATION_PENDING:
+      "We're still verifying this bank account. This usually takes a few business days.",
     PAYMENT_APPROVAL_TIMED_OUT: "Payment approval timed out. Please try again.",
     AMOUNT_OUT_OF_RANGE: "Payment amount is too high or too low.",
     INVALID_CURRENCY: "This currency is not supported.",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3949,6 +3949,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '409':
+          description: Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US bank account on the request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected, so retry once validation completes. An account that failed validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '429':
           description: Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when the requested amount would exceed the configured daily volume limit for the withdrawal currency.
           content:
@@ -4329,6 +4335,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error403'
+        '409':
+          description: Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US bank account on the request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected, so retry once validation completes. An account that failed validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error409'
         '412':
           description: Counterparty doesn't support UMA version
           content:
@@ -14185,6 +14197,7 @@ components:
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
             | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
             | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
+            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -14195,6 +14208,7 @@ components:
             - PASSKEY_ALREADY_ENROLLED
             - SCA_SESSION_REQUIRED
             - BENEFICIARY_TRUSTED
+            - BANK_ACCOUNT_VALIDATION_PENDING
             - INVALID_STATE_TRANSITION
             - CARD_ALREADY_CLOSED
             - CARD_NOT_MUTABLE

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14192,12 +14192,12 @@ components:
             | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
             | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
             | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
+            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | INVALID_STATE_TRANSITION | The requested card `status` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
             | CARD_ALREADY_CLOSED | `status: CLOSED` was requested for a card that is already `CLOSED` |
             | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
             | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
             | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
-            | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
             | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
           enum:
             - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -27,6 +27,7 @@ properties:
       | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
       | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
       | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
+      | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL
@@ -37,6 +38,7 @@ properties:
       - PASSKEY_ALREADY_ENROLLED
       - SCA_SESSION_REQUIRED
       - BENEFICIARY_TRUSTED
+      - BANK_ACCOUNT_VALIDATION_PENDING
       - INVALID_STATE_TRANSITION
       - CARD_ALREADY_CLOSED
       - CARD_NOT_MUTABLE

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -22,12 +22,12 @@ properties:
       | PASSKEY_ALREADY_ENROLLED | The customer already has an enrolled passkey factor; only one passkey per customer is supported. Delete the existing one before enrolling another |
       | SCA_SESSION_REQUIRED | The customer's Strong Customer Authentication login session is missing or expired. Re-authenticate the customer, then retry the request. Distinct from a `401`, which means the platform's own API credentials were rejected |
       | BENEFICIARY_TRUSTED | The external account is currently a trusted beneficiary, so it cannot be deleted. Untrust it first via `POST /customers/external-accounts/{externalAccountId}/untrust` (and its `/confirm`), then delete |
+      | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
       | INVALID_STATE_TRANSITION | The requested card `status` transition is not one of `ACTIVE ⇄ FROZEN` or `ACTIVE \| FROZEN → CLOSED` |
       | CARD_ALREADY_CLOSED | `status: CLOSED` was requested for a card that is already `CLOSED` |
       | CARD_NOT_MUTABLE | The card is `CLOSED`, so it can no longer be mutated |
       | CARD_LIMIT_REACHED | The platform has reached the maximum number of live cards it may hold, or the cardholder already holds a card and the platform is limited to one per cardholder. Closing a card frees its slot; contact Lightspark to raise the limit |
       | STABLECOIN_GRID_ENABLEMENT_NOT_REQUESTABLE | Grid enablement can only be requested while the stablecoin is `NOT_ENABLED` (a repeat request while already `PENDING_APPROVAL` succeeds). `ENABLING`, `ENABLED` and `DISABLED` are driven by Lightspark and cannot be requested |
-      | BANK_ACCOUNT_VALIDATION_PENDING | The US bank account on this request is still being validated. Grid verifies a newly added ACH account by sending a micro-entry and waiting out the return window, which takes a few banking days. The account is not rejected; retry once validation completes. A permanently failed account returns `400 INVALID_BANK_ACCOUNT` instead |
       | CONFLICT | Generic resource-state conflict. Returned, for example, when `platformCustomerId` on a customer create call collides with an existing active customer on the same platform |
     enum:
       - TRANSACTION_NOT_PENDING_PLATFORM_APPROVAL

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -168,6 +168,18 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error403.yaml
+    '409':
+      description: >-
+        Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US
+        bank account on the request is still being validated. Grid verifies a
+        newly added ACH account by sending a micro-entry and waiting out the
+        return window, which takes a few banking days. The account is not
+        rejected, so retry once validation completes. An account that failed
+        validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
     '412':
       description: Counterparty doesn't support UMA version
       content:

--- a/openapi/paths/transfers/transfer_out.yaml
+++ b/openapi/paths/transfers/transfer_out.yaml
@@ -80,6 +80,18 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '409':
+      description: >-
+        Conflict. Returned with `BANK_ACCOUNT_VALIDATION_PENDING` when the US
+        bank account on the request is still being validated. Grid verifies a
+        newly added ACH account by sending a micro-entry and waiting out the
+        return window, which takes a few banking days. The account is not
+        rejected, so retry once validation completes. An account that failed
+        validation outright returns `400` with `INVALID_BANK_ACCOUNT`.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error409.yaml
     '429':
       description: >-
         Too many requests. Returned with `DAILY_VOLUME_LIMIT_EXCEEDED` when


### PR DESCRIPTION
https://lightspark.atlassian.net/browse/AT-6613

## What this does

Grid validates a customer's US bank account before it will move money over ACH. It does that by sending a tiny entry to the bank and waiting to see whether it comes back, which takes a few banking days.

Until now that wait was invisible to platforms. The check ran at the last moment, when the money was already moving, so a platform found out by watching a payment fail.

webdev#35017 moves the check to quote creation, so a platform is told up front. This spec change describes what it will be told.

## The new code

`BANK_ACCOUNT_VALIDATION_PENDING`, returned with a `409`.

It means the account is fine and the check has not finished. Nothing is wrong with the details the customer gave you, so do not send them back to re-enter anything. Wait and retry.

That is the distinction worth having. An account that actually fails validation returns a `400` with `INVALID_BANK_ACCOUNT`, which is permanent and does need the customer to fix something. One is "not yet", the other is "no".

## Why `/quotes` and `/transfer-out` gained a 409

Neither operation declared one. Both can now return it.

`/transfer-out` reaches the same quote code internally, so it inherits the behavior even though the path looks unrelated.

Worth noting for anyone auditing this file: both operations could already return statuses they did not declare. `/quotes` raises several `404`s today and declares none. That is a pre-existing gap and this PR does not try to close it, but it is the reason to check the declared list rather than assume it is complete.

## Merge order

This is a spec-only change and safe to merge on its own.

It should land before webdev#35019, which is the sparkcore change that emits the code. That PR currently maps the pending case to the generic `CONFLICT`, because a code has to exist in this spec before Grid may return it. Once this merges, that mapping switches to `BANK_ACCOUNT_VALIDATION_PENDING`.

## Checks

`make build` regenerated both bundles. `make lint` passes with 0 errors. The three `Error409` informational notices about missing property examples are pre-existing and unrelated.
