### PR TITLE
docs(cards): carry the merchant descriptor in a card transaction's description

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -11921,6 +11921,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_b81c2a4f
                     status: AUTHORIZED
                     direction: DEBIT
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -11951,6 +11952,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_b81c2a4f
                     status: SETTLED
                     direction: DEBIT
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -11989,6 +11991,7 @@ webhooks:
                     status: SETTLED
                     direction: CREDIT
                     originalTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -12026,6 +12029,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_d41a7f02
                     status: DECLINED
                     direction: DEBIT
+                    description: UBER EATS
                     merchant:
                       descriptor: UBER EATS
                       mcc: '5812'
@@ -12056,6 +12060,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_c92d3b5a
                     status: EXCEPTION
                     direction: DEBIT
+                    description: UBER EATS
                     merchant:
                       descriptor: UBER EATS
                       mcc: '5812'
@@ -23981,6 +23986,10 @@ components:
           type: string
           description: 'On a refund row (`direction: CREDIT`), the id of the purchase this return credits back against. Absent on purchases and on standalone credits with no matching purchase.'
           example: Transaction:019542f5-b3e7-1d02-0000-000000000099
+        description:
+          type: string
+          description: The merchant descriptor, repeated from `merchant.descriptor` so a transaction list reads without expanding each card row. Unlike `description` on other transaction types, this is set by Grid from the card network's descriptor, not supplied by the platform.
+          example: BLUE BOTTLE COFFEE SF
         merchant:
           $ref: '#/components/schemas/CardMerchant'
         authorizedAmount:

--- a/mintlify/snippets/cards/webhooks.mdx
+++ b/mintlify/snippets/cards/webhooks.mdx
@@ -95,6 +95,7 @@ approved:
     "issuerTransactionToken": "lithic_txn_b81c2a4f",
     "status": "AUTHORIZED",
     "direction": "DEBIT",
+    "description": "BLUE BOTTLE COFFEE SF",
     "merchant": {
       "descriptor": "BLUE BOTTLE COFFEE SF",
       "mcc": "5814",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11921,6 +11921,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_b81c2a4f
                     status: AUTHORIZED
                     direction: DEBIT
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -11951,6 +11952,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_b81c2a4f
                     status: SETTLED
                     direction: DEBIT
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -11989,6 +11991,7 @@ webhooks:
                     status: SETTLED
                     direction: CREDIT
                     originalTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
+                    description: BLUE BOTTLE COFFEE SF
                     merchant:
                       descriptor: BLUE BOTTLE COFFEE SF
                       mcc: '5814'
@@ -12026,6 +12029,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_d41a7f02
                     status: DECLINED
                     direction: DEBIT
+                    description: UBER EATS
                     merchant:
                       descriptor: UBER EATS
                       mcc: '5812'
@@ -12056,6 +12060,7 @@ webhooks:
                     issuerTransactionToken: lithic_txn_c92d3b5a
                     status: EXCEPTION
                     direction: DEBIT
+                    description: UBER EATS
                     merchant:
                       descriptor: UBER EATS
                       mcc: '5812'
@@ -23981,6 +23986,10 @@ components:
           type: string
           description: 'On a refund row (`direction: CREDIT`), the id of the purchase this return credits back against. Absent on purchases and on standalone credits with no matching purchase.'
           example: Transaction:019542f5-b3e7-1d02-0000-000000000099
+        description:
+          type: string
+          description: The merchant descriptor, repeated from `merchant.descriptor` so a transaction list reads without expanding each card row. Unlike `description` on other transaction types, this is set by Grid from the card network's descriptor, not supplied by the platform.
+          example: BLUE BOTTLE COFFEE SF
         merchant:
           $ref: '#/components/schemas/CardMerchant'
         authorizedAmount:

--- a/openapi/components/schemas/cards/CardTransaction.yaml
+++ b/openapi/components/schemas/cards/CardTransaction.yaml
@@ -65,6 +65,14 @@ properties:
       return credits back against. Absent on purchases and on standalone
       credits with no matching purchase.
     example: Transaction:019542f5-b3e7-1d02-0000-000000000099
+  description:
+    type: string
+    description: >-
+      The merchant descriptor, repeated from `merchant.descriptor` so a
+      transaction list reads without expanding each card row. Unlike
+      `description` on other transaction types, this is set by Grid from the
+      card network's descriptor, not supplied by the platform.
+    example: BLUE BOTTLE COFFEE SF
   merchant:
     $ref: ./CardMerchant.yaml
   authorizedAmount:

--- a/openapi/webhooks/card-transaction.yaml
+++ b/openapi/webhooks/card-transaction.yaml
@@ -65,6 +65,7 @@ post:
                 issuerTransactionToken: lithic_txn_b81c2a4f
                 status: AUTHORIZED
                 direction: DEBIT
+                description: BLUE BOTTLE COFFEE SF
                 merchant:
                   descriptor: BLUE BOTTLE COFFEE SF
                   mcc: '5814'
@@ -95,6 +96,7 @@ post:
                 issuerTransactionToken: lithic_txn_b81c2a4f
                 status: SETTLED
                 direction: DEBIT
+                description: BLUE BOTTLE COFFEE SF
                 merchant:
                   descriptor: BLUE BOTTLE COFFEE SF
                   mcc: '5814'
@@ -133,6 +135,7 @@ post:
                 status: SETTLED
                 direction: CREDIT
                 originalTransactionId: Transaction:019542f5-b3e7-1d02-0000-000000000100
+                description: BLUE BOTTLE COFFEE SF
                 merchant:
                   descriptor: BLUE BOTTLE COFFEE SF
                   mcc: '5814'
@@ -170,6 +173,7 @@ post:
                 issuerTransactionToken: lithic_txn_d41a7f02
                 status: DECLINED
                 direction: DEBIT
+                description: UBER EATS
                 merchant:
                   descriptor: UBER EATS
                   mcc: '5812'
@@ -200,6 +204,7 @@ post:
                 issuerTransactionToken: lithic_txn_c92d3b5a
                 status: EXCEPTION
                 direction: DEBIT
+                description: UBER EATS
                 merchant:
                   descriptor: UBER EATS
                   mcc: '5812'


### PR DESCRIPTION
https://lightspark.atlassian.net/browse/ENG-11675

## What this does

`GET /transactions` returns a mixed list of transactions. Every type in that list carries a `description` field that says, in one line, what the money was for.

Card transactions are the exception. Their merchant name only lives inside the `merchant` object, so a platform rendering a transaction list has to open each card row to find out where the money went.

This adds `description` to the card transaction schema. It carries the merchant descriptor, the same string as `merchant.descriptor`.

## How it works

`description` on a card transaction is set by Grid from the descriptor the card network sends. On other transaction types the platform supplies it. The schema says so, because a reader coming from the base `Transaction` will assume they can write it.

`merchant` does not change. It keeps the structured fields, including the descriptor, the merchant category code, and the country.

The field is optional, so this is not a breaking change for anyone reading the spec today.

## Follow-up

The server does not fill this field yet. That is a webdev change and it lands after this spec merges, because it needs a regenerated client.
